### PR TITLE
feat: add personalized registration endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ go.work.sum
 .defra/
 
 .vscode
+.idea
 
 logs/*.txt
 logs/*.logs

--- a/pkg/server/health.go
+++ b/pkg/server/health.go
@@ -99,6 +99,7 @@ func NewHealthServer(port int, host HealthChecker, defraURL string, metricsHandl
 	// Register routes
 	mux.HandleFunc("/health", hs.healthHandler)
 	mux.HandleFunc("/registration", hs.registrationHandler)
+	mux.HandleFunc("/registration-app", hs.registrationAppHandler)
 	mux.HandleFunc("/stats", hs.metricsHandler)
 	mux.HandleFunc("/", hs.rootHandler)
 
@@ -157,6 +158,35 @@ func (hs *HealthServer) healthHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(response)
 }
 
+// getRegistrationData returns the signed registration data for the indexer
+func (hs *HealthServer) getRegistrationData() (*DisplayRegistration, error) {
+	if hs.host == nil {
+		return nil, fmt.Errorf("host not available")
+	}
+
+	const registrationMessage = "Shinzo Network host registration"
+	defraReg, peerReg, signErr := hs.host.SignMessages(registrationMessage)
+	registration := &DisplayRegistration{
+		Enabled: signErr == nil,
+		Message: normalizeHex(hex.EncodeToString([]byte(registrationMessage))),
+	}
+	if signErr != nil {
+		return registration, signErr
+	}
+
+	// Normalize signed fields to 0x-prefixed hex strings for API consumers.
+	registration.DefraPKRegistration = DefraPKRegistration{
+		PublicKey:   normalizeHex(defraReg.PublicKey),
+		SignedPKMsg: normalizeHex(defraReg.SignedPKMsg),
+	}
+	registration.PeerIDRegistration = PeerIDRegistration{
+		PeerID:        normalizeHex(peerReg.PeerID),
+		SignedPeerMsg: normalizeHex(peerReg.SignedPeerMsg),
+	}
+
+	return registration, nil
+}
+
 // registrationHandler handles readiness probe requests
 func (hs *HealthServer) registrationHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -196,23 +226,8 @@ func (hs *HealthServer) registrationHandler(w http.ResponseWriter, r *http.Reque
 			return
 		}
 
-		// Include signed registration information on the registration endpoint.
-		const registrationMessage = "Shinzo Network host registration"
-		defraReg, peerReg, signErr := hs.host.SignMessages(registrationMessage)
-		registration := &DisplayRegistration{
-			Enabled: signErr == nil,
-			Message: normalizeHex(hex.EncodeToString([]byte(registrationMessage))),
-		}
-		if signErr == nil {
-			// Normalize signed fields to 0x-prefixed hex strings for API consumers.
-			defraReg.PublicKey = normalizeHex(defraReg.PublicKey)
-			peerReg.PeerID = normalizeHex(peerReg.PeerID)
-			defraReg.SignedPKMsg = normalizeHex(defraReg.SignedPKMsg)
-			peerReg.SignedPeerMsg = normalizeHex(peerReg.SignedPeerMsg)
-			registration.DefraPKRegistration = defraReg
-			registration.PeerIDRegistration = peerReg
-		}
-		response.Registration = registration
+    registration, _ := hs.getRegistrationData()
+  	response.Registration = registration
 	}
 
 	if !ready {
@@ -222,6 +237,26 @@ func (hs *HealthServer) registrationHandler(w http.ResponseWriter, r *http.Reque
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(response)
+}
+
+// registrationAppHandler redirects to the registration app with registration data as query params
+func (hs *HealthServer) registrationAppHandler(w http.ResponseWriter, r *http.Request) {
+	registration, err := hs.getRegistrationData()
+	if err != nil || registration == nil || !registration.Enabled {
+		http.Error(w, "Registration data not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	redirectURL := fmt.Sprintf(
+		"https://register.shinzo.network/?role=host&signedMessage=%s&peerId=%s&peerSignedMessage=%s&defraPublicKey=%s&defraPublicKeySignedMessage=%s",
+		registration.Message,
+		registration.PeerIDRegistration.PeerID,
+		registration.PeerIDRegistration.SignedPeerMsg,
+		registration.DefraPKRegistration.PublicKey,
+		registration.DefraPKRegistration.SignedPKMsg,
+	)
+
+	http.Redirect(w, r, redirectURL, http.StatusTemporaryRedirect)
 }
 
 // metricsHandler provides basic metrics in JSON format
@@ -258,10 +293,11 @@ func (hs *HealthServer) rootHandler(w http.ResponseWriter, r *http.Request) {
 		"status":    "running",
 		"timestamp": time.Now(),
 		"endpoints": []string{
-			"/health       - Health probe",
-			"/registration - Registration information",
-			"/stats        - Basic metrics/stats",
-			"/metrics      - Detailed host metrics",
+			"/health           - Health probe",
+			"/registration     - Registration information",
+			"/registration-app - Registration webapp",
+			"/stats            - Basic metrics/stats",
+			"/metrics          - Detailed host metrics",
 		},
 	}
 


### PR DESCRIPTION
Copies the work from Indexer client on making a personalized registration endpoint. Redirects users to register.shinzo.network with filled query parameters to allow one-click host registration.

How it looks:

<img width="3024" height="2050" alt="screencapture-register-shinzo-network-2026-01-13-17_44_40" src="https://github.com/user-attachments/assets/88606746-3a58-4a8d-85d2-030dd05841a7" />

## Steps to Test
1. Pull branch locally
2. `make build` and then `make start`
3. Go to `/registration-app` route and see if it redirects correctly

## Checklist
- [x] Code compiles / runs
- [ ] Tests added / updated
- [ ] Documentation updated if needed
- [x] PR is self-contained and focused
- [x] Code does not break any existing features
- [x] Code passes personal internal testing