### PR TITLE
Menna/develop

### DIFF
--- a/host-prod-setup.sh
+++ b/host-prod-setup.sh
@@ -27,7 +27,8 @@ defradb:
 shinzo:
   minimum_attestations: 1
   start_height: 0 # Indexer auto-detects from chain tip
-  hub_base_url: rpc.devnet.shinzo.network:26657
+  # hub_base_url: rpc.devnet.shinzo.network:26657
+  hub_base_url: rpc.develop.devnet.shinzo.network:26657
   # P2P Control Settings
   wait_for_gaps: true         # Wait for gap processing before starting P2P
   max_gap_size: 1000          # Skip P2P if gap is larger than this

--- a/pkg/shinzohub/query.go
+++ b/pkg/shinzohub/query.go
@@ -85,6 +85,13 @@ func (c *RPCClient) getLastProcessedPage(ctx context.Context) (int, int) {
 			maxPageSize = rec.PageSize
 		}
 	}
+	// Guard against persisted records that stored pageSize=0 (an older bug
+	// saved totalCount here instead of pageSize; 0 makes tx_search return
+	// no rows and the whole query loop finds zero views). Fall back to the
+	// default so affected hosts self-heal on next restart.
+	if maxPageSize <= 0 {
+		maxPageSize = 5
+	}
 	logger.Sugar.Debugf("📡 getLastProcessedPage: page=%d, pageSize=%d", maxPage, maxPageSize)
 	return maxPage, maxPageSize
 }
@@ -181,9 +188,13 @@ func (c *RPCClient) FetchAllRegisteredViews(ctx context.Context) ([]view.View, i
 			break
 		}
 	}
-	// Save progress after each successful page
-	c.saveLastProcessedPage(ctx, lastSuccessfulPage, totalCount)
-	logger.Sugar.Debugf("📡 Saved progress: page %d + total_count: %d", lastSuccessfulPage, totalCount)
+	// Save progress after each successful page. Persist the actual page size
+	// used in the queries, not the server-reported total_count — the latter
+	// used to sneak into this slot and land pageSize=0 in the record, which
+	// made the next startup query tx_search with per_page=0 and silently
+	// observe zero rows.
+	c.saveLastProcessedPage(ctx, lastSuccessfulPage, pageSize)
+	logger.Sugar.Debugf("📡 Saved progress: page %d (pageSize=%d, total_count=%d)", lastSuccessfulPage, pageSize, totalCount)
 
 	logger.Sugar.Infof("📡 ShinzoHub query complete: found %d new views with lenses", len(allViews))
 	return allViews, totalCount, nil

