### PR TITLE
feat: update event subscriptions for new ShinzoHub module architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ logs/
 .local_tests/
 
 /pkg/view/var/
+reviews/

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -27,7 +27,8 @@ defradb:
 shinzo:
   minimum_attestations: 1
   start_height: 0 # Indexer auto-detects from chain tip
-  hub_base_url: rpc.devnet.shinzo.network:26657
+  # hub_base_url: rpc.devnet.shinzo.network:26657
+  hub_base_url: rpc.develop.devnet.shinzo.network:26657
   # P2P Control Settings
   wait_for_gaps: true         # Wait for gap processing before starting P2P
   max_gap_size: 1000          # Skip P2P if gap is larger than this

--- a/pkg/host/host.go
+++ b/pkg/host/host.go
@@ -712,23 +712,43 @@ func (h *Host) handleIncomingEvents(ctx context.Context, channel <-chan shinzohu
 				} else {
 					logger.Sugar.Warn("ViewManager not initialized - cannot register view")
 				}
-			} else if entityEvent, ok := event.(*shinzohub.EntityRegisteredEvent); ok {
-				// Process EntityRegistered events - add as P2P peers
-				entityType := shinzohub.GetEntityType(entityEvent.Entity)
-				logger.Sugar.Infof("🎯 Received EntityRegistered event: type=%s, key=%s, owner=%s, pid=%s",
-					entityType, entityEvent.Key, entityEvent.Owner, entityEvent.Pid)
+			} else if hostEvent, ok := event.(*shinzohub.HostRegisteredEvent); ok {
+				logger.Sugar.Infof("Received host registration: owner=%s, did=%s, conn=%s",
+					hostEvent.Owner, hostEvent.DID, hostEvent.ConnectionString)
 
-				// Add entity as P2P peer for communication
-				if h.NetworkHandler != nil {
-					err := h.NetworkHandler.AddPeer(entityEvent.Pid)
-					if err != nil {
-						logger.Sugar.Errorf("❌ Failed to add %s peer %s: %v", entityType, entityEvent.Pid, err)
-					} else {
-						logger.Sugar.Infof("✅ Successfully added %s as P2P peer: %s", entityType, entityEvent.Pid)
+				if h.NetworkHandler != nil && hostEvent.ConnectionString != "" {
+					resolved := resolveBootstrapPeers(context.Background(),
+						[]string{hostEvent.ConnectionString},
+						5*time.Second,
+					)
+					for _, addr := range resolved {
+						if err := h.NetworkHandler.AddPeer(addr); err != nil {
+							logger.Sugar.Errorf("Failed to add host peer %s: %v", addr, err)
+						} else {
+							logger.Sugar.Infof("Added host as P2P peer: %s", addr)
+						}
 					}
-				} else {
-					logger.Sugar.Warn("NetworkHandler not initialized - cannot add P2P peer")
 				}
+
+			} else if indexerEvent, ok := event.(*shinzohub.IndexerRegisteredEvent); ok {
+				logger.Sugar.Infof("Received indexer registration: owner=%s, did=%s, chain=%s/%s, conn=%s",
+					indexerEvent.Owner, indexerEvent.DID, indexerEvent.SourceChain,
+					indexerEvent.SourceChainID, indexerEvent.ConnectionString)
+
+				if h.NetworkHandler != nil && indexerEvent.ConnectionString != "" {
+					resolved := resolveBootstrapPeers(context.Background(),
+						[]string{indexerEvent.ConnectionString},
+						5*time.Second,
+					)
+					for _, addr := range resolved {
+						if err := h.NetworkHandler.AddPeer(addr); err != nil {
+							logger.Sugar.Errorf("Failed to add indexer peer %s: %v", addr, err)
+						} else {
+							logger.Sugar.Infof("Added indexer as P2P peer: %s", addr)
+						}
+					}
+				}
+
 			} else {
 				logger.Sugar.Debugf("Received unknown event type: %+v", event)
 			}

--- a/pkg/host/host_test.go
+++ b/pkg/host/host_test.go
@@ -753,7 +753,7 @@ func TestHandleIncomingEvents_ChannelClosed(t *testing.T) {
 	}
 }
 
-func TestHandleIncomingEvents_EntityRegisteredEvent_NoNetworkHandler(t *testing.T) {
+func TestHandleIncomingEvents_IndexerRegisteredEvent_NoNetworkHandler(t *testing.T) {
 	h := &Host{
 		NetworkHandler: nil,
 	}
@@ -769,12 +769,12 @@ func TestHandleIncomingEvents_EntityRegisteredEvent_NoNetworkHandler(t *testing.
 	}()
 
 	// Send entity event
-	ch <- &shinzohub.EntityRegisteredEvent{
-		Key:    "key1",
-		Owner:  "owner1",
-		DID:    "did1",
-		Pid:    "/ip4/10.0.0.1/tcp/9171/p2p/12D3KooWNgSiQsYTdRon2r7439zSockGQxqwNSGFrwmdqTknhN6r",
-		Entity: "\u0001",
+	ch <- &shinzohub.IndexerRegisteredEvent{
+		Owner:            "owner1",
+		DID:              "did1",
+		ConnectionString: "/ip4/10.0.0.1/tcp/9171/p2p/12D3KooWNgSiQsYTdRon2r7439zSockGQxqwNSGFrwmdqTknhN6r",
+		SourceChain:      "ethereum",
+		SourceChainID:    "1",
 	}
 
 	time.Sleep(100 * time.Millisecond)
@@ -805,7 +805,7 @@ func TestHandleIncomingEvents_ViewRegisteredEvent_NilViewManager(t *testing.T) {
 	query := "SELECT * FROM blocks"
 	sdl := "type Block { hash: String }"
 	ch <- &shinzohub.ViewRegisteredEvent{
-		Key:     "key1",
+		ViewAddress: "0xkey1",
 		Creator: "creator1",
 		View: view.View{
 			Name: "TestView",
@@ -843,7 +843,7 @@ func TestHandleIncomingEvents_ViewRegisteredEvent_MissingQuery(t *testing.T) {
 
 	// View with nil Query
 	ch <- &shinzohub.ViewRegisteredEvent{
-		Key:     "key1",
+		ViewAddress: "0xkey1",
 		Creator: "creator1",
 		View: view.View{
 			Name: "TestView",
@@ -877,7 +877,7 @@ func TestHandleIncomingEvents_ViewRegisteredEvent_EmptyQuery(t *testing.T) {
 
 	emptyQuery := ""
 	ch <- &shinzohub.ViewRegisteredEvent{
-		Key:     "key1",
+		ViewAddress: "0xkey1",
 		Creator: "creator1",
 		View: view.View{
 			Name: "TestView",
@@ -914,7 +914,7 @@ func TestHandleIncomingEvents_ViewRegisteredEvent_MissingSDL(t *testing.T) {
 
 	query := "SELECT * FROM blocks"
 	ch <- &shinzohub.ViewRegisteredEvent{
-		Key:     "key1",
+		ViewAddress: "0xkey1",
 		Creator: "creator1",
 		View: view.View{
 			Name: "TestView",
@@ -952,7 +952,7 @@ func TestHandleIncomingEvents_ViewRegisteredEvent_EmptySDL(t *testing.T) {
 	query := "SELECT * FROM blocks"
 	emptySDL := ""
 	ch <- &shinzohub.ViewRegisteredEvent{
-		Key:     "key1",
+		ViewAddress: "0xkey1",
 		Creator: "creator1",
 		View: view.View{
 			Name: "TestView",
@@ -1054,7 +1054,7 @@ func TestHost_ProcessViewRegistrationEvent_WithLenses(t *testing.T) {
 	query := "SELECT * FROM test"
 	sdl := "type TestView { field: String }"
 	event := shinzohub.ViewRegisteredEvent{
-		Key:     "key1",
+		ViewAddress: "0xkey1",
 		Creator: "creator1",
 		View: view.View{
 			Name: "TestViewLens",
@@ -1096,7 +1096,7 @@ func TestHost_ProcessViewRegistrationEvent_WithViewManager(t *testing.T) {
 	query := "SELECT * FROM test"
 	sdl := "type TestView { field: String }"
 	event := shinzohub.ViewRegisteredEvent{
-		Key:     "key1",
+		ViewAddress: "0xkey1",
 		Creator: "creator1",
 		View: view.View{
 			Name: "TestView",
@@ -1305,7 +1305,7 @@ func TestHost_GetPeerPublicKey_WithRealDefraDB(t *testing.T) {
 // handleIncomingEvents - entity event with real NetworkHandler
 // ---------------------------------------------------------------------------
 
-func TestHandleIncomingEvents_EntityRegisteredEvent_WithoutNetworkHandler(t *testing.T) {
+func TestHandleIncomingEvents_HostRegisteredEvent_WithoutNetworkHandler(t *testing.T) {
 	// NetworkHandler is nil — exercises the entity event parsing and nil-check branch
 	// (cannot use bare &defra.NetworkHandler{} because AddPeer panics on uninitialized maps)
 	h := &Host{}
@@ -1320,12 +1320,10 @@ func TestHandleIncomingEvents_EntityRegisteredEvent_WithoutNetworkHandler(t *tes
 		close(done)
 	}()
 
-	ch <- &shinzohub.EntityRegisteredEvent{
-		Key:    "key1",
-		Owner:  "owner1",
-		DID:    "did1",
-		Pid:    "/ip4/10.0.0.1/tcp/9171/p2p/12D3KooWNgSiQsYTdRon2r7439zSockGQxqwNSGFrwmdqTknhN6r",
-		Entity: "\u0002", // Host entity type
+	ch <- &shinzohub.HostRegisteredEvent{
+		Owner:            "owner1",
+		DID:              "did1",
+		ConnectionString: "/ip4/10.0.0.1/tcp/9171/p2p/12D3KooWNgSiQsYTdRon2r7439zSockGQxqwNSGFrwmdqTknhN6r",
 	}
 
 	time.Sleep(100 * time.Millisecond)
@@ -1359,7 +1357,7 @@ func TestHandleIncomingEvents_UnknownEventType(t *testing.T) {
 		close(done)
 	}()
 
-	// Send an event that is neither ViewRegistered nor EntityRegistered
+	// Send an event that is none of the known types
 	ch <- &unknownTestEvent{}
 
 	time.Sleep(100 * time.Millisecond)
@@ -1405,7 +1403,7 @@ func TestHandleIncomingEvents_ViewRegisteredEvent_WithLenses(t *testing.T) {
 	sdl := "type TestView { hash: String }"
 	// View with lenses that have invalid WASM (will fail PostWasmToFile but exercises the path)
 	ch <- &shinzohub.ViewRegisteredEvent{
-		Key:     "key1",
+		ViewAddress: "0xkey1",
 		Creator: "creator1",
 		View: view.View{
 			Name: "TestViewWithLenses",
@@ -1461,7 +1459,7 @@ func TestHandleIncomingEvents_ViewRegisteredEvent_WithViewManager(t *testing.T) 
 	query := "SELECT * FROM blocks"
 	sdl := "type TestView { hash: String }"
 	ch <- &shinzohub.ViewRegisteredEvent{
-		Key:     "key1",
+		ViewAddress: "0xkey1",
 		Creator: "creator1",
 		View: view.View{
 			Name: "TestView",
@@ -1623,7 +1621,7 @@ func TestHandleIncomingEvents_ViewRegisteredEvent_WithBase64Lens(t *testing.T) {
 	sdl := "type TestLensView { address: String }"
 	// Use valid base64 (tiny fake WASM) so PostWasmToFile succeeds
 	ch <- &shinzohub.ViewRegisteredEvent{
-		Key:     "key1",
+		ViewAddress: "0xkey1",
 		Creator: "creator1",
 		View: view.View{
 			Name: "TestLensView",
@@ -1683,7 +1681,7 @@ func TestHandleIncomingEvents_ViewRegisteredEvent_NoLenses_WithViewManager(t *te
 	query := "Log { address }"
 	sdl := "type NoLensView { address: String }"
 	ch <- &shinzohub.ViewRegisteredEvent{
-		Key:     "key2",
+		ViewAddress: "0xkey2",
 		Creator: "creator2",
 		View: view.View{
 			Name: "NoLensView",

--- a/pkg/schema/schema.graphql
+++ b/pkg/schema/schema.graphql
@@ -54,7 +54,7 @@ type Ethereum__Mainnet__SnapshotSignature {
 type Ethereum__Mainnet__Transaction {
     hash: String @index(unique: true)
     blockHash: String
-    blockNumber: Int
+    blockNumber: Int @index
     from: String
     to: String
     value: String
@@ -82,7 +82,7 @@ type Ethereum__Mainnet__Transaction {
 
 type Ethereum__Mainnet__AccessListEntry {
     address: String
-    blockNumber: Int
+    blockNumber: Int @index
     storageKeys: [String]
     transaction: Ethereum__Mainnet__Transaction @index @relation(name: "transaction_accessList")
 }
@@ -93,7 +93,7 @@ type Ethereum__Mainnet__Log {
     data: String
     transactionHash: String
     blockHash: String
-    blockNumber: Int
+    blockNumber: Int @index
     transactionIndex: Int
     logIndex: Int
     removed: String

--- a/pkg/shinzohub/entityRegistered_test.go
+++ b/pkg/shinzohub/entityRegistered_test.go
@@ -10,23 +10,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestEntityRegisteredEventSubscription tests the subscription to EntityRegistered events
-func TestEntityRegisteredEventSubscription(t *testing.T) {
-	// Create a mock WebSocket server for testing
+// TestHostRegisteredEventSubscription tests the subscription to HostRegistered events via WebSocket
+func TestHostRegisteredEventSubscription(t *testing.T) {
 	mockServer := NewMockWebSocketServer()
 	defer mockServer.Close()
 
-	// Start the event subscription with the mock server
 	cancel, eventChan, err := StartEventSubscription(mockServer.WebsocketURL())
 	require.NoError(t, err)
 	defer cancel()
 
-	// Send a mock EntityRegistered event
 	mockEvent := RPCResponse{
 		JsonRpcVersion: "2.0",
-		ID:             1,
+		ID:             2,
 		Result: RPCResult{
-			Query: "tm.event='Tx' AND EntityRegistered.key EXISTS",
+			Query: "tm.event='Tx' AND HostRegistered.owner EXISTS",
 			Data: RPCData{
 				Type: "tendermint.event",
 				Value: TxResult{
@@ -37,14 +34,11 @@ func TestEntityRegisteredEventSubscription(t *testing.T) {
 							Data: "success",
 							Events: []Event{
 								{
-									Type: "EntityRegistered",
+									Type: "HostRegistered",
 									Attributes: []EventAttribute{
-										{Key: "key", Value: "0x2dabf350a86364713863b2bc7bf59029bb7a87aceb2633c5b2a8b733c16f5e86", Index: true},
-										{Key: "owner", Value: "shinzo10hphdkj8srj7afwezpu4m3puugj8lrywgswzpy", Index: true},
-										{Key: "did", Value: "did:key:zQ3shbKR7JqKU3SVfMvxHv5N8UtV4EzbChhJXFyprouANr9mt", Index: true},
-										{Key: "pid", Value: "12D3KooWQuQrFFtJ7dNi4R69MaEjrJ7dKxiwjKAhLgzqxjC1ntbo", Index: true},
-										{Key: "entity", Value: "\u0002", Index: true},
-										{Key: "msg_index", Value: "0", Index: true},
+										{Key: "owner", Value: "shinzo1k2e3g3696x7ycdz5tlqslplpgyh3dwy7e7jarm", Index: true},
+										{Key: "did", Value: "did:key:z7r8orQ6nZti55L4MsGEfJcpMBpjFAHResJ2wscTo77VFAdot5JNZ8Bz87hCMZ8XLwgA6YYMyQ521AXaEGYb9BSYfKf7i", Index: true},
+										{Key: "connection_string", Value: "/ip4/192.168.1.100/tcp/9171/p2p/12D3KooWQuQrFFtJ7dNi4R69MaEjrJ7dKxiwjKAhLgzqxjC1ntbo", Index: true},
 									},
 								},
 							},
@@ -55,10 +49,8 @@ func TestEntityRegisteredEventSubscription(t *testing.T) {
 		},
 	}
 
-	// Send the mock event to the subscription
 	mockServer.SendEvent(mockEvent)
 
-	// Wait for the event to be processed
 	timeout := time.After(5 * time.Second)
 	for {
 		select {
@@ -67,40 +59,30 @@ func TestEntityRegisteredEventSubscription(t *testing.T) {
 				t.Fatal("Event channel closed unexpectedly")
 			}
 
-			// Check if we received an EntityRegistered event
-			if entityEvent, ok := event.(*EntityRegisteredEvent); ok {
-				require.Equal(t, "0x2dabf350a86364713863b2bc7bf59029bb7a87aceb2633c5b2a8b733c16f5e86", entityEvent.Key)
-				require.Equal(t, "shinzo10hphdkj8srj7afwezpu4m3puugj8lrywgswzpy", entityEvent.Owner)
-				require.Equal(t, "did:key:zQ3shbKR7JqKU3SVfMvxHv5N8UtV4EzbChhJXFyprouANr9mt", entityEvent.DID)
-				require.Equal(t, "12D3KooWQuQrFFtJ7dNi4R69MaEjrJ7dKxiwjKAhLgzqxjC1ntbo", entityEvent.Pid)
-				require.Equal(t, "\u0002", entityEvent.Entity)
+			if hostEvent, ok := event.(*HostRegisteredEvent); ok {
+				require.Equal(t, "shinzo1k2e3g3696x7ycdz5tlqslplpgyh3dwy7e7jarm", hostEvent.Owner)
+				require.Equal(t, "did:key:z7r8orQ6nZti55L4MsGEfJcpMBpjFAHResJ2wscTo77VFAdot5JNZ8Bz87hCMZ8XLwgA6YYMyQ521AXaEGYb9BSYfKf7i", hostEvent.DID)
+				require.Equal(t, "/ip4/192.168.1.100/tcp/9171/p2p/12D3KooWQuQrFFtJ7dNi4R69MaEjrJ7dKxiwjKAhLgzqxjC1ntbo", hostEvent.ConnectionString)
 
-				t.Logf("✅ Successfully received EntityRegistered event: %s", entityEvent.ToString())
+				t.Logf("Successfully received HostRegistered event: %s", hostEvent.ToString())
 				return
 			}
 
-			// If it's a ViewRegistered event, continue waiting
-			if _, ok := event.(*ViewRegisteredEvent); ok {
-				t.Log("Received ViewRegistered event, waiting for EntityRegistered...")
-				continue
-			}
-
-			t.Fatalf("Unexpected event type: %T", event)
+			// Skip other event types (ViewRegistered, etc.)
+			continue
 
 		case <-timeout:
-			t.Fatal("Timeout waiting for EntityRegistered event")
+			t.Fatal("Timeout waiting for HostRegistered event")
 		}
 	}
 }
 
-// TestExtractEntityRegisteredEvents tests the extraction function directly
-func TestExtractEntityRegisteredEvents(t *testing.T) {
-	// Create a test RPC response with EntityRegistered events
+// TestExtractHostAndIndexerRegisteredEvents tests the extraction function directly
+func TestExtractHostAndIndexerRegisteredEvents(t *testing.T) {
 	testMsg := RPCResponse{
 		JsonRpcVersion: "2.0",
 		ID:             1,
 		Result: RPCResult{
-			Query: "tm.event='Tx' AND EntityRegistered.key EXISTS",
 			Data: RPCData{
 				Type: "tendermint.event",
 				Value: TxResult{
@@ -109,27 +91,34 @@ func TestExtractEntityRegisteredEvents(t *testing.T) {
 						Result: TxResultResult{
 							Events: []Event{
 								{
-									Type: "EntityRegistered",
+									Type: "HostRegistered",
 									Attributes: []EventAttribute{
-										{Key: "key", Value: "0x2dabf350a86364713863b2bc7bf59029bb7a87aceb2633c5b2a8b733c16f5e86", Index: true},
-										{Key: "owner", Value: "shinzo10hphdkj8srj7afwezpu4m3puugj8lrywgswzpy", Index: true},
-										{Key: "did", Value: "did:key:zQ3shbKR7JqKU3SVfMvxHv5N8UtV4EzbChhJXFyprouANr9mt", Index: true},
-										{Key: "pid", Value: "12D3KooWQuQrFFtJ7dNi4R69MaEjrJ7dKxiwjKAhLgzqxjC1ntbo", Index: true},
-										{Key: "entity", Value: "\u0002", Index: true},
+										{Key: "owner", Value: "shinzo1k2e3g3696x7ycdz5tlqslplpgyh3dwy7e7jarm", Index: true},
+										{Key: "did", Value: "did:key:z7r8orQ6nZti55L4MsGEfJcpMBpjFAHResJ2wscTo77VFAdot5JNZ8Bz87hCMZ8XLwgA6YYMyQ521AXaEGYb9BSYfKf7i", Index: true},
+										{Key: "connection_string", Value: "/ip4/192.168.1.100/tcp/8080/p2p/12D3KooWQuQrFFtJ7dNi4R69MaEjrJ7dKxiwjKAhLgzqxjC1ntbo", Index: true},
 									},
 								},
 								{
-									Type: "EntityRegistered",
+									Type: "IndexerRegistered",
 									Attributes: []EventAttribute{
-										{Key: "key", Value: "0x1234567890abcdef", Index: true},
-										{Key: "owner", Value: "shinzo1abcdef", Index: true},
-										// Missing some attributes - should be filtered out
+										{Key: "owner", Value: "shinzo1k2e3g3696x7ycdz5tlqslplpgyh3dwy7e7jarm", Index: true},
+										{Key: "did", Value: "did:key:z7r8op4kfY1gpaF3x3uPBT2VJEsCEJiMGq8EG9u9DXzKzRv2jzG2T4d8ictygKyMCVDSsYSwNreSyiepJfeajFfZSkRQb", Index: true},
+										{Key: "connection_string", Value: "10.0.0.50:9090", Index: true},
+										{Key: "source_chain", Value: "ethereum", Index: true},
+										{Key: "source_chain_id", Value: "1", Index: true},
 									},
 								},
 								{
-									Type: "OtherEvent", // Should be ignored
+									Type: "HostRegistered",
 									Attributes: []EventAttribute{
-										{Key: "key", Value: "0xdeadbeef", Index: true},
+										{Key: "owner", Value: "shinzo1incomplete"},
+										// Missing DID: should be filtered out
+									},
+								},
+								{
+									Type: "OtherEvent",
+									Attributes: []EventAttribute{
+										{Key: "key", Value: "0xdeadbeef"},
 									},
 								},
 							},
@@ -140,50 +129,45 @@ func TestExtractEntityRegisteredEvents(t *testing.T) {
 		},
 	}
 
-	// Extract events
 	allEvents := extractShinzoEvents(testMsg)
 
-	// Filter for EntityRegistered events only
-	var events []EntityRegisteredEvent
-	for _, event := range allEvents {
-		if entityEvent, ok := event.(*EntityRegisteredEvent); ok {
-			events = append(events, *entityEvent)
-		}
-	}
+	// Should get 1 host + 1 indexer (incomplete host and other event filtered out)
+	require.Len(t, allEvents, 2, "Should extract exactly 2 complete events")
 
-	// Should only get the complete EntityRegistered event (the second one is incomplete)
-	require.Len(t, events, 1, "Should extract exactly 1 complete EntityRegistered event")
+	// First event: HostRegistered
+	hostEvent, ok := allEvents[0].(*HostRegisteredEvent)
+	require.True(t, ok, "First event should be HostRegisteredEvent")
+	require.Equal(t, "shinzo1k2e3g3696x7ycdz5tlqslplpgyh3dwy7e7jarm", hostEvent.Owner)
+	require.Equal(t, "did:key:z7r8orQ6nZti55L4MsGEfJcpMBpjFAHResJ2wscTo77VFAdot5JNZ8Bz87hCMZ8XLwgA6YYMyQ521AXaEGYb9BSYfKf7i", hostEvent.DID)
+	require.Equal(t, "/ip4/192.168.1.100/tcp/8080/p2p/12D3KooWQuQrFFtJ7dNi4R69MaEjrJ7dKxiwjKAhLgzqxjC1ntbo", hostEvent.ConnectionString)
 
-	event := events[0]
-	require.Equal(t, "0x2dabf350a86364713863b2bc7bf59029bb7a87aceb2633c5b2a8b733c16f5e86", event.Key)
-	require.Equal(t, "shinzo10hphdkj8srj7afwezpu4m3puugj8lrywgswzpy", event.Owner)
-	require.Equal(t, "did:key:zQ3shbKR7JqKU3SVfMvxHv5N8UtV4EzbChhJXFyprouANr9mt", event.DID)
-	require.Equal(t, "12D3KooWQuQrFFtJ7dNi4R69MaEjrJ7dKxiwjKAhLgzqxjC1ntbo", event.Pid)
-	require.Equal(t, "\u0002", event.Entity)
-
-	t.Logf("✅ Successfully extracted EntityRegistered event: %s", event.ToString())
+	// Second event: IndexerRegistered
+	indexerEvent, ok := allEvents[1].(*IndexerRegisteredEvent)
+	require.True(t, ok, "Second event should be IndexerRegisteredEvent")
+	require.Equal(t, "shinzo1k2e3g3696x7ycdz5tlqslplpgyh3dwy7e7jarm", indexerEvent.Owner)
+	require.Equal(t, "did:key:z7r8op4kfY1gpaF3x3uPBT2VJEsCEJiMGq8EG9u9DXzKzRv2jzG2T4d8ictygKyMCVDSsYSwNreSyiepJfeajFfZSkRQb", indexerEvent.DID)
+	require.Equal(t, "10.0.0.50:9090", indexerEvent.ConnectionString)
+	require.Equal(t, "ethereum", indexerEvent.SourceChain)
+	require.Equal(t, "1", indexerEvent.SourceChainID)
 }
 
-// TestMixedEventSubscription tests receiving both ViewRegistered and EntityRegistered events
+// TestMixedEventSubscription tests receiving ViewRegistered and HostRegistered events together
 func TestMixedEventSubscription(t *testing.T) {
-	// Create a mock WebSocket server for testing
 	mockServer := NewMockWebSocketServer()
 	defer mockServer.Close()
 
-	// Start the event subscription with the mock server
 	cancel, eventChan, err := StartEventSubscription(mockServer.WebsocketURL())
 	require.NoError(t, err)
 	defer cancel()
 
-		// Create valid WASM magic number + some data
+	// Create valid WASM magic number + some data
 	wasmData := []byte{0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00, 0xAA, 0xBB, 0xCC, 0xDD}
 	wasmBase64 := base64.StdEncoding.EncodeToString(wasmData)
-	// Test data
 	query := "Ethereum__Mainnet__Log {address topics data transactionHash blockNumber}"
 	expectedView := view.View{
 		Data: viewbundle.View{
 			Query: query,
-			Sdl:   "type FilteredAndDecodedLogs_0xdc0812f6a7ea5d7b3bf2ee7362e4ed87e7c070eb6d2852c7aaa9589a85dcdd85 @materialized(if: false) {transactionHash: String}",
+			Sdl:   "type FilteredAndDecodedLogs @materialized(if: false) {transactionHash: String}",
 			Transform: viewbundle.Transform{
 				Lenses: []viewbundle.Lens{
 					{Path: wasmBase64},
@@ -198,12 +182,11 @@ func TestMixedEventSubscription(t *testing.T) {
 	require.NoError(t, err)
 	viewBase64 := base64.StdEncoding.EncodeToString(wire)
 
-	// Send a mixed event with both ViewRegistered and EntityRegistered
+	// Send a mixed event with ViewRegistered and HostRegistered
 	mixedEvent := RPCResponse{
 		JsonRpcVersion: "2.0",
 		ID:             1,
 		Result: RPCResult{
-			Query: "tm.event='Tx' AND (Registered.key EXISTS OR EntityRegistered.key EXISTS)",
 			Data: RPCData{
 				Type: "tendermint.event",
 				Value: TxResult{
@@ -212,21 +195,20 @@ func TestMixedEventSubscription(t *testing.T) {
 						Result: TxResultResult{
 							Events: []Event{
 								{
-									Type: "Registered",
+									Type: "ViewRegistered",
 									Attributes: []EventAttribute{
-										{Key: "key", Value: "0xdc0812f6a7ea5d7b3bf2ee7362e4ed87e7c070eb6d2852c7aaa9589a85dcdd85", Index: true},
+										{Key: "view_address", Value: "0xf00DFed28B5304251f271c6474dF260067ee6BDa", Index: true},
+										{Key: "view_name", Value: "FilteredAndDecodedLogs", Index: true},
 										{Key: "creator", Value: "shinzo140fehngcrxvhdt84x729p3f0qmkmea8nq3rk92", Index: true},
-										{Key: "view", Value: viewBase64, Index: true},
+										{Key: "data", Value: viewBase64, Index: true},
 									},
 								},
 								{
-									Type: "EntityRegistered",
+									Type: "HostRegistered",
 									Attributes: []EventAttribute{
-										{Key: "key", Value: "0x2dabf350a86364713863b2bc7bf59029bb7a87aceb2633c5b2a8b733c16f5e86", Index: true},
-										{Key: "owner", Value: "shinzo10hphdkj8srj7afwezpu4m3puugj8lrywgswzpy", Index: true},
-										{Key: "did", Value: "did:key:zQ3shbKR7JqKU3SVfMvxHv5N8UtV4EzbChhJXFyprouANr9mt", Index: true},
-										{Key: "pid", Value: "12D3KooWQuQrFFtJ7dNi4R69MaEjrJ7dKxiwjKAhLgzqxjC1ntbo", Index: true},
-										{Key: "entity", Value: "\u0002", Index: true},
+										{Key: "owner", Value: "shinzo1k2e3g3696x7ycdz5tlqslplpgyh3dwy7e7jarm", Index: true},
+										{Key: "did", Value: "did:key:z7r8host", Index: true},
+										{Key: "connection_string", Value: "/ip4/192.168.1.100/tcp/9171/p2p/12D3KooWQuQrFFtJ7dNi4R69MaEjrJ7dKxiwjKAhLgzqxjC1ntbo", Index: true},
 									},
 								},
 							},
@@ -237,12 +219,10 @@ func TestMixedEventSubscription(t *testing.T) {
 		},
 	}
 
-	// Send the mixed event
 	mockServer.SendEvent(mixedEvent)
 
-	// Wait for both events
 	receivedView := false
-	receivedEntity := false
+	receivedHost := false
 	timeout := time.After(5 * time.Second)
 
 	for {
@@ -255,48 +235,59 @@ func TestMixedEventSubscription(t *testing.T) {
 			switch e := event.(type) {
 			case *ViewRegisteredEvent:
 				if !receivedView {
-					require.Equal(t, "0xdc0812f6a7ea5d7b3bf2ee7362e4ed87e7c070eb6d2852c7aaa9589a85dcdd85", e.Key)
+					require.Equal(t, "0xf00DFed28B5304251f271c6474dF260067ee6BDa", e.ViewAddress)
 					require.Equal(t, "shinzo140fehngcrxvhdt84x729p3f0qmkmea8nq3rk92", e.Creator)
 					require.Equal(t, expectedView.Data.Query, e.View.Data.Query)
 					receivedView = true
-					t.Log("✅ Received ViewRegistered event")
+					t.Log("Received ViewRegistered event")
 				}
 
-			case *EntityRegisteredEvent:
-				if !receivedEntity {
-					require.Equal(t, "0x2dabf350a86364713863b2bc7bf59029bb7a87aceb2633c5b2a8b733c16f5e86", e.Key)
-					require.Equal(t, "shinzo10hphdkj8srj7afwezpu4m3puugj8lrywgswzpy", e.Owner)
-					require.Equal(t, "did:key:zQ3shbKR7JqKU3SVfMvxHv5N8UtV4EzbChhJXFyprouANr9mt", e.DID)
-					receivedEntity = true
-					t.Log("✅ Received EntityRegistered event")
+			case *HostRegisteredEvent:
+				if !receivedHost {
+					require.Equal(t, "shinzo1k2e3g3696x7ycdz5tlqslplpgyh3dwy7e7jarm", e.Owner)
+					require.Equal(t, "did:key:z7r8host", e.DID)
+					require.Equal(t, "/ip4/192.168.1.100/tcp/9171/p2p/12D3KooWQuQrFFtJ7dNi4R69MaEjrJ7dKxiwjKAhLgzqxjC1ntbo", e.ConnectionString)
+					receivedHost = true
+					t.Log("Received HostRegistered event")
 				}
 
 			default:
 				t.Fatalf("Unexpected event type: %T", event)
 			}
 
-			// If we've received both events, test is successful
-			if receivedView && receivedEntity {
-				t.Log("✅ Successfully received both ViewRegistered and EntityRegistered events")
+			if receivedView && receivedHost {
+				t.Log("Successfully received both ViewRegistered and HostRegistered events")
 				return
 			}
 
 		case <-timeout:
-			t.Fatal("Timeout waiting for events")
+			t.Fatalf("Timeout waiting for events (view=%v, host=%v)", receivedView, receivedHost)
 		}
 	}
 }
 
-// TestEntityRegisteredEventToString tests the string representation
-func TestEntityRegisteredEventToString(t *testing.T) {
-	event := EntityRegisteredEvent{
-		Key:    "0x2dabf350a86364713863b2bc7bf59029bb7a87aceb2633c5b2a8b733c16f5e86",
-		Owner:  "shinzo10hphdkj8srj7afwezpu4m3puugj8lrywgswzpy",
-		DID:    "did:key:zQ3shbKR7JqKU3SVfMvxHv5N8UtV4EzbChhJXFyprouANr9mt",
-		Pid:    "12D3KooWQuQrFFtJ7dNi4R69MaEjrJ7dKxiwjKAhLgzqxjC1ntbo",
-		Entity: "\u0002",
+// TestHostRegisteredEventToString tests the string representation
+func TestHostRegisteredEventToString(t *testing.T) {
+	event := HostRegisteredEvent{
+		Owner:            "shinzo1k2e3g3696x7ycdz5tlqslplpgyh3dwy7e7jarm",
+		DID:              "did:key:z7r8orQ6nZti55L4MsGEfJcpMBpjFAHResJ2wscTo77VFAdot5JNZ8Bz87hCMZ8XLwgA6YYMyQ521AXaEGYb9BSYfKf7i",
+		ConnectionString: "/ip4/192.168.1.100/tcp/8080/p2p/12D3KooWQuQrFFtJ7dNi4R69MaEjrJ7dKxiwjKAhLgzqxjC1ntbo",
 	}
 
-	expected := "EntityRegistered: key=0x2dabf350a86364713863b2bc7bf59029bb7a87aceb2633c5b2a8b733c16f5e86, owner=shinzo10hphdkj8srj7afwezpu4m3puugj8lrywgswzpy, did=did:key:zQ3shbKR7JqKU3SVfMvxHv5N8UtV4EzbChhJXFyprouANr9mt, pid=12D3KooWQuQrFFtJ7dNi4R69MaEjrJ7dKxiwjKAhLgzqxjC1ntbo"
+	expected := "HostRegistered: owner=shinzo1k2e3g3696x7ycdz5tlqslplpgyh3dwy7e7jarm, did=did:key:z7r8orQ6nZti55L4MsGEfJcpMBpjFAHResJ2wscTo77VFAdot5JNZ8Bz87hCMZ8XLwgA6YYMyQ521AXaEGYb9BSYfKf7i, conn=/ip4/192.168.1.100/tcp/8080/p2p/12D3KooWQuQrFFtJ7dNi4R69MaEjrJ7dKxiwjKAhLgzqxjC1ntbo"
+	require.Equal(t, expected, event.ToString())
+}
+
+// TestIndexerRegisteredEventToString tests the string representation
+func TestIndexerRegisteredEventToString(t *testing.T) {
+	event := IndexerRegisteredEvent{
+		Owner:            "shinzo1k2e3g3696x7ycdz5tlqslplpgyh3dwy7e7jarm",
+		DID:              "did:key:z7r8op4kfY1gpaF3x3uPBT2VJEsCEJiMGq8EG9u9DXzKzRv2jzG2T4d8ictygKyMCVDSsYSwNreSyiepJfeajFfZSkRQb",
+		ConnectionString: "/ip4/10.0.0.50/tcp/9171/p2p/12D3KooWNgSiQsYTdRon2r7439zSockGQxqwNSGFrwmdqTknhN6r",
+		SourceChain:      "ethereum",
+		SourceChainID:    "1",
+	}
+
+	expected := "IndexerRegistered: owner=shinzo1k2e3g3696x7ycdz5tlqslplpgyh3dwy7e7jarm, did=did:key:z7r8op4kfY1gpaF3x3uPBT2VJEsCEJiMGq8EG9u9DXzKzRv2jzG2T4d8ictygKyMCVDSsYSwNreSyiepJfeajFfZSkRQb, conn=/ip4/10.0.0.50/tcp/9171/p2p/12D3KooWNgSiQsYTdRon2r7439zSockGQxqwNSGFrwmdqTknhN6r, chain=ethereum/1"
 	require.Equal(t, expected, event.ToString())
 }

--- a/pkg/shinzohub/events.go
+++ b/pkg/shinzohub/events.go
@@ -58,27 +58,6 @@ type ShinzoEvent interface {
 	ToString() string
 }
 
-// EntityType represents the type of entity
-type EntityType string
-
-const (
-	EntityTypeIndexer EntityType = "Indexer"
-	EntityTypeHost    EntityType = "Host"
-	EntityTypeUnknown EntityType = "Unknown"
-)
-
-// GetEntityType determines the entity type from the entity field value
-func GetEntityType(entityValue string) EntityType {
-	switch entityValue {
-	case "\u0001":
-		return EntityTypeIndexer
-	case "\u0002":
-		return EntityTypeHost
-	default:
-		return EntityTypeUnknown
-	}
-}
-
 // StartEventSubscription starts the event subscription and returns a context for cancellation and event channel
 func StartEventSubscription(tendermintURL string) (context.CancelFunc, <-chan ShinzoEvent, error) {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -92,10 +71,12 @@ func StartEventSubscription(tendermintURL string) (context.CancelFunc, <-chan Sh
 	// Create an unbuffered channel for events (direct processing)
 	eventChan := make(chan ShinzoEvent)
 
-	// Subscribe to Registered and EntityRegistered events separately because Tendermint doesn't support OR logic
+	// Subscribe to ViewRegistered, HostRegistered, and IndexerRegistered events separately
+	// because Tendermint doesn't support OR logic
 	queries := []string{
-		"tm.event='Tx' AND Registered.key EXISTS",
-		"tm.event='Tx' AND EntityRegistered.key EXISTS",
+		"tm.event='Tx' AND ViewRegistered.view_address EXISTS",
+		"tm.event='Tx' AND HostRegistered.owner EXISTS",
+		"tm.event='Tx' AND IndexerRegistered.owner EXISTS",
 	}
 
 	for i, query := range queries {
@@ -164,12 +145,6 @@ func StartEventSubscription(tendermintURL string) (context.CancelFunc, <-chan Sh
 				fmt.Printf("Context cancelled, stopping message loop\n")
 				return
 			default:
-				// Set a deadline for the next read
-				// if err := conn.SetReadDeadline(time.Now().Add(30 * time.Second)); err != nil {
-				// 	fmt.Printf("Failed to set read deadline: %v\n", err)
-				// 	return
-				// }
-
 				// Read raw message first to see what we're getting
 				_, message, err := conn.ReadMessage()
 				if err != nil {
@@ -200,7 +175,7 @@ func StartEventSubscription(tendermintURL string) (context.CancelFunc, <-chan Sh
 	return cancel, eventChan, nil
 }
 
-// extractShinzoEvents extracts Registered and EntityRegistered events from an RPC message.
+// extractShinzoEvents extracts ViewRegistered, HostRegistered, and IndexerRegistered events from an RPC message.
 func extractShinzoEvents(msg RPCResponse) []ShinzoEvent {
 	var events []ShinzoEvent
 	if msg.JsonRpcVersion != "2.0" ||
@@ -212,73 +187,80 @@ func extractShinzoEvents(msg RPCResponse) []ShinzoEvent {
 	// Navigate through the nested structure to find events
 	for _, event := range msg.Result.Data.Value.TxResult.Result.Events {
 		switch event.Type {
-		case "Registered":
+		case "ViewRegistered":
 			registeredEvent := ViewRegisteredEvent{}
 
-			// Extract attributes
 			for _, attr := range event.Attributes {
 				switch attr.Key {
-				case "key":
-					registeredEvent.Key = attr.Value
+				case "view_address":
+					registeredEvent.ViewAddress = attr.Value
+				case "view_name":
+					registeredEvent.ViewName = attr.Value
 				case "creator":
 					registeredEvent.Creator = attr.Value
-				case "view":
-					// Process view from wire format
+				case "data":
 					newView, err := ProcessViewFromWireFormat(attr.Value)
 					if err != nil {
 						fmt.Printf("Failed to process view from wire: %v\n", err)
 						continue
 					}
-
 					registeredEvent.View = newView
 				}
 			}
 
-			// Only add if we have all required fields
-			if registeredEvent.Key != "" && registeredEvent.Creator != "" && registeredEvent.View.Data.Query != "" {
-				fmt.Printf(" View %s registered for monitoring\n", registeredEvent.View.Name)
-
+			if registeredEvent.ViewAddress != "" && registeredEvent.Creator != "" && registeredEvent.View.Data.Query != "" {
+				fmt.Printf("View %s registered for monitoring\n", registeredEvent.View.Name)
 				events = append(events, &registeredEvent)
 			} else {
-				fmt.Printf("Incomplete Registered event: %+v\n", registeredEvent)
+				fmt.Printf("Incomplete ViewRegistered event: %+v\n", registeredEvent)
 			}
 
-		case "EntityRegistered":
-			entityRegisteredEvent := EntityRegisteredEvent{}
+		case "HostRegistered":
+			hostEvent := HostRegisteredEvent{}
 
-			// Extract attributes
 			for _, attr := range event.Attributes {
 				switch attr.Key {
-				case "key":
-					entityRegisteredEvent.Key = attr.Value
 				case "owner":
-					entityRegisteredEvent.Owner = attr.Value
+					hostEvent.Owner = attr.Value
 				case "did":
-					entityRegisteredEvent.DID = attr.Value
-				case "pid":
-					entityRegisteredEvent.Pid = attr.Value
-				case "entity":
-					entityRegisteredEvent.Entity = attr.Value
+					hostEvent.DID = attr.Value
+				case "connection_string":
+					hostEvent.ConnectionString = attr.Value
 				}
 			}
 
-			// Only add if we have all required fields
-			if entityRegisteredEvent.Key != "" && entityRegisteredEvent.Owner != "" && entityRegisteredEvent.DID != "" && entityRegisteredEvent.Pid != "" {
-				// Determine entity type
-				entityType := "Unknown"
-				switch entityRegisteredEvent.Entity {
-				case "\u0001":
-					entityType = "Indexer"
-				case "\u0002":
-					entityType = "Host"
-				}
-
-				fmt.Printf("🎯 Processing EntityRegistered: type=%s, key=%s, owner=%s, did=%s, pid=%s\n",
-					entityType, entityRegisteredEvent.Key, entityRegisteredEvent.Owner, entityRegisteredEvent.DID, entityRegisteredEvent.Pid)
-
-				events = append(events, &entityRegisteredEvent)
+			if hostEvent.Owner != "" && hostEvent.DID != "" {
+				fmt.Printf("Host registered: owner=%s, did=%s, conn=%s\n",
+					hostEvent.Owner, hostEvent.DID, hostEvent.ConnectionString)
+				events = append(events, &hostEvent)
 			} else {
-				fmt.Printf("Incomplete EntityRegistered event: %+v\n", entityRegisteredEvent)
+				fmt.Printf("Incomplete HostRegistered event: %+v\n", hostEvent)
+			}
+
+		case "IndexerRegistered":
+			indexerEvent := IndexerRegisteredEvent{}
+
+			for _, attr := range event.Attributes {
+				switch attr.Key {
+				case "owner":
+					indexerEvent.Owner = attr.Value
+				case "did":
+					indexerEvent.DID = attr.Value
+				case "connection_string":
+					indexerEvent.ConnectionString = attr.Value
+				case "source_chain":
+					indexerEvent.SourceChain = attr.Value
+				case "source_chain_id":
+					indexerEvent.SourceChainID = attr.Value
+				}
+			}
+
+			if indexerEvent.Owner != "" && indexerEvent.DID != "" {
+				fmt.Printf("Indexer registered: owner=%s, did=%s, chain=%s/%s\n",
+					indexerEvent.Owner, indexerEvent.DID, indexerEvent.SourceChain, indexerEvent.SourceChainID)
+				events = append(events, &indexerEvent)
+			} else {
+				fmt.Printf("Incomplete IndexerRegistered event: %+v\n", indexerEvent)
 			}
 		}
 	}

--- a/pkg/shinzohub/events_essential_test.go
+++ b/pkg/shinzohub/events_essential_test.go
@@ -8,161 +8,316 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestViewRegisteredEvent_ToString tests event string representation
+// Real devnet values used across tests
+const (
+	testHostAddress    = "shinzo1k2e3g3696x7ycdz5tlqslplpgyh3dwy7e7jarm"
+	testHostDID        = "did:key:z7r8orQ6nZti55L4MsGEfJcpMBpjFAHResJ2wscTo77VFAdot5JNZ8Bz87hCMZ8XLwgA6YYMyQ521AXaEGYb9BSYfKf7i"
+	testHostConnString = "/ip4/192.168.1.100/tcp/9171/p2p/12D3KooWQuQrFFtJ7dNi4R69MaEjrJ7dKxiwjKAhLgzqxjC1ntbo"
+
+	testIndexerAddress    = "shinzo1k2e3g3696x7ycdz5tlqslplpgyh3dwy7e7jarm"
+	testIndexerDID        = "did:key:z7r8op4kfY1gpaF3x3uPBT2VJEsCEJiMGq8EG9u9DXzKzRv2jzG2T4d8ictygKyMCVDSsYSwNreSyiepJfeajFfZSkRQb"
+	testIndexerConnString = "/ip4/10.0.0.50/tcp/9171/p2p/12D3KooWNgSiQsYTdRon2r7439zSockGQxqwNSGFrwmdqTknhN6r"
+
+	testViewCreator  = "shinzo1cg7rssfan6duymqrvhhce2ldyycwvqll0z338z"
+	testViewAddress1 = "0x6814589574569e6c25e72EB52f62aFaDDf5eF14D"
+	testViewAddress2 = "0xf00DFed28B5304251f271c6474dF260067ee6BDa"
+)
+
 func TestViewRegisteredEvent_ToString(t *testing.T) {
 	event := ViewRegisteredEvent{
-		Key:     "test-key-123",
-		Creator: "test-creator",
+		ViewAddress: testViewAddress2,
+		ViewName:    "StablecoinEvent",
+		Creator:     testViewCreator,
 		View: view.View{
-			Name: "TestView",
+			Name: "StablecoinEvent",
 		},
 	}
 
-	expected := "ViewRegistered: key=test-key-123, creator=test-creator, view=TestView"
+	expected := "ViewRegistered: address=" + testViewAddress2 + ", name=StablecoinEvent, creator=" + testViewCreator
 	actual := event.ToString()
 
 	require.Equal(t, expected, actual)
 }
 
-// TestEntityRegisteredEvent_ToString tests event string representation
-func TestEntityRegisteredEvent_ToString(t *testing.T) {
-	event := EntityRegisteredEvent{
-		Key:    "entity-key-456",
-		Owner:  "entity-owner",
-		DID:    "did:key:test123",
-		Pid:    "pid456",
-		Entity: "\u0001",
+func TestHostRegisteredEvent_ToString(t *testing.T) {
+	event := HostRegisteredEvent{
+		Owner:            testHostAddress,
+		DID:              testHostDID,
+		ConnectionString: testHostConnString,
 	}
 
-	expected := "EntityRegistered: key=entity-key-456, owner=entity-owner, did=did:key:test123, pid=pid456"
+	expected := "HostRegistered: owner=" + testHostAddress + ", did=" + testHostDID + ", conn=" + testHostConnString
 	actual := event.ToString()
 
 	require.Equal(t, expected, actual)
 }
 
-// TestExtractViewFromEvent tests view extraction from events
+func TestIndexerRegisteredEvent_ToString(t *testing.T) {
+	event := IndexerRegisteredEvent{
+		Owner:            testIndexerAddress,
+		DID:              testIndexerDID,
+		ConnectionString: testIndexerConnString,
+		SourceChain:      "ethereum",
+		SourceChainID:    "1",
+	}
+
+	expected := "IndexerRegistered: owner=" + testIndexerAddress + ", did=" + testIndexerDID + ", conn=" + testIndexerConnString + ", chain=ethereum/1"
+	actual := event.ToString()
+
+	require.Equal(t, expected, actual)
+}
+
 func TestExtractViewFromEvent(t *testing.T) {
-	// This would test the extractViewFromEvent function in query.go
-	// For now, we'll test the event structure
 	event := ViewRegisteredEvent{
-		Key:     "test-key",
-		Creator: "test-creator",
+		ViewAddress: testViewAddress1,
+		ViewName:    "SimpleLog",
+		Creator:     testViewCreator,
 		View: view.View{
-			Name: "TestView",
+			Name: "SimpleLog",
 			Data: viewbundle.View{
-				Query: "Log { address }",
-				Sdl:   "type TestView { address: String }",
+				Query: "Ethereum__Mainnet__Log { address topics data transactionHash blockNumber }",
+				Sdl:   "type SimpleLog @materialized(if: false) { transactionHash: String }",
 			},
 		},
 	}
 
-	// Verify event structure
-	require.Equal(t, "test-key", event.Key)
-	require.Equal(t, "test-creator", event.Creator)
-	require.Equal(t, "TestView", event.View.Name)
-	require.Equal(t, "Log { address }", event.View.Data.Query)
-	require.Equal(t, "type TestView { address: String }", event.View.Data.Sdl)
+	require.Equal(t, testViewAddress1, event.ViewAddress)
+	require.Equal(t, "SimpleLog", event.ViewName)
+	require.Equal(t, testViewCreator, event.Creator)
+	require.Equal(t, "SimpleLog", event.View.Name)
+	require.Equal(t, "Ethereum__Mainnet__Log { address topics data transactionHash blockNumber }", event.View.Data.Query)
 }
 
-// TestGetEntityType tests entity type detection
-func TestGetEntityType(t *testing.T) {
-	tests := []struct {
-		name         string
-		entityValue  string
-		expectedType EntityType
-	}{
-		{
-			name:         "indexer entity",
-			entityValue:  "\u0001",
-			expectedType: EntityTypeIndexer,
-		},
-		{
-			name:         "host entity",
-			entityValue:  "\u0002",
-			expectedType: EntityTypeHost,
-		},
-		{
-			name:         "unknown entity",
-			entityValue:  "\u0003",
-			expectedType: EntityTypeUnknown,
-		},
-		{
-			name:         "empty entity",
-			entityValue:  "",
-			expectedType: EntityTypeUnknown,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := GetEntityType(tt.entityValue)
-			require.Equal(t, tt.expectedType, result)
-		})
-	}
-}
-
-// TestEventStructures tests event struct definitions
 func TestEventStructures(t *testing.T) {
-	// Test ViewRegisteredEvent structure
 	viewEvent := ViewRegisteredEvent{
-		Key:     "view-key",
-		Creator: "view-creator",
+		ViewAddress: testViewAddress2,
+		ViewName:    "StablecoinEvent",
+		Creator:     testViewCreator,
 		View: view.View{
-			Name: "ViewName",
+			Name: "StablecoinEvent",
 			Data: viewbundle.View{
-				Query: "TestQuery",
-				Sdl:   "type TestType { field: String }",
+				Query: "Ethereum__Mainnet__Log { address topics data }",
+				Sdl:   "type StablecoinEvent @materialized(if: false) { address: String }",
 			},
 		},
 	}
 
-	require.Equal(t, "view-key", viewEvent.Key)
-	require.Equal(t, "view-creator", viewEvent.Creator)
-	require.Equal(t, "ViewName", viewEvent.View.Name)
-	require.Equal(t, "TestQuery", viewEvent.View.Data.Query)
-	require.Equal(t, "type TestType { field: String }", viewEvent.View.Data.Sdl)
+	require.Equal(t, testViewAddress2, viewEvent.ViewAddress)
+	require.Equal(t, "StablecoinEvent", viewEvent.ViewName)
+	require.Equal(t, testViewCreator, viewEvent.Creator)
 
-	// Test EntityRegisteredEvent structure
-	entityEvent := EntityRegisteredEvent{
-		Key:    "entity-key",
-		Owner:  "entity-owner",
-		DID:    "did:key:abc123",
-		Pid:    "pid123",
-		Entity: "\u0001",
+	hostEvent := HostRegisteredEvent{
+		Owner:            testHostAddress,
+		DID:              testHostDID,
+		ConnectionString: testHostConnString,
 	}
 
-	require.Equal(t, "entity-key", entityEvent.Key)
-	require.Equal(t, "entity-owner", entityEvent.Owner)
-	require.Equal(t, "did:key:abc123", entityEvent.DID)
-	require.Equal(t, "pid123", entityEvent.Pid)
-	require.Equal(t, "\u0001", entityEvent.Entity)
+	require.Equal(t, testHostAddress, hostEvent.Owner)
+	require.Equal(t, testHostDID, hostEvent.DID)
+	require.Equal(t, testHostConnString, hostEvent.ConnectionString)
+
+	indexerEvent := IndexerRegisteredEvent{
+		Owner:            testIndexerAddress,
+		DID:              testIndexerDID,
+		ConnectionString: testIndexerConnString,
+		SourceChain:      "ethereum",
+		SourceChainID:    "1",
+	}
+
+	require.Equal(t, testIndexerAddress, indexerEvent.Owner)
+	require.Equal(t, testIndexerDID, indexerEvent.DID)
+	require.Equal(t, testIndexerConnString, indexerEvent.ConnectionString)
+	require.Equal(t, "ethereum", indexerEvent.SourceChain)
+	require.Equal(t, "1", indexerEvent.SourceChainID)
 }
 
-// TestEventInterface tests that events implement the ShinzoEvent interface
 func TestEventInterface(t *testing.T) {
-	// Test ViewRegisteredEvent implements ShinzoEvent
 	var viewEvent ShinzoEvent = &ViewRegisteredEvent{
-		Key:     "test",
-		Creator: "test",
-		View:    view.View{Name: "Test"},
+		ViewAddress: testViewAddress1,
+		Creator:     testViewCreator,
+		View:        view.View{Name: "SimpleLog"},
+	}
+	require.NotPanics(t, func() { _ = viewEvent.ToString() })
+
+	var hostEvent ShinzoEvent = &HostRegisteredEvent{
+		Owner: testHostAddress,
+		DID:   testHostDID,
+	}
+	require.NotPanics(t, func() { _ = hostEvent.ToString() })
+
+	var indexerEvent ShinzoEvent = &IndexerRegisteredEvent{
+		Owner:       testIndexerAddress,
+		DID:         testIndexerDID,
+		SourceChain: "ethereum",
+	}
+	require.NotPanics(t, func() { _ = indexerEvent.ToString() })
+}
+
+func TestExtractShinzoEvents_ViewRegistered(t *testing.T) {
+	msg := RPCResponse{
+		JsonRpcVersion: "2.0",
+		ID:             1,
+		Result: RPCResult{
+			Data: RPCData{
+				Type: "tendermint.event",
+				Value: TxResult{
+					TxResult: TxResultData{
+						Result: TxResultResult{
+							Events: []Event{
+								{
+									Type: "ViewRegistered",
+									Attributes: []EventAttribute{
+										{Key: "view_address", Value: testViewAddress1},
+										{Key: "view_name", Value: "SimpleLog"},
+										{Key: "creator", Value: testViewCreator},
+										// "data" omitted: wire format would need real viewbundle
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
-	// Should have ToString method
-	require.NotPanics(t, func() {
-		_ = viewEvent.ToString()
-	})
+	events := extractShinzoEvents(msg)
+	require.Len(t, events, 0, "should reject ViewRegistered event without valid view data")
+}
 
-	// Test EntityRegisteredEvent implements ShinzoEvent
-	var entityEvent ShinzoEvent = &EntityRegisteredEvent{
-		Key:    "test",
-		Owner:  "test",
-		DID:    "test",
-		Pid:    "test",
-		Entity: "\u0001",
+func TestExtractShinzoEvents_HostRegistered(t *testing.T) {
+	msg := RPCResponse{
+		JsonRpcVersion: "2.0",
+		ID:             2,
+		Result: RPCResult{
+			Data: RPCData{
+				Type: "tendermint.event",
+				Value: TxResult{
+					TxResult: TxResultData{
+						Result: TxResultResult{
+							Events: []Event{
+								{
+									Type: "HostRegistered",
+									Attributes: []EventAttribute{
+										{Key: "owner", Value: testHostAddress},
+										{Key: "did", Value: testHostDID},
+										{Key: "connection_string", Value: testHostConnString},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
-	// Should have ToString method
-	require.NotPanics(t, func() {
-		_ = entityEvent.ToString()
-	})
+	events := extractShinzoEvents(msg)
+	require.Len(t, events, 1)
+
+	hostEvent, ok := events[0].(*HostRegisteredEvent)
+	require.True(t, ok, "event should be HostRegisteredEvent")
+	require.Equal(t, testHostAddress, hostEvent.Owner)
+	require.Equal(t, testHostDID, hostEvent.DID)
+	require.Equal(t, testHostConnString, hostEvent.ConnectionString)
+}
+
+func TestExtractShinzoEvents_IndexerRegistered(t *testing.T) {
+	msg := RPCResponse{
+		JsonRpcVersion: "2.0",
+		ID:             3,
+		Result: RPCResult{
+			Data: RPCData{
+				Type: "tendermint.event",
+				Value: TxResult{
+					TxResult: TxResultData{
+						Result: TxResultResult{
+							Events: []Event{
+								{
+									Type: "IndexerRegistered",
+									Attributes: []EventAttribute{
+										{Key: "owner", Value: testIndexerAddress},
+										{Key: "did", Value: testIndexerDID},
+										{Key: "connection_string", Value: testIndexerConnString},
+										{Key: "source_chain", Value: "ethereum"},
+										{Key: "source_chain_id", Value: "1"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	events := extractShinzoEvents(msg)
+	require.Len(t, events, 1)
+
+	indexerEvent, ok := events[0].(*IndexerRegisteredEvent)
+	require.True(t, ok, "event should be IndexerRegisteredEvent")
+	require.Equal(t, testIndexerAddress, indexerEvent.Owner)
+	require.Equal(t, testIndexerDID, indexerEvent.DID)
+	require.Equal(t, testIndexerConnString, indexerEvent.ConnectionString)
+	require.Equal(t, "ethereum", indexerEvent.SourceChain)
+	require.Equal(t, "1", indexerEvent.SourceChainID)
+}
+
+func TestExtractShinzoEvents_IncompleteHost(t *testing.T) {
+	msg := RPCResponse{
+		JsonRpcVersion: "2.0",
+		ID:             2,
+		Result: RPCResult{
+			Data: RPCData{
+				Type: "tendermint.event",
+				Value: TxResult{
+					TxResult: TxResultData{
+						Result: TxResultResult{
+							Events: []Event{
+								{
+									Type: "HostRegistered",
+									Attributes: []EventAttribute{
+										{Key: "owner", Value: testHostAddress},
+										// missing did
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	events := extractShinzoEvents(msg)
+	require.Len(t, events, 0, "should reject HostRegistered event missing DID")
+}
+
+func TestExtractShinzoEvents_IgnoresUnknownEvents(t *testing.T) {
+	msg := RPCResponse{
+		JsonRpcVersion: "2.0",
+		ID:             1,
+		Result: RPCResult{
+			Data: RPCData{
+				Type: "tendermint.event",
+				Value: TxResult{
+					TxResult: TxResultData{
+						Result: TxResultResult{
+							Events: []Event{
+								{
+									Type: "SomeOtherEvent",
+									Attributes: []EventAttribute{
+										{Key: "foo", Value: "bar"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	events := extractShinzoEvents(msg)
+	require.Len(t, events, 0)
 }

--- a/pkg/shinzohub/indexer_manager.go
+++ b/pkg/shinzohub/indexer_manager.go
@@ -5,63 +5,56 @@ import (
 	"fmt"
 )
 
-// IndexerManager defines the interface for managing indexers
+// IndexerManager defines the interface for managing indexers.
+// NOTE: This is not currently wired into the event handler in host.go.
+// The event handler calls AddPeer() directly. This interface exists for
+// future use when proper indexer tracking is needed.
 type IndexerManager interface {
-	AddIndexer(ctx context.Context, key string, owner string, did string, pid string) error
-	GetIndexer(key string) (Indexer, bool)
-	RemoveIndexer(key string) error
+	AddIndexer(ctx context.Context, owner string, did string, connectionString string, sourceChain string, sourceChainID string) error
+	GetIndexer(owner string) (Indexer, bool)
+	RemoveIndexer(owner string) error
 }
 
 // Indexer represents a blockchain indexer
 type Indexer struct {
-	Key    string
-	Owner  string
-	DID    string
-	Pid    string
-	Entity string
-	Active bool
+	Owner            string
+	DID              string
+	ConnectionString string
+	SourceChain      string
+	SourceChainID    string
+	Active           bool
 }
 
-// EntityRegistrationHandler manages indexer registration from EntityRegistered events
-type EntityRegistrationHandler struct {
+// RegistrationHandler manages indexer registration from IndexerRegistered events
+type RegistrationHandler struct {
 	indexerManager IndexerManager
 }
 
-// NewEntityRegistrationHandler creates a new entity registration handler
-func NewEntityRegistrationHandler(indexerManager IndexerManager) *EntityRegistrationHandler {
-	return &EntityRegistrationHandler{
+// NewRegistrationHandler creates a new registration handler
+func NewRegistrationHandler(indexerManager IndexerManager) *RegistrationHandler {
+	return &RegistrationHandler{
 		indexerManager: indexerManager,
 	}
 }
 
-// ProcessEntityRegisteredEvent handles an EntityRegistered event from Shinzo Hub
-func (erh *EntityRegistrationHandler) ProcessEntityRegisteredEvent(ctx context.Context, event EntityRegisteredEvent) error {
-	fmt.Printf("🚀 Processing EntityRegistered event for indexer: %s\n", event.Key)
-	
-	// Create a new indexer from the event
-	indexer := Indexer{
-		Key:    event.Key,
-		Owner:  event.Owner,
-		DID:    event.DID,
-		Pid:    event.Pid,
-		Entity: event.Entity,
-		Active: true,
-	}
+// ProcessIndexerRegisteredEvent handles an IndexerRegistered event from ShinzoHub
+func (rh *RegistrationHandler) ProcessIndexerRegisteredEvent(ctx context.Context, event IndexerRegisteredEvent) error {
+	fmt.Printf("Processing IndexerRegistered event for indexer: %s\n", event.Owner)
 
 	// Check if indexer already exists
-	if _, exists := erh.indexerManager.GetIndexer(event.Key); exists {
-		fmt.Printf("⚠️  Indexer %s already exists, updating...\n", event.Key)
+	if _, exists := rh.indexerManager.GetIndexer(event.Owner); exists {
+		fmt.Printf("Indexer %s already exists, updating...\n", event.Owner)
 	}
 
 	// Add or update the indexer
-	err := erh.indexerManager.AddIndexer(ctx, indexer.Key, indexer.Owner, indexer.DID, indexer.Pid)
+	err := rh.indexerManager.AddIndexer(ctx, event.Owner, event.DID, event.ConnectionString, event.SourceChain, event.SourceChainID)
 	if err != nil {
-		return fmt.Errorf("failed to add indexer %s: %w", event.Key, err)
+		return fmt.Errorf("failed to add indexer %s: %w", event.Owner, err)
 	}
 
-	fmt.Printf("✅ Successfully added indexer: %s (owner: %s, did: %s, pid: %s)\n", 
-		indexer.Key, indexer.Owner, indexer.DID, indexer.Pid)
-	
+	fmt.Printf("Successfully added indexer: %s (did: %s, chain: %s/%s)\n",
+		event.Owner, event.DID, event.SourceChain, event.SourceChainID)
+
 	return nil
 }
 
@@ -78,26 +71,27 @@ func NewMockIndexerManager() *MockIndexerManager {
 }
 
 // AddIndexer adds a new indexer
-func (mim *MockIndexerManager) AddIndexer(ctx context.Context, key string, owner string, did string, pid string) error {
-	mim.indexers[key] = Indexer{
-		Key:    key,
-		Owner:  owner,
-		DID:    did,
-		Pid:    pid,
-		Active: true,
+func (mim *MockIndexerManager) AddIndexer(ctx context.Context, owner string, did string, connectionString string, sourceChain string, sourceChainID string) error {
+	mim.indexers[owner] = Indexer{
+		Owner:            owner,
+		DID:              did,
+		ConnectionString: connectionString,
+		SourceChain:      sourceChain,
+		SourceChainID:    sourceChainID,
+		Active:           true,
 	}
 	return nil
 }
 
-// GetIndexer retrieves an indexer by key
-func (mim *MockIndexerManager) GetIndexer(key string) (Indexer, bool) {
-	indexer, exists := mim.indexers[key]
+// GetIndexer retrieves an indexer by owner address
+func (mim *MockIndexerManager) GetIndexer(owner string) (Indexer, bool) {
+	indexer, exists := mim.indexers[owner]
 	return indexer, exists
 }
 
-// RemoveIndexer removes an indexer by key
-func (mim *MockIndexerManager) RemoveIndexer(key string) error {
-	delete(mim.indexers, key)
+// RemoveIndexer removes an indexer by owner address
+func (mim *MockIndexerManager) RemoveIndexer(owner string) error {
+	delete(mim.indexers, owner)
 	return nil
 }
 

--- a/pkg/shinzohub/integration_test.go
+++ b/pkg/shinzohub/integration_test.go
@@ -8,29 +8,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestEntityRegisteredToIntegrationFlow tests the complete flow from EntityRegistered event to indexer addition
-func TestEntityRegisteredToIntegrationFlow(t *testing.T) {
-	// Create a mock indexer manager
+// TestIndexerRegisteredToIntegrationFlow tests the complete flow from IndexerRegistered event to indexer addition
+func TestIndexerRegisteredToIntegrationFlow(t *testing.T) {
 	indexerManager := NewMockIndexerManager()
-	
-	// Create the entity registration handler
-	entityHandler := NewEntityRegistrationHandler(indexerManager)
+	handler := NewRegistrationHandler(indexerManager)
 
-	// Create a mock WebSocket server
 	mockServer := NewMockWebSocketServer()
 	defer mockServer.Close()
 
-	// Start the event subscription
 	cancel, eventChan, err := StartEventSubscription(mockServer.WebsocketURL())
 	require.NoError(t, err)
 	defer cancel()
 
-	// Create a test EntityRegistered event
 	testEvent := RPCResponse{
 		JsonRpcVersion: "2.0",
-		ID:             1,
+		ID:             3,
 		Result: RPCResult{
-			Query: "tm.event='Tx' AND EntityRegistered.key EXISTS",
+			Query: "tm.event='Tx' AND IndexerRegistered.owner EXISTS",
 			Data: RPCData{
 				Type: "tendermint.event",
 				Value: TxResult{
@@ -39,13 +33,13 @@ func TestEntityRegisteredToIntegrationFlow(t *testing.T) {
 						Result: TxResultResult{
 							Events: []Event{
 								{
-									Type: "EntityRegistered",
+									Type: "IndexerRegistered",
 									Attributes: []EventAttribute{
-										{Key: "key", Value: "0x2dabf350a86364713863b2bc7bf59029bb7a87aceb2633c5b2a8b733c16f5e86", Index: true},
-										{Key: "owner", Value: "shinzo10hphdkj8srj7afwezpu4m3puugj8lrywgswzpy", Index: true},
-										{Key: "did", Value: "did:key:zQ3shbKR7JqKU3SVfMvxHv5N8UtV4EzbChhJXFyprouANr9mt", Index: true},
-										{Key: "pid", Value: "12D3KooWQuQrFFtJ7dNi4R69MaEjrJ7dKxiwjKAhLgzqxjC1ntbo", Index: true},
-										{Key: "entity", Value: "\u0002", Index: true},
+										{Key: "owner", Value: "shinzo1idx123", Index: true},
+										{Key: "did", Value: "did:key:z7r8idx", Index: true},
+										{Key: "connection_string", Value: "/ip4/10.0.0.50/tcp/9090/p2p/12D3KooWNgSiQsYTdRon2r7439zSockGQxqwNSGFrwmdqTknhN6r", Index: true},
+										{Key: "source_chain", Value: "ethereum", Index: true},
+										{Key: "source_chain_id", Value: "1", Index: true},
 									},
 								},
 							},
@@ -56,10 +50,8 @@ func TestEntityRegisteredToIntegrationFlow(t *testing.T) {
 		},
 	}
 
-	// Send the event
 	mockServer.SendEvent(testEvent)
 
-	// Process the event
 	timeout := time.After(5 * time.Second)
 	eventProcessed := false
 
@@ -70,20 +62,18 @@ func TestEntityRegisteredToIntegrationFlow(t *testing.T) {
 				t.Fatal("Event channel closed unexpectedly")
 			}
 
-			if entityEvent, ok := event.(*EntityRegisteredEvent); ok {
-				// Process the EntityRegistered event
-				err := entityHandler.ProcessEntityRegisteredEvent(context.Background(), *entityEvent)
+			if indexerEvent, ok := event.(*IndexerRegisteredEvent); ok {
+				err := handler.ProcessIndexerRegisteredEvent(context.Background(), *indexerEvent)
 				require.NoError(t, err)
-				
+
 				eventProcessed = true
-				t.Log("✅ Successfully processed EntityRegistered event")
+				t.Log("Successfully processed IndexerRegistered event")
 			}
 
 		case <-timeout:
 			if !eventProcessed {
-				t.Fatal("Timeout waiting for EntityRegistered event")
+				t.Fatal("Timeout waiting for IndexerRegistered event")
 			}
-			// Continue to verification
 		}
 
 		if eventProcessed {
@@ -91,46 +81,38 @@ func TestEntityRegisteredToIntegrationFlow(t *testing.T) {
 		}
 	}
 
-	// Verify the indexer was added
-	indexer, exists := indexerManager.GetIndexer("0x2dabf350a86364713863b2bc7bf59029bb7a87aceb2633c5b2a8b733c16f5e86")
-	require.True(t, exists, "Indexer should exist after EntityRegistered event")
+	// Verify the indexer was added (keyed by owner)
+	indexer, exists := indexerManager.GetIndexer("shinzo1idx123")
+	require.True(t, exists, "Indexer should exist after IndexerRegistered event")
 
-	require.Equal(t, "0x2dabf350a86364713863b2bc7bf59029bb7a87aceb2633c5b2a8b733c16f5e86", indexer.Key)
-	require.Equal(t, "shinzo10hphdkj8srj7afwezpu4m3puugj8lrywgswzpy", indexer.Owner)
-	require.Equal(t, "did:key:zQ3shbKR7JqKU3SVfMvxHv5N8UtV4EzbChhJXFyprouANr9mt", indexer.DID)
-	require.Equal(t, "12D3KooWQuQrFFtJ7dNi4R69MaEjrJ7dKxiwjKAhLgzqxjC1ntbo", indexer.Pid)
+	require.Equal(t, "shinzo1idx123", indexer.Owner)
+	require.Equal(t, "did:key:z7r8idx", indexer.DID)
+	require.Equal(t, "/ip4/10.0.0.50/tcp/9090/p2p/12D3KooWNgSiQsYTdRon2r7439zSockGQxqwNSGFrwmdqTknhN6r", indexer.ConnectionString)
+	require.Equal(t, "ethereum", indexer.SourceChain)
+	require.Equal(t, "1", indexer.SourceChainID)
 	require.True(t, indexer.Active)
 
-	// Verify indexer count
 	require.Equal(t, 1, indexerManager.GetIndexerCount())
-
-	t.Log("✅ Integration test completed successfully - indexer added from EntityRegistered event")
 }
 
-// TestMultipleEntityRegisteredEvents tests handling multiple EntityRegistered events
-func TestMultipleEntityRegisteredEvents(t *testing.T) {
-	// Create a mock indexer manager
+// TestMultipleIndexerRegisteredEvents tests handling multiple IndexerRegistered events
+func TestMultipleIndexerRegisteredEvents(t *testing.T) {
 	indexerManager := NewMockIndexerManager()
-	
-	// Create the entity registration handler
-	entityHandler := NewEntityRegistrationHandler(indexerManager)
+	handler := NewRegistrationHandler(indexerManager)
 
-	// Create a mock WebSocket server
 	mockServer := NewMockWebSocketServer()
 	defer mockServer.Close()
 
-	// Start the event subscription
 	cancel, eventChan, err := StartEventSubscription(mockServer.WebsocketURL())
 	require.NoError(t, err)
 	defer cancel()
 
-	// Test data for multiple events
 	testEvents := []RPCResponse{
 		{
 			JsonRpcVersion: "2.0",
-			ID:             1,
+			ID:             3,
 			Result: RPCResult{
-				Query: "tm.event='Tx' AND EntityRegistered.key EXISTS",
+				Query: "tm.event='Tx' AND IndexerRegistered.owner EXISTS",
 				Data: RPCData{
 					Type: "tendermint.event",
 					Value: TxResult{
@@ -139,12 +121,13 @@ func TestMultipleEntityRegisteredEvents(t *testing.T) {
 							Result: TxResultResult{
 								Events: []Event{
 									{
-										Type: "EntityRegistered",
+										Type: "IndexerRegistered",
 										Attributes: []EventAttribute{
-											{Key: "key", Value: "0x1111111111111111", Index: true},
-											{Key: "owner", Value: "shinzo1user1", Index: true},
+											{Key: "owner", Value: "shinzo1idx1", Index: true},
 											{Key: "did", Value: "did:key:1111", Index: true},
-											{Key: "pid", Value: "12D3KooW111111111111", Index: true},
+											{Key: "connection_string", Value: "/ip4/10.0.0.1/tcp/9090/p2p/12D3KooWQuQrFFtJ7dNi4R69MaEjrJ7dKxiwjKAhLgzqxjC1ntbo", Index: true},
+											{Key: "source_chain", Value: "ethereum", Index: true},
+											{Key: "source_chain_id", Value: "1", Index: true},
 										},
 									},
 								},
@@ -156,9 +139,9 @@ func TestMultipleEntityRegisteredEvents(t *testing.T) {
 		},
 		{
 			JsonRpcVersion: "2.0",
-			ID:             2,
+			ID:             3,
 			Result: RPCResult{
-				Query: "tm.event='Tx' AND EntityRegistered.key EXISTS",
+				Query: "tm.event='Tx' AND IndexerRegistered.owner EXISTS",
 				Data: RPCData{
 					Type: "tendermint.event",
 					Value: TxResult{
@@ -167,12 +150,13 @@ func TestMultipleEntityRegisteredEvents(t *testing.T) {
 							Result: TxResultResult{
 								Events: []Event{
 									{
-										Type: "EntityRegistered",
+										Type: "IndexerRegistered",
 										Attributes: []EventAttribute{
-											{Key: "key", Value: "0x2222222222222222", Index: true},
-											{Key: "owner", Value: "shinzo1user2", Index: true},
+											{Key: "owner", Value: "shinzo1idx2", Index: true},
 											{Key: "did", Value: "did:key:2222", Index: true},
-											{Key: "pid", Value: "12D3KooW222222222222", Index: true},
+											{Key: "connection_string", Value: "/ip4/10.0.0.2/tcp/9090/p2p/12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN", Index: true},
+											{Key: "source_chain", Value: "polygon", Index: true},
+											{Key: "source_chain_id", Value: "137", Index: true},
 										},
 									},
 								},
@@ -184,11 +168,9 @@ func TestMultipleEntityRegisteredEvents(t *testing.T) {
 		},
 	}
 
-	// Send multiple events
 	for i, event := range testEvents {
 		mockServer.SendEvent(event)
-		
-		// Wait for and process each event
+
 		timeout := time.After(2 * time.Second)
 		eventProcessed := false
 
@@ -199,17 +181,17 @@ func TestMultipleEntityRegisteredEvents(t *testing.T) {
 					t.Fatal("Event channel closed unexpectedly")
 				}
 
-				if entityEvent, ok := receivedEvent.(*EntityRegisteredEvent); ok {
-					err := entityHandler.ProcessEntityRegisteredEvent(context.Background(), *entityEvent)
+				if indexerEvent, ok := receivedEvent.(*IndexerRegisteredEvent); ok {
+					err := handler.ProcessIndexerRegisteredEvent(context.Background(), *indexerEvent)
 					require.NoError(t, err)
-					
+
 					eventProcessed = true
-					t.Logf("✅ Processed event %d: %s", i+1, entityEvent.Key)
+					t.Logf("Processed event %d: %s", i+1, indexerEvent.Owner)
 				}
 
 			case <-timeout:
 				if !eventProcessed {
-					t.Fatalf("Timeout waiting for EntityRegistered event %d", i+1)
+					t.Fatalf("Timeout waiting for IndexerRegistered event %d", i+1)
 				}
 			}
 
@@ -219,58 +201,48 @@ func TestMultipleEntityRegisteredEvents(t *testing.T) {
 		}
 	}
 
-	// Verify all indexers were added
 	require.Equal(t, 2, indexerManager.GetIndexerCount())
 
-	// Check first indexer
-	indexer1, exists1 := indexerManager.GetIndexer("0x1111111111111111")
+	indexer1, exists1 := indexerManager.GetIndexer("shinzo1idx1")
 	require.True(t, exists1)
-	require.Equal(t, "shinzo1user1", indexer1.Owner)
+	require.Equal(t, "ethereum", indexer1.SourceChain)
 
-	// Check second indexer
-	indexer2, exists2 := indexerManager.GetIndexer("0x2222222222222222")
+	indexer2, exists2 := indexerManager.GetIndexer("shinzo1idx2")
 	require.True(t, exists2)
-	require.Equal(t, "shinzo1user2", indexer2.Owner)
-
-	t.Log("✅ Multiple EntityRegistered events processed successfully")
+	require.Equal(t, "polygon", indexer2.SourceChain)
 }
 
 // TestIndexerManagerFunctionality tests the indexer manager directly
 func TestIndexerManagerFunctionality(t *testing.T) {
 	manager := NewMockIndexerManager()
 
-	// Test adding indexers
-	err := manager.AddIndexer(context.Background(), "test-key-1", "owner1", "did1", "pid1")
+	err := manager.AddIndexer(context.Background(), "shinzo1owner1", "did1", "/ip4/10.0.0.1/tcp/9090/p2p/12D3KooWQuQrFFtJ7dNi4R69MaEjrJ7dKxiwjKAhLgzqxjC1ntbo", "ethereum", "1")
 	require.NoError(t, err)
 
-	err = manager.AddIndexer(context.Background(), "test-key-2", "owner2", "did2", "pid2")
+	err = manager.AddIndexer(context.Background(), "shinzo1owner2", "did2", "/ip4/10.0.0.2/tcp/9090/p2p/12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN", "polygon", "137")
 	require.NoError(t, err)
 
-	// Test getting indexers
-	indexer1, exists1 := manager.GetIndexer("test-key-1")
+	indexer1, exists1 := manager.GetIndexer("shinzo1owner1")
 	require.True(t, exists1)
-	require.Equal(t, "owner1", indexer1.Owner)
+	require.Equal(t, "did1", indexer1.DID)
+	require.Equal(t, "ethereum", indexer1.SourceChain)
 
-	indexer2, exists2 := manager.GetIndexer("test-key-2")
+	indexer2, exists2 := manager.GetIndexer("shinzo1owner2")
 	require.True(t, exists2)
-	require.Equal(t, "owner2", indexer2.Owner)
+	require.Equal(t, "did2", indexer2.DID)
+	require.Equal(t, "polygon", indexer2.SourceChain)
 
-	// Test non-existent indexer
 	_, exists3 := manager.GetIndexer("non-existent")
 	require.False(t, exists3)
 
-	// Test listing indexers
 	indexers := manager.ListIndexers()
 	require.Len(t, indexers, 2)
 
-	// Test removing indexer
-	err = manager.RemoveIndexer("test-key-1")
+	err = manager.RemoveIndexer("shinzo1owner1")
 	require.NoError(t, err)
 
-	_, exists4 := manager.GetIndexer("test-key-1")
+	_, exists4 := manager.GetIndexer("shinzo1owner1")
 	require.False(t, exists4)
 
 	require.Equal(t, 1, manager.GetIndexerCount())
-
-	t.Log("✅ Indexer manager functionality test passed")
 }

--- a/pkg/shinzohub/mock_websocket_test.go
+++ b/pkg/shinzohub/mock_websocket_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"sync"
+	"time"
 
 	"github.com/gorilla/websocket"
 )
@@ -13,8 +15,10 @@ type MockWebSocketServer struct {
 	server   *http.Server
 	upgrader websocket.Upgrader
 	conn     *websocket.Conn
+	connMu   sync.Mutex // protects concurrent writes to conn
 	done     chan struct{}
 	port     int
+	ready    chan struct{} // signals when all subscriptions have been processed
 }
 
 // NewMockWebSocketServer creates a new mock WebSocket server
@@ -24,23 +28,23 @@ func NewMockWebSocketServer() *MockWebSocketServer {
 	if err != nil {
 		panic(fmt.Sprintf("Failed to create listener: %v", err))
 	}
-	
+
 	server := &http.Server{Handler: mux}
-	
+
 	mock := &MockWebSocketServer{
 		server: server,
 		upgrader: websocket.Upgrader{
 			CheckOrigin: func(r *http.Request) bool {
-				return true // Allow all origins for testing
+				return true
 			},
 		},
-		done: make(chan struct{}),
-		port: listener.Addr().(*net.TCPAddr).Port,
+		done:  make(chan struct{}),
+		ready: make(chan struct{}),
+		port:  listener.Addr().(*net.TCPAddr).Port,
 	}
 
 	mux.HandleFunc("/websocket", mock.handleWebSocket)
-	
-	// Start the server in a goroutine
+
 	go func() {
 		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
 			fmt.Printf("Mock WebSocket server error: %v\n", err)
@@ -61,32 +65,29 @@ func (m *MockWebSocketServer) Close() {
 	if m.server != nil {
 		m.server.Close()
 	}
+	m.connMu.Lock()
 	if m.conn != nil {
 		m.conn.Close()
 	}
+	m.connMu.Unlock()
 }
 
-// SendEvent sends a mock event to the connected client
+// SendEvent sends a mock event to the connected client.
+// Waits briefly for subscriptions to be processed before sending.
 func (m *MockWebSocketServer) SendEvent(event RPCResponse) {
+	// Wait for the handler to finish processing subscriptions
+	select {
+	case <-m.ready:
+	case <-time.After(2 * time.Second):
+	}
+
+	m.connMu.Lock()
+	defer m.connMu.Unlock()
+
 	if m.conn == nil {
 		return
 	}
 
-	// Send subscription response first (simulating successful subscription)
-	subscriptionResponse := map[string]interface{}{
-		"jsonrpc": "2.0",
-		"id":      1,
-		"result": map[string]interface{}{
-			"query": "tm.event='Tx' AND (Registered.key EXISTS OR EntityRegistered.key EXISTS)",
-		},
-	}
-
-	if err := m.conn.WriteJSON(subscriptionResponse); err != nil {
-		fmt.Printf("Failed to send subscription response: %v\n", err)
-		return
-	}
-
-	// Send the actual event
 	if err := m.conn.WriteJSON(event); err != nil {
 		fmt.Printf("Failed to send event: %v\n", err)
 		return
@@ -101,10 +102,13 @@ func (m *MockWebSocketServer) handleWebSocket(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	m.connMu.Lock()
 	m.conn = conn
+	m.connMu.Unlock()
 	defer conn.Close()
 
-	// Handle WebSocket messages
+	subscriptionCount := 0
+
 	for {
 		select {
 		case <-m.done:
@@ -118,9 +122,8 @@ func (m *MockWebSocketServer) handleWebSocket(w http.ResponseWriter, r *http.Req
 				return
 			}
 
-			// Handle subscription message
 			if method, ok := msg["method"].(string); ok && method == "subscribe" {
-				// Send subscription confirmation
+				m.connMu.Lock()
 				response := map[string]interface{}{
 					"jsonrpc": "2.0",
 					"id":      msg["id"],
@@ -129,8 +132,21 @@ func (m *MockWebSocketServer) handleWebSocket(w http.ResponseWriter, r *http.Req
 					},
 				}
 				if err := conn.WriteJSON(response); err != nil {
+					m.connMu.Unlock()
 					fmt.Printf("Failed to send subscription response: %v\n", err)
 					return
+				}
+				m.connMu.Unlock()
+
+				subscriptionCount++
+				// Signal ready after all 3 subscriptions are processed
+				if subscriptionCount >= 3 {
+					select {
+					case <-m.ready:
+						// already closed
+					default:
+						close(m.ready)
+					}
 				}
 			}
 		}

--- a/pkg/shinzohub/query.go
+++ b/pkg/shinzohub/query.go
@@ -192,8 +192,8 @@ func (c *RPCClient) FetchAllRegisteredViews(ctx context.Context) ([]view.View, i
 // fetchRegisteredViewsPage fetches a single page of Registered events with retry logic.
 func (c *RPCClient) fetchRegisteredViewsPage(ctx context.Context, page, perPage int) ([]view.View, int, error) {
 	// Build the query URL
-	// Query: Registered.key EXISTS
-	query := url.QueryEscape(`Registered.key EXISTS`)
+	// Query: ViewRegistered.view_address EXISTS
+	query := url.QueryEscape(`ViewRegistered.view_address EXISTS`)
 	endpoint := fmt.Sprintf("%s/tx_search?query=\"%s\"&page=%d&per_page=%d&order_by=\"asc\"",
 		c.rpcURL, query, page, perPage)
 
@@ -252,7 +252,7 @@ func (c *RPCClient) fetchRegisteredViewsPage(ctx context.Context, page, perPage 
 
 	for _, tx := range txResp.Result.Txs {
 		for _, event := range tx.TxResult.Events {
-			if event.Type == "Registered" {
+			if event.Type == "ViewRegistered" {
 				v, err := extractViewFromEvent(event)
 				if err != nil {
 					skippedMalformed++
@@ -280,7 +280,7 @@ func extractViewFromEvent(event Event) (view.View, error) {
 
 	for _, attr := range event.Attributes {
 		switch attr.Key {
-		case "view":
+		case "data":
 			// Process view from wire format
 			newView, err := ProcessViewFromWireFormat(attr.Value)
 			if err != nil {

--- a/pkg/shinzohub/view.go
+++ b/pkg/shinzohub/view.go
@@ -6,26 +6,44 @@ import (
 	"github.com/shinzonetwork/shinzo-host-client/pkg/view"
 )
 
-// ViewRegisteredEvent represents a view registration event
+// ViewRegisteredEvent represents a view registration event from ShinzoHub.
+// Emitted by ViewRegistry precompile (0x210) as Cosmos SDK event "ViewRegistered".
 type ViewRegisteredEvent struct {
-	Key     string
-	Creator string
-	View    view.View
+	ViewAddress string    // attr "view_address": hex EVM contract address of deployed View.sol
+	ViewName    string    // attr "view_name": SDL resource name extracted from viewbundle
+	Creator     string    // attr "creator": bech32 address of the view creator
+	View        view.View // attr "data": decoded from base64 viewbundle wire format
 }
 
-// EntityRegisteredEvent represents an entity registration event
-type EntityRegisteredEvent struct {
-	Key    string
-	Owner  string
-	DID    string
-	Pid    string
-	Entity string
+// HostRegisteredEvent represents a host registration event from ShinzoHub.
+// Emitted by HostRegistry precompile (0x211) as Cosmos SDK event "HostRegistered".
+type HostRegisteredEvent struct {
+	Owner            string // attr "owner": bech32 address of host operator
+	DID              string // attr "did": decentralized identifier derived from registration pubkey
+	ConnectionString string // attr "connection_string": network address (multiaddr or ip:port)
+}
+
+// IndexerRegisteredEvent represents an indexer registration event from ShinzoHub.
+// Emitted by IndexerRegistry precompile (0x212) as Cosmos SDK event "IndexerRegistered".
+type IndexerRegisteredEvent struct {
+	Owner            string // attr "owner": bech32 address of indexer operator
+	DID              string // attr "did": decentralized identifier derived from registration pubkey
+	ConnectionString string // attr "connection_string": network address (multiaddr or ip:port)
+	SourceChain      string // attr "source_chain": name of indexed chain (e.g., "ethereum")
+	SourceChainID    string // attr "source_chain_id": chain ID as string (e.g., "1")
 }
 
 func (vre *ViewRegisteredEvent) ToString() string {
-	return fmt.Sprintf("ViewRegistered: key=%s, creator=%s, view=%s", vre.Key, vre.Creator, vre.View.Name)
+	return fmt.Sprintf("ViewRegistered: address=%s, name=%s, creator=%s",
+		vre.ViewAddress, vre.ViewName, vre.Creator)
 }
 
-func (ere *EntityRegisteredEvent) ToString() string {
-	return fmt.Sprintf("EntityRegistered: key=%s, owner=%s, did=%s, pid=%s", ere.Key, ere.Owner, ere.DID, ere.Pid)
+func (hre *HostRegisteredEvent) ToString() string {
+	return fmt.Sprintf("HostRegistered: owner=%s, did=%s, conn=%s",
+		hre.Owner, hre.DID, hre.ConnectionString)
+}
+
+func (ire *IndexerRegisteredEvent) ToString() string {
+	return fmt.Sprintf("IndexerRegistered: owner=%s, did=%s, conn=%s, chain=%s/%s",
+		ire.Owner, ire.DID, ire.ConnectionString, ire.SourceChain, ire.SourceChainID)
 }


### PR DESCRIPTION
## Description                                                                                                                      
                                                                                                                                      
  The new ShinzoHub (develop branch) refactored the monolithic `x/sourcehub` module into separate `x/view`, `x/host`, and `x/indexer` modules. This changed all Cosmos SDK event types and attribute names. The host-client was completely blind to the new develop devnet (found 0 views, received 0 events).                                                                                                
                                                            
  This PR updates the host-client to consume the new event format.                                                                    
   
  ## Changes                                                                                                                          
                                                            
  - **Event subscriptions**: `Registered.key EXISTS` and `EntityRegistered.key EXISTS` replaced with `ViewRegistered.view_address     
  EXISTS`, `HostRegistered.owner EXISTS`, and `IndexerRegistered.owner EXISTS`
  - **Event structs**: `ViewRegisteredEvent.Key` replaced with `ViewAddress` and `ViewName`. `EntityRegisteredEvent` replaced with  separate `HostRegisteredEvent` and `IndexerRegisteredEvent` structs                                                                 
  - **Event parsing**: `extractShinzoEvents()` rewritten for new event types and attribute names (`view_address`, `view_name`, `data`, `connection_string`, `source_chain`, `source_chain_id`)                                                                            
  - **Historical query**: `tx_search` query updated from `Registered.key EXISTS` to `ViewRegistered.view_address EXISTS`, attribute `view` renamed to `data`                                                                                                            
  - **Peer discovery**: Host/indexer event handlers now use `connection_string` (multiaddr format) instead of `pid`, routed through `resolveBootstrapPeers()` for proper multiaddr parsing                                                                              
  - **IndexerManager**: Updated struct fields and interface signatures to match new event format (not wired into event handler, existing pattern preserved)                                                                                                         
  - **Tests**: All test files updated with new event types and realistic devnet values
                                                                                                                                      
  ## Event Format Mapping                                                                                                             
                                                                                                                                      
  | Old | New |                                                                                                                       
  |---|---|                                                 
  | `Registered` (views) | `ViewRegistered` |
  | attr `key` | attr `view_address` |
  | attr `view` | attr `data` |                                                                                                       
  | (not emitted) | attr `view_name` |
  | `EntityRegistered` (hosts + indexers) | `HostRegistered` and `IndexerRegistered` (separate events) |                              
  | attr `pid` | attr `connection_string` |                                                                                           
  | attr `entity` (type byte) | (implicit from event type) |                                                                          
  | attr `key` (keccak256 hash) | (dropped, `owner` used as identifier) |                                                             
                                                                                                                                      
  ## Verified                                                                                                                         
                                                                                                                                      
  Tested against live develop devnet (`rpc.develop.devnet.shinzo.network`):                                                           
  - Before: `found 0 new views with lenses`
  - After: `found 2 new views with lenses` (SimpleLog, StablecoinEvent)                                                               
  - WebSocket subscriptions confirmed for all 3 event types                                                                           
                                                                                                                                      
  ## Steps to Test                                                                                                                    
                                                            
  1. `rm -rf .defra/` (clear stale state from old devnet)                                                                             
  2. Set `hub_base_url: rpc.develop.devnet.shinzo.network:26657` in `config/config.yaml`
  3. `go run cmd/main.go --config config/config.yaml`                                                                                 
  4. Verify logs show "found 2 new views" and subscriptions use new event names

## Related Issues
#191 
                                                                                                                                      
  ## Checklist                                              
                                                                                                                                      
  - [x] Code compiles / runs                                                                                                          
  - [x] Tests added / updated
  - [x] PR is self-contained and focused                                                                                              
  - [x] Code does not break any existing features                                                                                     
  - [x] Code passes personal internal testing