### PR TITLE
fix: align DefraDB bind mount target with config store path

### DIFF
--- a/.github/DEPLOYMENT.md
+++ b/.github/DEPLOYMENT.md
@@ -68,7 +68,7 @@ docker run -d \
   -p 9181:9181 \
   -p 9182:9182 \
   -p 9171:9171 \
-  -v $(pwd)/data/defradb:/app/.defra/data \
+  -v $(pwd)/data/defradb:/app/.defra \
   -v $(pwd)/data/lens:/app/.lens \
   -v $(pwd)/config.yaml:/app/config.yaml:ro \
   -e DEFRA_URL=0.0.0.0:9181 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -118,7 +118,7 @@ COPY --from=builder /app/config/config.yaml /app/config.yaml
 COPY --from=builder /app/playground/dist /app/playground/dist
 
 # Create directories for data persistence
-RUN mkdir -p .defra/data .lens && \
+RUN mkdir -p .defra .lens && \
     chown -R shinzo:shinzo /app
 
 # Switch to non-root user

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -25,7 +25,7 @@ services:
     restart: unless-stopped
     container_name: shinzo-host
     volumes:
-      - ~/data/defradb:/app/.defra/data
+      - ~/data/defradb:/app/.defra
       - ~/data/lens:/app/.lens
       - ~/shinzo-host-client/config.yaml:/app/config.yaml:ro
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - "444:9182"  # GraphQL Playground 
       - "9171:9171"  # P2P networking (still needs external access)
     volumes:
-      - ~/data/defradb:/app/.defra/data
+      - ~/data/defradb:/app/.defra
       - ~/data/lens:/app/.lens
       - ~/config.yaml:/app/config.yaml:ro
     environment:

--- a/host-prod-setup.sh
+++ b/host-prod-setup.sh
@@ -147,7 +147,7 @@ services:
       - "444:9182"  # GraphQL Playground 
       - "9171:9171"  # P2P networking (still needs external access)
     volumes:
-      - ~/data/defradb:/app/.defra/data
+      - ~/data/defradb:/app/.defra
       - ~/data/lens:/app/.lens
       - ~/config.yaml:/app/config.yaml:ro
     environment:


### PR DESCRIPTION
The bind mount target was /app/.defra/data but DefraDB/Badger writes to /app/.defra (per config/config.yaml store.path: "./.defra"). All LSM/vlog files were landing in the container's overlay2 writable layer instead of the host volume, filling the devnet host VM disk to 100% and crashlooping the container with mmap faults.                                                               
                                                                                                                         
  Fixes the mount target in:                                                                                             
  - docker-compose.yml                                                                                                   
  - docker-compose-prod.yml                                                                                              
  - host-prod-setup.sh                                      
  - .github/DEPLOYMENT.md                                                                                                
                                                                                                                         
  Also fixes Dockerfile to mkdir .defra instead of .defra/data so the pre-created directory matches the mount point.                                                                         
                                                                                                                         
  scripts/gcp-startup-host.sh and gcp-startup-host-local-ssd.sh were already consistent.