### PR TITLE
Fix Peer Info 

### DIFF
--- a/pkg/server/health.go
+++ b/pkg/server/health.go
@@ -254,7 +254,7 @@ func (hs *HealthServer) registrationHandler(w http.ResponseWriter, r *http.Reque
 		}
 
 		registration, _ := hs.getRegistrationData()
-  	response.Registration = registration
+		response.Registration = registration
 	}
 
 	if !ready {

--- a/pkg/server/health_status_page.html
+++ b/pkg/server/health_status_page.html
@@ -301,7 +301,7 @@
                     </div>
 
                     <div class="peer-section">
-                        <h3>Peer Connections</h3>
+                        <h3>Peer Info</h3>
                         <div id="peerList"></div>
                     </div>
                 </div>


### PR DESCRIPTION
commits:
chore: change display format for libp2p multihash chore: update peer connections to peer info

# Pull Request

## Description
This pr fixes the format peer id is displayed in.

## Changes
- fixes peer id display format
- updates text from connections to info

## Related Issue
https://github.com/shinzonetwork/shinzo-host-client/issues/129 

## Steps to Test
`make build && LOG_LEVEL=error ./bin/host`

## Checklist
- [x] Code compiles / runs
- [x] Tests added / updated
- [x] Documentation updated if needed
- [x] PR is self-contained and focused
- [x] Code does not break any existing features
- [x] Code passes personal internal testing

