### PR TITLE
Fix/schema

### DIFF
--- a/pkg/schema/schema.graphql
+++ b/pkg/schema/schema.graphql
@@ -54,7 +54,7 @@ type Ethereum__Mainnet__SnapshotSignature {
 type Ethereum__Mainnet__Transaction {
     hash: String @index(unique: true)
     blockHash: String
-    blockNumber: Int
+    blockNumber: Int @index
     from: String
     to: String
     value: String
@@ -82,7 +82,7 @@ type Ethereum__Mainnet__Transaction {
 
 type Ethereum__Mainnet__AccessListEntry {
     address: String
-    blockNumber: Int
+    blockNumber: Int @index
     storageKeys: [String]
     transaction: Ethereum__Mainnet__Transaction @index @relation(name: "transaction_accessList")
 }
@@ -93,7 +93,7 @@ type Ethereum__Mainnet__Log {
     data: String
     transactionHash: String
     blockHash: String
-    blockNumber: Int
+    blockNumber: Int @index
     transactionIndex: Int
     logIndex: Int
     removed: String


### PR DESCRIPTION
# Pull Request                                                                                                                      
                                                                                                                                      
  ## Description                                                                                                                      
                                                                                                                                      
  Add `@index` to `blockNumber` on Transaction, Log, and AccessListEntry in the host schema to fix the Explorer transaction list timeout.                                                                                                                            
                                                                                                                                      
  Without `@index`, DefraDB's query planner inserts an `orderNode` that loads ALL documents into memory and sorts them before  returning results. With 660K+ transactions, this times out. With `@index`, the planner uses the index iterator to stream pre-sorted  results, skipping the in-memory sort entirely. This is the same mechanism that makes Block queries fast (`number: Int @index`  already exists on Block).                                                                                                           
   
  ## Changes                                                                                                                          
                                                            
  - Added `@index` to `blockNumber: Int` on `Ethereum__Mainnet__Transaction` (line 57)
  - Added `@index` to `blockNumber: Int` on `Ethereum__Mainnet__AccessListEntry` (line 85)
  - Added `@index` to `blockNumber: Int` on `Ethereum__Mainnet__Log` (line 96)
                                                                                                                                      
  ## Related Issue                        
                                                                                                                                      
  Fixes shinzonetwork/web#74 - Explorer: Transaction list is not loading                                                              
  Related: shinzonetwork/web#137, shinzonetwork/web#96, shinzonetwork/web#102                                                         
  Upstream: sourcenetwork/defradb#4351, sourcenetwork/defradb#4345                                                                    
                                                                                                                                      
  ## Steps to Test                            
                                                                                                                                      
  1. Pull branch locally                                    
  2. Build the host: `make build`                                                                                                     
  3. Start with a fresh data directory (indexes are created at schema init)
  4. Connect to devnet indexers and wait for blocks to arrive                                                                         
  5. Run `@explain` to confirm no `orderNode`:              
  ```bash                                                                                                                             
  curl -s "http://localhost:9181/api/v0/graphql" -X POST \                                                                            
    -H "Content-Type: application/json" \                                                                                             
    -d '{"query":"query @explain { Ethereum__Mainnet__Transaction(order: {blockNumber: DESC}, limit: 5) { hash blockNumber } }"}' \   
    | python3 -m json.tool    
  ```                                                                                                 
  6. The output should show limitNode -> selectNode -> scanNode with no orderNode                                                     
  7. Point the Explorer at the host and verify the transaction list loads                                                             

                                                                                                                  
  ## Checklist                                                                                                                           
                                                            
  - [x] Code compiles / runs                                                                                                              
  - [ ] Tests added / updated                                                                                                             
  - [x]  Documentation updated if needed
  - [x] PR is self-contained and focused                                                                                                  
  - [x] Code does not break any existing features               
  - [x] Code passes personal internal testing                                                                                             
                                                            
  ## Notes                                                                                                                               
                                                                                                                                      
  - The host must start with a fresh data directory after this change so DefraDB builds the new indexes during schema initialization. Adding indexes to existing collections with data may require a re-sync.                                                             
  - No changes to DefraDB are needed. DefraDB already supports index-backed ORDER BY (planner/index_helpers.go:107-127). The Transaction collection simply never had the index added.                                                                            
  - Validated locally with a host connected to devnet indexers receiving real Ethereum blocks. Explorer shows both blocks and transactions loading correctly.                   


## Before Fix:
<img width="1685" height="899" alt="image" src="https://github.com/user-attachments/assets/1a4e24d8-4519-41a6-9180-9f9eabc14399" />


## After Fix: 

<img width="1697" height="829" alt="image" src="https://github.com/user-attachments/assets/9419ed95-7e80-4e2f-85c8-2b3065f85396" />