--- a/pkg/view/view.go
+++ b/pkg/view/view.go
@@ -234,7 +234,6 @@ func (v *View) ConfigureLens(ctx context.Context, defraNode *node.Node, schemaSe
 
 // attemptQueryCorrection tries to fix common field name issues based on error message
 func (v *View) attemptQueryCorrection(errMsg string) string {
-	// Extract the incorrect field and suggested field from error message
 	// Error format: Cannot query field "inputData" on type "X". Did you mean "input"?
 	re := regexp.MustCompile(`Cannot query field "([^"]+)".*Did you mean "([^"]+)"`)
 	matches := re.FindStringSubmatch(errMsg)
@@ -242,8 +241,15 @@ func (v *View) attemptQueryCorrection(errMsg string) string {
 	if len(matches) == 3 {
 		incorrectField := matches[1]
 		suggestedField := matches[2]
-		correctedQuery := strings.ReplaceAll(v.Data.Query, incorrectField, suggestedField)
-		return correctedQuery
+		// Match whole-word occurrences only. A plain strings.ReplaceAll
+		// would also mangle identifiers that merely contain incorrectField
+		// as a substring (e.g. replacing "Log" would damage "Logger" or
+		// "logIndex" in the same query). DefraDB errors always refer to
+		// one specific identifier, so word-boundary matching is correct.
+		// The literal replacement variant makes sure a suggested field
+		// containing "$" isn't treated as a capture-group reference.
+		tokenRe := regexp.MustCompile(`\b` + regexp.QuoteMeta(incorrectField) + `\b`)
+		return tokenRe.ReplaceAllLiteralString(v.Data.Query, suggestedField)
 	}
 
 	return v.Data.Query

--- a/pkg/view/viewManager.go
+++ b/pkg/view/viewManager.go
@@ -224,9 +224,13 @@ func (vm *ViewManager) RegisterView(ctx context.Context, v *View) error {
 		logger.Sugar.Infof("Lens CID for view %s: %s", v.Name, lensCID)
 	}
 
-	// Step 2: Auto-fix collection name if needed and create view in DefraDB
+	// Step 2: Auto-fix collection name if needed and create view in DefraDB.
+	// The empty-string guard matters: strings.Replace with an empty old
+	// inserts the replacement at byte 0, which would corrupt the query.
+	// Letting extractCollectionFromQuery return "" should never reach this
+	// branch, but we guard in case a future caller passes a malformed query.
 	sourceCollection := extractCollectionFromQuery(v.Data.Query)
-	if !strings.HasPrefix(sourceCollection, constants.CollectionChain+"__") {
+	if sourceCollection != "" && !strings.HasPrefix(sourceCollection, constants.CollectionChain+"__") {
 		v.Data.Query = strings.Replace(v.Data.Query, sourceCollection, constants.CollectionChain+"__"+sourceCollection, 1)
 		logger.Sugar.Debugf("Fixed collection name: %s → %s__%s", sourceCollection, constants.CollectionChain, sourceCollection)
 	}
@@ -279,7 +283,13 @@ func (vm *ViewManager) subscribeToSourceCollection(ctx context.Context, collecti
 	return nil
 }
 
+// extractCollectionFromQuery returns the first identifier in a GraphQL
+// query (the top-level type). Leading whitespace is skipped first; without
+// that skip, a query that starts with a newline would return "" and the
+// caller would then insert the chain prefix at byte 0, producing a
+// malformed query.
 func extractCollectionFromQuery(query string) string {
+	query = strings.TrimLeft(query, " \n\t\r")
 	for i, r := range query {
 		if r == '{' || r == ' ' || r == '\n' || r == '\t' {
 			return query[:i]

--- a/pkg/view/viewManager_test.go
+++ b/pkg/view/viewManager_test.go
@@ -708,6 +708,20 @@ func TestExtractCollectionFromQuery_ComplexQueries(t *testing.T) {
 			query:    "",
 			expected: "",
 		},
+		{
+			// Template-rendered query.graphql files routinely start with a
+			// newline. Without a leading-whitespace trim the extractor used
+			// to return "" here, which caused the caller to insert the
+			// chain prefix at byte 0 and produce a malformed query.
+			name:     "query with leading newline",
+			query:    "\nLog { address }",
+			expected: "Log",
+		},
+		{
+			name:     "query with mixed leading whitespace",
+			query:    "  \n\tLog { address }",
+			expected: "Log",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/view/view_test.go
+++ b/pkg/view/view_test.go
@@ -171,3 +171,59 @@ func TestView_ExtractNameFromSDL(t *testing.T) {
 		})
 	}
 }
+
+// TestAttemptQueryCorrection_WholeWordReplacementOnly makes sure the
+// corrector doesn't mangle identifiers that merely contain the incorrect
+// field as a substring. A plain strings.ReplaceAll would have.
+func TestAttemptQueryCorrection_WholeWordReplacementOnly(t *testing.T) {
+	cases := []struct {
+		name     string
+		query    string
+		errMsg   string
+		expected string
+	}{
+		{
+			name:     "single occurrence gets corrected",
+			query:    "Log { address }",
+			errMsg:   `Cannot query field "Log" on type "Query". Did you mean "Ethereum__Mainnet__Log"`,
+			expected: "Ethereum__Mainnet__Log { address }",
+		},
+		{
+			// "Log" as a substring of "Logger" must not be replaced.
+			name:     "substring in a different identifier is untouched",
+			query:    "Log { Logger address }",
+			errMsg:   `Cannot query field "Log" on type "Query". Did you mean "Ethereum__Mainnet__Log"`,
+			expected: "Ethereum__Mainnet__Log { Logger address }",
+		},
+		{
+			// "inputData" fix must not clip "inputDataLength".
+			name:     "substring suffix is untouched",
+			query:    "Log { inputData inputDataLength }",
+			errMsg:   `Cannot query field "inputData" on type "Log". Did you mean "input"`,
+			expected: "Log { input inputDataLength }",
+		},
+		{
+			// A genuine repeat of the same identifier should all be fixed.
+			name:     "multiple whole-word occurrences all get corrected",
+			query:    "Log { nested { Log } }",
+			errMsg:   `Cannot query field "Log" on type "Query". Did you mean "Ethereum__Mainnet__Log"`,
+			expected: "Ethereum__Mainnet__Log { nested { Ethereum__Mainnet__Log } }",
+		},
+		{
+			// Error string that doesn't match the expected pattern
+			// leaves the query untouched.
+			name:     "unparseable error leaves query alone",
+			query:    "Log { address }",
+			errMsg:   "some unrelated error",
+			expected: "Log { address }",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &View{Data: viewbundle.View{Query: tt.query}}
+			got := v.attemptQueryCorrection(tt.errMsg)
+			require.Equal(t, tt.expected, got)
+		})
+	}
+}


### PR DESCRIPTION

 Found while deploying a Uniswap v4 view through the new shinzo-app framework                                                                                                       
                                                                                                         
### Changes                                                   
                                                                                                                         
  - `host-prod-setup.sh`: the heredoc hard-coded the devnet hub URL, so any host provisioned by this script ended up subscribed to the v1 hub. The host binary uses v2 subscription query names, which the v1 hub never emits, so these hosts matched zero events. Now writes the develop-devnet URL (matching the committed `config/config.yaml`),  with the devnet line kept as a comment.                                                                              
                                                                                                                         
  - `pkg/shinzohub/query.go`: `saveLastProcessedPage` was being called with `totalCount` in the slot named `pageSize`. On an empty hub this wrote `pageSize=0` into DefraDB. Next startup read it back and  queried `tx_search` with`per_page=0`, which returns zero rows, so the host logged "found 0 views" even when the hub had views. The call now passes `pageSize`. I also added a check in `getLastProcessedPage` that replaces a stored `pageSize` of 0 or less with the default (5), so any host that already wrote a bad value recovers automatically on the next restart.        
  - `pkg/view/viewManager.go`: `extractCollectionFromQuery` treated a leading `\n` as a terminator and returned an empty string. The caller then did `strings.Replace(query, "", prefix, 1)`; Go's `strings.Replace` with an empty old-string inserts at byte 0, so the query became `Ethereum__Mainnet__\nLog {...}`, which DefraDB rejected. Fixed by trimming leading whitespace in the extractor and adding a guard in the caller so an empty sourceCollection is never passed to `strings.Replace`.           
  - `pkg/view/view.go`: `attemptQueryCorrection` used  `strings.ReplaceAll`. When DefraDB suggested replacing `Log` with `Ethereum__Mainnet__Log`, `ReplaceAll` also matched `Log` inside `Logger` and `logIndex`. Swapped to a regex with `\b` word  boundaries plus `regexp.QuoteMeta` and `ReplaceAllLiteralString`. Only whole-word matches are replaced; substrings are left alone.                                                     

  ---                                                                                                                    
###   Steps to Test                                             

  1. `go test ./...` — all 10 packages pass on Go 1.25.9.
                                                                                                                         
  2. Targeted tests for the new cases:
     - `go test ./pkg/view/... -run TestExtractCollectionFromQuery`                                                      
       (7 existing cases + 2 new for leading-whitespace queries)                                                         
     - `go test ./pkg/view/... -run TestAttemptQueryCorrection`                                                          
       (5 new cases for the whole-word replace behavior)                                                                 
                                                                                                                         
  3. End-to-end on a fresh host (optional, already verified live on v063):                                               
     - Re-provision with `host-prod-setup.sh`.
     - Boot against develop-devnet.                                                                                      
     - Expect "ShinzoHub base URL: http://rpc.develop.devnet.shinzo.network:26657" and "ShinzoHub query complete: found N new views with lenses" with N > 0.
     - `curl http://127.0.0.1:9181/api/v0/collections` should include the `DecodedXEvents` collection for every view registered on develop-devnet.                                                                                                   
                                                            
  ---                                                                                                                    
 ###  Checklist                                                 

  - [x] Code compiles / runs
  - [x] Tests added / updated
  - [x] Documentation updated if needed  (two review docs in reviews/)                                                   
  - [x] PR is self-contained and focused
  - [x] Code does not break any existing features                                                                        
  - [x] Code passes personal internal testing               
                                             