### PR TITLE
Menna/remove app sdk

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"strings"
 
-	appConfig "github.com/shinzonetwork/shinzo-app-sdk/pkg/config"
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/pruner"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/defradb"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/pruner"
 	"gopkg.in/yaml.v3"
 )
 
@@ -182,17 +182,18 @@ func LoadConfig(path string) (*Config, error) {
 	return &cfg, nil
 }
 
-// ToAppConfig converts the host config to an app-sdk config.
-func (c *Config) ToAppConfig() *appConfig.Config {
+// ToInternalConfig converts the host config to the pkg/defradb internal config
+// shape consumed by StartDefraInstance and signer helpers.
+func (c *Config) ToInternalConfig() *defradb.Config {
 	if c == nil {
 		return nil
 	}
 
-	return &appConfig.Config{
-		DefraDB: appConfig.DefraDBConfig{
+	return &defradb.Config{
+		DefraDB: defradb.DefraDBConfig{
 			Url:           c.DefraDB.Url,
 			KeyringSecret: c.DefraDB.KeyringSecret,
-			P2P: appConfig.DefraP2PConfig{
+			P2P: defradb.DefraP2PConfig{
 				Enabled:             c.DefraDB.P2P.Enabled,
 				BootstrapPeers:      []string{}, // Empty - peers added after ViewManager init
 				ListenAddr:          c.DefraDB.P2P.ListenAddr,
@@ -201,7 +202,7 @@ func (c *Config) ToAppConfig() *appConfig.Config {
 				ReconnectIntervalMs: c.DefraDB.P2P.ReconnectIntervalMs,
 				EnableAutoReconnect: c.DefraDB.P2P.EnableAutoReconnect,
 			},
-			Store: appConfig.DefraStoreConfig{
+			Store: defradb.DefraStoreConfig{
 				Path:                    c.DefraDB.Store.Path,
 				BlockCacheMB:            c.DefraDB.Store.BlockCacheMB,
 				MemTableMB:              c.DefraDB.Store.MemTableMB,
@@ -212,7 +213,7 @@ func (c *Config) ToAppConfig() *appConfig.Config {
 				ValueLogFileSizeMB:      c.DefraDB.Store.ValueLogFileSizeMB,
 			},
 		},
-		Logger: appConfig.LoggerConfig{
+		Logger: defradb.LoggerConfig{
 			Development: c.Logger.Development,
 		},
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -129,7 +129,7 @@ shinzo:
 	}
 }
 
-func TestToAppConfig(t *testing.T) {
+func TestToInternalConfig(t *testing.T) {
 	cfg := &Config{
 		DefraDB: DefraDBConfig{
 			Url:           "localhost:9181",
@@ -159,7 +159,7 @@ func TestToAppConfig(t *testing.T) {
 		},
 	}
 
-	appCfg := cfg.ToAppConfig()
+	appCfg := cfg.ToInternalConfig()
 	require.NotNil(t, appCfg)
 	require.Equal(t, "localhost:9181", appCfg.DefraDB.Url)
 	require.Equal(t, "secret123", appCfg.DefraDB.KeyringSecret)
@@ -182,9 +182,9 @@ func TestToAppConfig(t *testing.T) {
 	require.True(t, appCfg.Logger.Development)
 }
 
-func TestToAppConfig_Nil(t *testing.T) {
+func TestToInternalConfig_Nil(t *testing.T) {
 	var cfg *Config
-	appCfg := cfg.ToAppConfig()
+	appCfg := cfg.ToInternalConfig()
 	require.Nil(t, appCfg)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/multiformats/go-multiaddr v0.16.1
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/rs/zerolog v1.34.0
-	github.com/shinzonetwork/shinzo-app-sdk v0.0.0-20260324214239-d756a4069836
 	github.com/shinzonetwork/shinzo-indexer-client v0.0.0-20251219184827-5722330739e8
 	github.com/shinzonetwork/viewbundle-go v0.1.1
 	github.com/sourcenetwork/corelog v0.0.8
@@ -212,7 +211,6 @@ require (
 	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/jmhodges/levigo v1.0.0 // indirect
-	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/kilic/bls12-381 v0.1.1-0.20210503002446-7b7597926c69 // indirect
 	github.com/klauspost/compress v1.18.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1646,8 +1646,6 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfC
 github.com/jmhodges/levigo v1.0.0 h1:q5EC36kV79HWeTBWsod3mG11EgStG3qArTKcvlksN1U=
 github.com/jmhodges/levigo v1.0.0/go.mod h1:Q6Qx+uH3RAqyK4rFQroq9RL7mdkABMcfhEI+nNuzMJQ=
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
-github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
-github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jonboulle/clockwork v0.2.0/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
@@ -2251,8 +2249,6 @@ github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNX
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/shazow/go-diff v0.0.0-20160112020656-b6b7b6733b8c/go.mod h1:/PevMnwAxekIXwN8qQyfc5gl2NlkB3CQlkizAbOkeBs=
-github.com/shinzonetwork/shinzo-app-sdk v0.0.0-20260324214239-d756a4069836 h1:4JTkSBJ9LymwuSO6QK4MCAcJ9t1UINmUWMftdVJE4hU=
-github.com/shinzonetwork/shinzo-app-sdk v0.0.0-20260324214239-d756a4069836/go.mod h1:jPCm2FVOLt3u6McMDxaE37Jputno2iIFxxJzc4bx8Q4=
 github.com/shinzonetwork/shinzo-indexer-client v0.0.0-20251219184827-5722330739e8 h1:g+7aGWLyrrFFHWq7mch0b0Af2YXCNKR2xOTQ/Ed/z70=
 github.com/shinzonetwork/shinzo-indexer-client v0.0.0-20251219184827-5722330739e8/go.mod h1:IpuhmHiO6IYcutRGG+c1vvUvxYb2c8yqB1eyHOdXx3c=
 github.com/shinzonetwork/viewbundle-go v0.1.1 h1:GTSh7bYHqEzZSSJHAySdaciLDq+TyvBwY6jmyX9udYk=

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 
 	"github.com/rs/zerolog"
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/defra"
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/logger"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/defradb"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/attestation"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/constants"
 	localschema "github.com/shinzonetwork/shinzo-host-client/pkg/schema"
@@ -30,7 +30,7 @@ func TestIntegration(t *testing.T) {
 	ctx := context.Background()
 
 	// Create test config with P2P enabled to replicate data from indexer
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0" // Use random available port
 	testConfig.DefraDB.Url = "localhost:0"
@@ -42,8 +42,8 @@ func TestIntegration(t *testing.T) {
 	}
 
 	// Start defra with real connection using schema applier
-	schemaApplier := defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild())
-	defraNode, networkHandler, err := defra.StartDefraInstance(testConfig, schemaApplier, nil, nil, constants.AllCollections...)
+	schemaApplier := defradb.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild())
+	defraNode, networkHandler, err := defradb.StartDefraInstance(testConfig, schemaApplier, nil, nil, constants.AllCollections...)
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -211,7 +211,7 @@ func waitForBlockViaSubscription(t *testing.T, ctx context.Context, defraNode *n
 	// Create subscription query for blocks
 	subscription := fmt.Sprintf(`subscription { %s { hash number } }`, constants.CollectionBlock)
 
-	blockChan, err := defra.Subscribe[map[string]any](ctx, defraNode, subscription)
+	blockChan, err := defradb.Subscribe[map[string]any](ctx, defraNode, subscription)
 	if err != nil {
 		return fmt.Errorf("failed to create block subscription: %w", err)
 	}
@@ -244,7 +244,7 @@ func testQueries(t *testing.T, ctx context.Context, defraNode *node.Node) {
 	t.Run("IndividualCollectionQueries", func(t *testing.T) {
 		// Query Block
 		blockQuery := fmt.Sprintf(`{ %s(limit: 1) { hash number timestamp } }`, constants.CollectionBlock)
-		blocks, err := defra.QueryArray[map[string]any](ctx, defraNode, blockQuery)
+		blocks, err := defradb.QueryArray[map[string]any](ctx, defraNode, blockQuery)
 		if err != nil {
 			t.Logf("ERROR querying blocks: %v", err)
 		}
@@ -254,7 +254,7 @@ func testQueries(t *testing.T, ctx context.Context, defraNode *node.Node) {
 
 		// Query Transaction
 		txQuery := fmt.Sprintf(`{ %s(limit: 10) { hash blockNumber from to } }`, constants.CollectionTransaction)
-		txs, err := defra.QueryArray[map[string]any](ctx, defraNode, txQuery)
+		txs, err := defradb.QueryArray[map[string]any](ctx, defraNode, txQuery)
 		if err != nil {
 			t.Logf("ERROR querying transactions: %v", err)
 		}
@@ -264,7 +264,7 @@ func testQueries(t *testing.T, ctx context.Context, defraNode *node.Node) {
 
 		// Query Log
 		logQuery := fmt.Sprintf(`{ %s(limit: 10) { address blockNumber transactionHash logIndex } }`, constants.CollectionLog)
-		logs, err := defra.QueryArray[map[string]any](ctx, defraNode, logQuery)
+		logs, err := defradb.QueryArray[map[string]any](ctx, defraNode, logQuery)
 		if err != nil {
 			t.Logf("ERROR querying logs: %v", err)
 		}
@@ -274,7 +274,7 @@ func testQueries(t *testing.T, ctx context.Context, defraNode *node.Node) {
 
 		// Query AccessListEntry
 		accessQuery := fmt.Sprintf(`{ %s(limit: 3) { address storageKeys } }`, constants.CollectionAccessListEntry)
-		accessList, err := defra.QueryArray[map[string]any](ctx, defraNode, accessQuery)
+		accessList, err := defradb.QueryArray[map[string]any](ctx, defraNode, accessQuery)
 		if err != nil {
 			t.Logf("ERROR querying access list entries: %v", err)
 		}
@@ -283,7 +283,7 @@ func testQueries(t *testing.T, ctx context.Context, defraNode *node.Node) {
 
 		// Query AttestationRecord
 		attestQuery := fmt.Sprintf(`{ %s(limit: 10) { attested_doc source_doc doc_type vote_count CIDs } }`, constants.CollectionAttestationRecord)
-		attestations, err := defra.QueryArray[map[string]any](ctx, defraNode, attestQuery)
+		attestations, err := defradb.QueryArray[map[string]any](ctx, defraNode, attestQuery)
 		if err != nil {
 			t.Logf("ERROR querying attestation records: %v", err)
 		}
@@ -313,7 +313,7 @@ func testQueries(t *testing.T, ctx context.Context, defraNode *node.Node) {
 			} 
 		}`, constants.CollectionBlock)
 
-		results, err := defra.QueryArray[map[string]any](ctx, defraNode, nestedQuery)
+		results, err := defradb.QueryArray[map[string]any](ctx, defraNode, nestedQuery)
 		if err != nil {
 			t.Logf("ERROR executing nested query: %v", err)
 		}
@@ -353,7 +353,7 @@ func testQueries(t *testing.T, ctx context.Context, defraNode *node.Node) {
 			} 
 		}`, constants.CollectionTransaction)
 
-		results, err := defra.QueryArray[map[string]any](ctx, defraNode, nestedQuery)
+		results, err := defradb.QueryArray[map[string]any](ctx, defraNode, nestedQuery)
 		if err != nil {
 			t.Logf("ERROR executing nested transaction query: %v", err)
 		}
@@ -373,7 +373,7 @@ func testQueries(t *testing.T, ctx context.Context, defraNode *node.Node) {
 			} 
 		}`, constants.CollectionLog)
 
-		results, err := defra.QueryArray[map[string]any](ctx, defraNode, nestedQuery)
+		results, err := defradb.QueryArray[map[string]any](ctx, defraNode, nestedQuery)
 		if err != nil {
 			t.Logf("ERROR executing nested log query: %v", err)
 		}
@@ -385,7 +385,7 @@ func testQueries(t *testing.T, ctx context.Context, defraNode *node.Node) {
 	t.Run("DocIDLookup", func(t *testing.T) {
 		// First get a document to get its _docID
 		getDocQuery := fmt.Sprintf(`{ %s(limit: 1) { _docID topics address } }`, constants.CollectionLog)
-		docs, err := defra.QueryArray[map[string]any](ctx, defraNode, getDocQuery)
+		docs, err := defradb.QueryArray[map[string]any](ctx, defraNode, getDocQuery)
 		if err != nil {
 			t.Logf("ERROR getting document with _docID: %v", err)
 		}
@@ -415,7 +415,7 @@ func testQueries(t *testing.T, ctx context.Context, defraNode *node.Node) {
 			} 
 		}`, constants.CollectionLog, docID)
 
-		result, err := defra.QuerySingle[map[string]any](ctx, defraNode, docIDLookupQuery)
+		result, err := defradb.QuerySingle[map[string]any](ctx, defraNode, docIDLookupQuery)
 		if err != nil {
 			t.Logf("ERROR looking up by _docID: %v", err)
 		}

--- a/pkg/attestation/attestationRecordService.go
+++ b/pkg/attestation/attestationRecordService.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/defra"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/defradb"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/constants"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/node"
@@ -407,7 +407,7 @@ func CheckExistingAttestation(ctx context.Context, defraNode *node.Node, docID s
 		}
 	`, constants.CollectionAttestationRecord, docID, docType)
 
-	existing, err := defra.QueryArray[AttestationRecord](ctx, defraNode, query)
+	existing, err := defradb.QueryArray[AttestationRecord](ctx, defraNode, query)
 	if err != nil {
 		if strings.Contains(err.Error(), "No attestation records found") {
 			return nil, nil // No existing attestation, not an error
@@ -547,7 +547,7 @@ func IsDocumentAttestedViaBlock(ctx context.Context, defraNode *node.Node, block
 		}
 	`, constants.CollectionAttestationRecord, blockAttestedID)
 
-	records, err := defra.QueryArray[AttestationRecord](ctx, defraNode, query)
+	records, err := defradb.QueryArray[AttestationRecord](ctx, defraNode, query)
 	if err != nil {
 		if strings.Contains(err.Error(), "No attestation records found") {
 			return false, nil
@@ -588,7 +588,7 @@ func GetBlockAttestations(ctx context.Context, defraNode *node.Node, blockNumber
 		}
 	`, constants.CollectionAttestationRecord, blockPrefix)
 
-	records, err := defra.QueryArray[AttestationRecord](ctx, defraNode, query)
+	records, err := defradb.QueryArray[AttestationRecord](ctx, defraNode, query)
 	if err != nil {
 		if strings.Contains(err.Error(), "No attestation records found") {
 			return nil, nil
@@ -626,7 +626,7 @@ func GetAttestationRecordsByViewName(ctx context.Context, defraNode *node.Node, 
 			}
 		`, collectionName, inList)
 
-		return defra.QueryArray[AttestationRecord](ctx, defraNode, query)
+		return defradb.QueryArray[AttestationRecord](ctx, defraNode, query)
 	} else {
 		// Query all records for this view
 		query := fmt.Sprintf(`
@@ -640,6 +640,6 @@ func GetAttestationRecordsByViewName(ctx context.Context, defraNode *node.Node, 
 			}
 		`, collectionName)
 
-		return defra.QueryArray[AttestationRecord](ctx, defraNode, query)
+		return defradb.QueryArray[AttestationRecord](ctx, defraNode, query)
 	}
 }

--- a/pkg/attestation/attestationRecordService_test.go
+++ b/pkg/attestation/attestationRecordService_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/defra"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/defradb"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/constants"
 	"github.com/stretchr/testify/require"
 )
@@ -184,7 +184,7 @@ func TestPostAttestationRecord(t *testing.T) {
 	`
 
 	// Create and start client using new API with test config
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()                          // Use temp directory for test data
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing" // Set test keyring secret
 	testConfig.DefraDB.Url = "localhost:0"                               // Use random available port for API
@@ -192,7 +192,7 @@ func TestPostAttestationRecord(t *testing.T) {
 	testConfig.DefraDB.P2P.Enabled = false                               // Disable P2P networking for testing
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}                   // No bootstrap peers
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -228,7 +228,7 @@ func TestPostAttestationRecord(t *testing.T) {
 		}
 	`
 
-	testDocResult, err := defra.PostMutation[TestDoc](t.Context(), defraNode, createTestDocMutation)
+	testDocResult, err := defradb.PostMutation[TestDoc](t.Context(), defraNode, createTestDocMutation)
 	require.NoError(t, err)
 	require.NotNil(t, testDocResult)
 	require.Greater(t, len(testDocResult.DocId), 0)
@@ -261,7 +261,7 @@ func TestPostAttestationRecord(t *testing.T) {
 		}
 	`, constants.CollectionAttestationRecord)
 
-	results, err := defra.QueryArray[AttestationRecord](t.Context(), defraNode, query)
+	results, err := defradb.QueryArray[AttestationRecord](t.Context(), defraNode, query)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 
@@ -419,7 +419,7 @@ func TestMergeAttestationRecords_IntegrationWithDefraDB(t *testing.T) {
 	`
 
 	// Create and start client using new API with test config
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()                          // Use temp directory for test data
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing" // Set test keyring secret
 	testConfig.DefraDB.Url = "localhost:0"                               // Use random available port for API
@@ -427,7 +427,7 @@ func TestMergeAttestationRecords_IntegrationWithDefraDB(t *testing.T) {
 	testConfig.DefraDB.P2P.Enabled = false                               // Disable P2P networking for testing
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}                   // No bootstrap peers
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -480,11 +480,11 @@ func TestMergeAttestationRecords_IntegrationWithDefraDB(t *testing.T) {
 		}
 	`
 
-	doc1Result, err := defra.PostMutation[TestDoc](t.Context(), defraNode, createDoc1Mutation)
+	doc1Result, err := defradb.PostMutation[TestDoc](t.Context(), defraNode, createDoc1Mutation)
 	require.NoError(t, err)
 	require.NotNil(t, doc1Result)
 
-	doc2Result, err := defra.PostMutation[TestDoc](t.Context(), defraNode, createDoc2Mutation)
+	doc2Result, err := defradb.PostMutation[TestDoc](t.Context(), defraNode, createDoc2Mutation)
 	require.NoError(t, err)
 	require.NotNil(t, doc2Result)
 
@@ -525,7 +525,7 @@ func TestMergeAttestationRecords_IntegrationWithDefraDB(t *testing.T) {
 		}
 	`, constants.CollectionAttestationRecord)
 
-	results, err := defra.QueryArray[AttestationRecord](t.Context(), defraNode, query)
+	results, err := defradb.QueryArray[AttestationRecord](t.Context(), defraNode, query)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 
@@ -614,7 +614,7 @@ func TestPostAttestationRecord_NewDocument_CreatesSingleRecord(t *testing.T) {
 	`
 
 	// Create and start client using new API with test config
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()                          // Use temp directory for test data
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing" // Set test keyring secret
 	testConfig.DefraDB.Url = "localhost:0"                               // Use random available port for API
@@ -622,7 +622,7 @@ func TestPostAttestationRecord_NewDocument_CreatesSingleRecord(t *testing.T) {
 	testConfig.DefraDB.P2P.Enabled = false                               // Disable P2P networking for testing
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}                   // No bootstrap peers
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -654,7 +654,7 @@ func TestPostAttestationRecord_NewDocument_CreatesSingleRecord(t *testing.T) {
 		}
 	`, constants.CollectionAttestationRecord)
 
-	results, err := defra.QueryArray[AttestationRecord](t.Context(), defraNode, query)
+	results, err := defradb.QueryArray[AttestationRecord](t.Context(), defraNode, query)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	require.Equal(t, "doc-123", results[0].AttestedDocId)
@@ -679,7 +679,7 @@ func TestPostAttestationRecord_OldDocument_DuplicateCreateIsHandled(t *testing.T
 	`
 
 	// Create and start client using new API with test config
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()                          // Use temp directory for test data
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing" // Set test keyring secret
 	testConfig.DefraDB.Url = "localhost:0"                               // Use random available port for API
@@ -687,7 +687,7 @@ func TestPostAttestationRecord_OldDocument_DuplicateCreateIsHandled(t *testing.T
 	testConfig.DefraDB.P2P.Enabled = false                               // Disable P2P networking for testing
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}                   // No bootstrap peers
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -721,7 +721,7 @@ func TestPostAttestationRecord_OldDocument_DuplicateCreateIsHandled(t *testing.T
 		}
 	`, constants.CollectionAttestationRecord)
 
-	results, err := defra.QueryArray[AttestationRecord](t.Context(), defraNode, query)
+	results, err := defradb.QueryArray[AttestationRecord](t.Context(), defraNode, query)
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, len(results), 1)
 }
@@ -761,7 +761,7 @@ func TestPostAttestationRecord_MultipleIndexers_AppendsSourceDoc(t *testing.T) {
 			vote_count: Int @crdt(type: pcounter)
 		}
 	`
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(schema))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(schema))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -811,7 +811,7 @@ func TestPostAttestationRecordsBatch_UpdatesExistingRecord_AppendsCIDs(t *testin
 		}
 	`
 
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -819,7 +819,7 @@ func TestPostAttestationRecordsBatch_UpdatesExistingRecord_AppendsCIDs(t *testin
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -854,7 +854,7 @@ func TestPostAttestationRecordsBatch_UpdatesExistingRecord_AppendsCIDs(t *testin
 		}
 	`, constants.CollectionAttestationRecord)
 
-	results, err := defra.QueryArray[AttestationRecord](ctx, defraNode, query)
+	results, err := defradb.QueryArray[AttestationRecord](ctx, defraNode, query)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	require.ElementsMatch(t, []string{"cid-1", "cid-2"}, results[0].CIDs)
@@ -873,7 +873,7 @@ func TestPostAttestationRecordsBatch_UpdatesExistingRecord_AppendsCIDs(t *testin
 
 	// Step 3: Verify that the batch was posted (SaveMany creates a new record;
 	// CID merging only happens via the upsert_ mutation in PostAttestationRecord)
-	results, err = defra.QueryArray[AttestationRecord](ctx, defraNode, query)
+	results, err = defradb.QueryArray[AttestationRecord](ctx, defraNode, query)
 	require.NoError(t, err)
 	require.NotEmpty(t, results)
 }
@@ -891,7 +891,7 @@ func TestPostAttestationRecordsBatch_CreatesNewRecord_WhenNotExists(t *testing.T
 		}
 	`
 
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -899,7 +899,7 @@ func TestPostAttestationRecordsBatch_CreatesNewRecord_WhenNotExists(t *testing.T
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -932,7 +932,7 @@ func TestPostAttestationRecordsBatch_CreatesNewRecord_WhenNotExists(t *testing.T
 		}
 	`, constants.CollectionAttestationRecord)
 
-	results, err := defra.QueryArray[AttestationRecord](ctx, defraNode, query)
+	results, err := defradb.QueryArray[AttestationRecord](ctx, defraNode, query)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	require.Equal(t, "new-attested-doc", results[0].AttestedDocId)
@@ -953,7 +953,7 @@ func TestPostAttestationRecordsBatch_MultipleBatchRecords(t *testing.T) {
 		}
 	`
 
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -961,7 +961,7 @@ func TestPostAttestationRecordsBatch_MultipleBatchRecords(t *testing.T) {
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -1003,7 +1003,7 @@ func TestPostAttestationRecordsBatch_MultipleBatchRecords(t *testing.T) {
 		}
 	`, constants.CollectionAttestationRecord)
 
-	results, err := defra.QueryArray[AttestationRecord](ctx, defraNode, query)
+	results, err := defradb.QueryArray[AttestationRecord](ctx, defraNode, query)
 	require.NoError(t, err)
 	require.Len(t, results, 2)
 
@@ -1032,7 +1032,7 @@ func TestPostAttestationRecordsBatch_EmptyRecords_ReturnsNil(t *testing.T) {
 		}
 	`
 
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -1040,7 +1040,7 @@ func TestPostAttestationRecordsBatch_EmptyRecords_ReturnsNil(t *testing.T) {
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -1079,7 +1079,7 @@ func TestPostAttestationRecordsBatch_DoesNotMutateInputRecords(t *testing.T) {
 		}
 	`
 
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -1087,7 +1087,7 @@ func TestPostAttestationRecordsBatch_DoesNotMutateInputRecords(t *testing.T) {
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -1387,7 +1387,7 @@ func TestHandleDocumentAttestation_AllSignaturesInvalid_NoCIDsPosted(t *testing.
 		}
 	`
 
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -1395,7 +1395,7 @@ func TestHandleDocumentAttestation_AllSignaturesInvalid_NoCIDsPosted(t *testing.
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -1422,7 +1422,7 @@ func TestHandleDocumentAttestation_AllSignaturesInvalid_NoCIDsPosted(t *testing.
 		}
 	`, constants.CollectionAttestationRecord)
 
-	results, err := defra.QueryArray[AttestationRecord](ctx, defraNode, query)
+	results, err := defradb.QueryArray[AttestationRecord](ctx, defraNode, query)
 	require.NoError(t, err)
 	require.Empty(t, results)
 }
@@ -1445,7 +1445,7 @@ func TestHandleDocumentAttestation_ValidSignatures_PostsRecord(t *testing.T) {
 		}
 	`
 
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -1453,7 +1453,7 @@ func TestHandleDocumentAttestation_ValidSignatures_PostsRecord(t *testing.T) {
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -1484,7 +1484,7 @@ func TestHandleDocumentAttestation_ValidSignatures_PostsRecord(t *testing.T) {
 		}
 	`, constants.CollectionAttestationRecord)
 
-	results, err := defra.QueryArray[AttestationRecord](ctx, defraNode, query)
+	results, err := defradb.QueryArray[AttestationRecord](ctx, defraNode, query)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	require.Equal(t, "doc-handle-1", results[0].AttestedDocId)
@@ -1566,7 +1566,7 @@ func TestHandleDocumentAttestationBatch_ValidInputs_PostsRecords(t *testing.T) {
 		}
 	`
 
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -1574,7 +1574,7 @@ func TestHandleDocumentAttestationBatch_ValidInputs_PostsRecords(t *testing.T) {
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -1615,7 +1615,7 @@ func TestHandleDocumentAttestationBatch_ValidInputs_PostsRecords(t *testing.T) {
 		}
 	`, constants.CollectionAttestationRecord)
 
-	results, err := defra.QueryArray[AttestationRecord](ctx, defraNode, query)
+	results, err := defradb.QueryArray[AttestationRecord](ctx, defraNode, query)
 	require.NoError(t, err)
 	require.Len(t, results, 2)
 
@@ -1648,7 +1648,7 @@ func TestHandleDocumentAttestationBatch_MixedValidAndInvalidVersions(t *testing.
 		}
 	`
 
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -1656,7 +1656,7 @@ func TestHandleDocumentAttestationBatch_MixedValidAndInvalidVersions(t *testing.
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -1694,7 +1694,7 @@ func TestHandleDocumentAttestationBatch_MixedValidAndInvalidVersions(t *testing.
 		}
 	`, constants.CollectionAttestationRecord)
 
-	results, err := defra.QueryArray[AttestationRecord](ctx, defraNode, query)
+	results, err := defradb.QueryArray[AttestationRecord](ctx, defraNode, query)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	require.Equal(t, "batch-mixed-1", results[0].AttestedDocId)
@@ -1717,7 +1717,7 @@ func TestCheckExistingAttestation_NoExistingRecords(t *testing.T) {
 		}
 	`
 
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -1725,7 +1725,7 @@ func TestCheckExistingAttestation_NoExistingRecords(t *testing.T) {
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -1755,7 +1755,7 @@ func TestCheckExistingAttestation_WithExistingRecord(t *testing.T) {
 		}
 	`
 
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -1763,7 +1763,7 @@ func TestCheckExistingAttestation_WithExistingRecord(t *testing.T) {
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -1808,7 +1808,7 @@ func TestCheckExistingAttestation_WrongDocType(t *testing.T) {
 		}
 	`
 
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -1816,7 +1816,7 @@ func TestCheckExistingAttestation_WrongDocType(t *testing.T) {
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -1861,7 +1861,7 @@ func TestIsDocumentAttestedViaBlock_NoBlockAttestation(t *testing.T) {
 		}
 	`
 
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -1869,7 +1869,7 @@ func TestIsDocumentAttestedViaBlock_NoBlockAttestation(t *testing.T) {
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -1899,7 +1899,7 @@ func TestIsDocumentAttestedViaBlock_CIDFound(t *testing.T) {
 		}
 	`
 
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -1907,7 +1907,7 @@ func TestIsDocumentAttestedViaBlock_CIDFound(t *testing.T) {
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -1948,7 +1948,7 @@ func TestIsDocumentAttestedViaBlock_CIDNotFound(t *testing.T) {
 		}
 	`
 
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -1956,7 +1956,7 @@ func TestIsDocumentAttestedViaBlock_CIDNotFound(t *testing.T) {
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -2001,7 +2001,7 @@ func TestGetBlockAttestations_NoRecords(t *testing.T) {
 		}
 	`
 
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -2009,7 +2009,7 @@ func TestGetBlockAttestations_NoRecords(t *testing.T) {
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -2038,7 +2038,7 @@ func TestGetBlockAttestations_WithRecords(t *testing.T) {
 		}
 	`
 
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -2046,7 +2046,7 @@ func TestGetBlockAttestations_WithRecords(t *testing.T) {
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -2121,7 +2121,7 @@ func TestGetAttestationRecordsByViewName_WithDocIds(t *testing.T) {
 		}
 	`, collectionName)
 
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -2129,7 +2129,7 @@ func TestGetAttestationRecordsByViewName_WithDocIds(t *testing.T) {
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -2148,7 +2148,7 @@ func TestGetAttestationRecordsByViewName_WithDocIds(t *testing.T) {
 			}
 		}
 	`, collectionName)
-	_, err = defra.PostMutation[map[string]any](ctx, defraNode, createMutation)
+	_, err = defradb.PostMutation[map[string]any](ctx, defraNode, createMutation)
 	require.NoError(t, err)
 
 	createMutation2 := fmt.Sprintf(`
@@ -2158,7 +2158,7 @@ func TestGetAttestationRecordsByViewName_WithDocIds(t *testing.T) {
 			}
 		}
 	`, collectionName)
-	_, err = defra.PostMutation[map[string]any](ctx, defraNode, createMutation2)
+	_, err = defradb.PostMutation[map[string]any](ctx, defraNode, createMutation2)
 	require.NoError(t, err)
 
 	createMutation3 := fmt.Sprintf(`
@@ -2168,7 +2168,7 @@ func TestGetAttestationRecordsByViewName_WithDocIds(t *testing.T) {
 			}
 		}
 	`, collectionName)
-	_, err = defra.PostMutation[map[string]any](ctx, defraNode, createMutation3)
+	_, err = defradb.PostMutation[map[string]any](ctx, defraNode, createMutation3)
 	require.NoError(t, err)
 
 	// Query with specific doc IDs
@@ -2198,7 +2198,7 @@ func TestGetAttestationRecordsByViewName_WithoutDocIds(t *testing.T) {
 		}
 	`, collectionName)
 
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -2206,7 +2206,7 @@ func TestGetAttestationRecordsByViewName_WithoutDocIds(t *testing.T) {
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -2225,7 +2225,7 @@ func TestGetAttestationRecordsByViewName_WithoutDocIds(t *testing.T) {
 			}
 		}
 	`, collectionName)
-	_, err = defra.PostMutation[map[string]any](ctx, defraNode, createMutation)
+	_, err = defradb.PostMutation[map[string]any](ctx, defraNode, createMutation)
 	require.NoError(t, err)
 
 	createMutation2 := fmt.Sprintf(`
@@ -2235,7 +2235,7 @@ func TestGetAttestationRecordsByViewName_WithoutDocIds(t *testing.T) {
 			}
 		}
 	`, collectionName)
-	_, err = defra.PostMutation[map[string]any](ctx, defraNode, createMutation2)
+	_, err = defradb.PostMutation[map[string]any](ctx, defraNode, createMutation2)
 	require.NoError(t, err)
 
 	// Query all records (no specific doc IDs)
@@ -2258,7 +2258,7 @@ func TestGetAttestationRecordsByViewName_EmptyDocIds(t *testing.T) {
 		}
 	`, collectionName)
 
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -2266,7 +2266,7 @@ func TestGetAttestationRecordsByViewName_EmptyDocIds(t *testing.T) {
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -2285,7 +2285,7 @@ func TestGetAttestationRecordsByViewName_EmptyDocIds(t *testing.T) {
 			}
 		}
 	`, collectionName)
-	_, err = defra.PostMutation[map[string]any](ctx, defraNode, createMutation)
+	_, err = defradb.PostMutation[map[string]any](ctx, defraNode, createMutation)
 	require.NoError(t, err)
 
 	// Empty doc IDs list (not nil) - takes the else branch in the function
@@ -2308,7 +2308,7 @@ func TestGetAttestationRecordsByViewName_NoRecords(t *testing.T) {
 		}
 	`, collectionName)
 
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -2316,7 +2316,7 @@ func TestGetAttestationRecordsByViewName_NoRecords(t *testing.T) {
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -2350,7 +2350,7 @@ func TestPostAttestationRecord_EmptyCIDs(t *testing.T) {
 		}
 	`
 
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -2358,7 +2358,7 @@ func TestPostAttestationRecord_EmptyCIDs(t *testing.T) {
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -2394,7 +2394,7 @@ func TestPostAttestationRecord_MultipleCIDs(t *testing.T) {
 		}
 	`
 
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -2402,7 +2402,7 @@ func TestPostAttestationRecord_MultipleCIDs(t *testing.T) {
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -2434,7 +2434,7 @@ func TestPostAttestationRecord_MultipleCIDs(t *testing.T) {
 		}
 	`, constants.CollectionAttestationRecord)
 
-	results, err := defra.QueryArray[AttestationRecord](ctx, defraNode, query)
+	results, err := defradb.QueryArray[AttestationRecord](ctx, defraNode, query)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	require.ElementsMatch(t, []string{"cid-1", "cid-2", "cid-3"}, results[0].CIDs)
@@ -2511,7 +2511,7 @@ func TestPostAttestationRecord_MissingSchema_ReturnsError(t *testing.T) {
 	ctx := context.Background()
 
 	// Create a defra node without the attestation schema applied
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -2519,7 +2519,7 @@ func TestPostAttestationRecord_MissingSchema_ReturnsError(t *testing.T) {
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -2549,7 +2549,7 @@ func TestPostAttestationRecordsBatch_MissingSchema_ReturnsError(t *testing.T) {
 	ctx := context.Background()
 
 	// Create a defra node without the attestation schema
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -2557,7 +2557,7 @@ func TestPostAttestationRecordsBatch_MissingSchema_ReturnsError(t *testing.T) {
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -2597,7 +2597,7 @@ func TestPostAttestationRecordsBatch_AllNilOrEmptyCIDs_ReturnsNil(t *testing.T) 
 		}
 	`
 
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -2605,7 +2605,7 @@ func TestPostAttestationRecordsBatch_AllNilOrEmptyCIDs_ReturnsNil(t *testing.T) 
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -2641,7 +2641,7 @@ func TestHandleDocumentAttestation_PostAttestationRecordError(t *testing.T) {
 	}
 
 	// Create a defra node without the attestation schema so PostAttestationRecord fails
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -2649,7 +2649,7 @@ func TestHandleDocumentAttestation_PostAttestationRecordError(t *testing.T) {
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -2696,7 +2696,7 @@ func TestHandleDocumentAttestationBatch_MixedEmptyAndValidAndInvalidSigs(t *test
 		}
 	`
 
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -2704,7 +2704,7 @@ func TestHandleDocumentAttestationBatch_MixedEmptyAndValidAndInvalidSigs(t *test
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -2748,7 +2748,7 @@ func TestHandleDocumentAttestationBatch_MixedEmptyAndValidAndInvalidSigs(t *test
 		}
 	`, constants.CollectionAttestationRecord)
 
-	results, err := defra.QueryArray[AttestationRecord](ctx, defraNode, query)
+	results, err := defradb.QueryArray[AttestationRecord](ctx, defraNode, query)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	require.Equal(t, "doc-valid", results[0].AttestedDocId)
@@ -2771,7 +2771,7 @@ func TestCheckExistingAttestation_ReturnsMultipleRecords(t *testing.T) {
 		}
 	`
 
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -2779,7 +2779,7 @@ func TestCheckExistingAttestation_ReturnsMultipleRecords(t *testing.T) {
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -2826,7 +2826,7 @@ func TestIsDocumentAttestedViaBlock_MultipleRecords_CIDInSecond(t *testing.T) {
 		}
 	`
 
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -2834,7 +2834,7 @@ func TestIsDocumentAttestedViaBlock_MultipleRecords_CIDInSecond(t *testing.T) {
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -2885,7 +2885,7 @@ func TestGetBlockAttestations_DifferentBlockNumbers(t *testing.T) {
 		}
 	`
 
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -2893,7 +2893,7 @@ func TestGetBlockAttestations_DifferentBlockNumbers(t *testing.T) {
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -2938,7 +2938,7 @@ func TestGetBlockAttestations_DifferentBlockNumbers(t *testing.T) {
 // ========================================
 // These tests call CheckExistingAttestation, IsDocumentAttestedViaBlock, and
 // GetBlockAttestations against a DefraDB instance that has NO attestation
-// schema applied. When the collection doesn't exist, defra.QueryArray returns
+// schema applied. When the collection doesn't exist, defradb.QueryArray returns
 // an error whose message contains "No attestation records found" (or similar),
 // and the functions under test should treat this as a non-error (return nil/false).
 
@@ -2946,7 +2946,7 @@ func TestCheckExistingAttestation_MissingSchema_ReturnsNilNil(t *testing.T) {
 	ctx := context.Background()
 
 	// Create a defra node WITHOUT applying the attestation schema
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -2954,7 +2954,7 @@ func TestCheckExistingAttestation_MissingSchema_ReturnsNilNil(t *testing.T) {
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -2983,7 +2983,7 @@ func TestIsDocumentAttestedViaBlock_MissingSchema_ReturnsFalseNil(t *testing.T) 
 	ctx := context.Background()
 
 	// Create a defra node WITHOUT applying the attestation schema
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -2991,7 +2991,7 @@ func TestIsDocumentAttestedViaBlock_MissingSchema_ReturnsFalseNil(t *testing.T) 
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -3013,7 +3013,7 @@ func TestGetBlockAttestations_MissingSchema_ReturnsNilNil(t *testing.T) {
 	ctx := context.Background()
 
 	// Create a defra node WITHOUT applying the attestation schema
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -3021,7 +3021,7 @@ func TestGetBlockAttestations_MissingSchema_ReturnsNilNil(t *testing.T) {
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -3222,7 +3222,7 @@ func TestPostAttestationRecordsBatch_NilRecordsInSlice_SkipNilOnly(t *testing.T)
 		}
 	`
 
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -3230,7 +3230,7 @@ func TestPostAttestationRecordsBatch_NilRecordsInSlice_SkipNilOnly(t *testing.T)
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -3259,7 +3259,7 @@ func TestPostAttestationRecordsBatch_NilRecordsInSlice_SkipNilOnly(t *testing.T)
 		}
 	`, constants.CollectionAttestationRecord)
 
-	results, err := defra.QueryArray[AttestationRecord](ctx, defraNode, query)
+	results, err := defradb.QueryArray[AttestationRecord](ctx, defraNode, query)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	require.Equal(t, "nil-test-doc", results[0].AttestedDocId)
@@ -3378,7 +3378,7 @@ func TestLookupExistingAttestation_NotFound(t *testing.T) {
 		}
 	`
 
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -3386,7 +3386,7 @@ func TestLookupExistingAttestation_NotFound(t *testing.T) {
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -3418,7 +3418,7 @@ func TestLookupExistingAttestation_Found(t *testing.T) {
 		}
 	`
 
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -3426,7 +3426,7 @@ func TestLookupExistingAttestation_Found(t *testing.T) {
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -3520,7 +3520,7 @@ func TestGetAttestationRecordsByViewName_MissingViewSchema(t *testing.T) {
 	ctx := context.Background()
 
 	// Create a defra node without any view-specific attestation schema
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -3528,7 +3528,7 @@ func TestGetAttestationRecordsByViewName_MissingViewSchema(t *testing.T) {
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)

--- a/pkg/attestation/blockSignatureVerifier.go
+++ b/pkg/attestation/blockSignatureVerifier.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 
 	gocid "github.com/ipfs/go-cid"
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/logger"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
 	"github.com/sourcenetwork/defradb/crypto"
 )
 

--- a/pkg/attestation/blockSignatureVerifier_test.go
+++ b/pkg/attestation/blockSignatureVerifier_test.go
@@ -10,7 +10,7 @@ import (
 
 	gocid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/logger"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
 	"github.com/sourcenetwork/defradb/crypto"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/attestation/signatureVerifier_test.go
+++ b/pkg/attestation/signatureVerifier_test.go
@@ -5,7 +5,7 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/defra"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/defradb"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/constants"
 	"github.com/sourcenetwork/defradb/crypto"
 	"github.com/sourcenetwork/defradb/node"
@@ -206,7 +206,7 @@ func TestMockSignatureVerifier_DifferentCIDs(t *testing.T) {
 // ========================================
 
 // setupDefraForVerifier creates a defra client with the attestation schema and returns the node.
-func setupDefraForVerifier(t *testing.T) *defra.Client {
+func setupDefraForVerifier(t *testing.T) *defradb.Client {
 	t.Helper()
 	testSchema := `
 		type TestDoc {
@@ -220,7 +220,7 @@ func setupDefraForVerifier(t *testing.T) *defra.Client {
 			vote_count: Int @crdt(type: pcounter)
 		}
 	`
-	testConfig := defra.DefaultConfig
+	testConfig := defradb.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
 	testConfig.DefraDB.Url = "localhost:0"
@@ -228,7 +228,7 @@ func setupDefraForVerifier(t *testing.T) *defra.Client {
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
-	client, err := defra.NewClient(testConfig)
+	client, err := defradb.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
@@ -354,7 +354,7 @@ func TestDefraSignatureVerifier_Verify_Success_WithMetrics(t *testing.T) {
 		}
 	`
 
-	docResult, err := defra.PostMutation[TestDoc](ctx, defraNode, createDocMutation)
+	docResult, err := defradb.PostMutation[TestDoc](ctx, defraNode, createDocMutation)
 	require.NoError(t, err)
 	require.NotNil(t, docResult)
 	require.Len(t, docResult.Version, 1)
@@ -398,7 +398,7 @@ func TestDefraSignatureVerifier_Verify_Success_NilMetrics(t *testing.T) {
 		}
 	`
 
-	docResult, err := defra.PostMutation[TestDoc](ctx, defraNode, createDocMutation)
+	docResult, err := defradb.PostMutation[TestDoc](ctx, defraNode, createDocMutation)
 	require.NoError(t, err)
 	require.NotNil(t, docResult)
 	require.Len(t, docResult.Version, 1)

--- a/pkg/defradb/config.go
+++ b/pkg/defradb/config.go
@@ -1,0 +1,46 @@
+package defradb
+
+// Config holds the runtime configuration consumed by StartDefraInstance, the
+// signer, and other defradb-level helpers. It mirrors the SDK's config shape
+// so existing call sites pass through unchanged; host code populates it via
+// (*hostconfig.Config).ToInternalConfig().
+type Config struct {
+	DefraDB DefraDBConfig `yaml:"defradb"`
+	Logger  LoggerConfig  `yaml:"logger"`
+}
+
+type DefraDBConfig struct {
+	Url           string           `yaml:"url"`
+	KeyringSecret string           `yaml:"keyring_secret"`
+	P2P           DefraP2PConfig   `yaml:"p2p"`
+	Store         DefraStoreConfig `yaml:"store"`
+}
+
+type DefraP2PConfig struct {
+	Enabled             bool     `yaml:"enabled"`
+	BootstrapPeers      []string `yaml:"bootstrap_peers"`
+	ListenAddr          string   `yaml:"listen_addr"`
+	MaxRetries          int      `yaml:"max_retries"`
+	RetryBaseDelayMs    int      `yaml:"retry_base_delay_ms"`
+	ReconnectIntervalMs int      `yaml:"reconnect_interval_ms"`
+	EnableAutoReconnect bool     `yaml:"enable_auto_reconnect"`
+}
+
+type DefraStoreConfig struct {
+	Path string `yaml:"path"`
+	// Badger memory configuration.
+	BlockCacheMB int64 `yaml:"block_cache_mb"`
+	MemTableMB   int64 `yaml:"memtable_mb"`
+	IndexCacheMB int64 `yaml:"index_cache_mb"`
+	// Badger compaction configuration.
+	NumCompactors           int `yaml:"num_compactors"`
+	NumLevelZeroTables      int `yaml:"num_level_zero_tables"`
+	NumLevelZeroTablesStall int `yaml:"num_level_zero_tables_stall"`
+	// Badger value-log file size in MB. Defaults to 64 inside StartDefraInstance.
+	ValueLogFileSizeMB int64 `yaml:"value_log_file_size_mb"`
+}
+
+type LoggerConfig struct {
+	Development bool   `yaml:"development"`
+	LogsDir     string `yaml:"logs_dir"`
+}

--- a/pkg/defradb/defra.go
+++ b/pkg/defradb/defra.go
@@ -48,7 +48,7 @@ var DefaultConfig *Config = &Config{
 
 var requiredPeers []string = []string{} // Here, we can add some "big peers" to give nodes a starting place when building their peer network
 const defaultListenAddress string = "/ip4/127.0.0.1/tcp/9171"
-const nodeIdentityKeyName string = "node-identity-key"
+const NodeIdentityKeyName string = "node-identity-key"
 
 // Key Management Implementation Notes:
 //
@@ -70,9 +70,12 @@ const nodeIdentityKeyName string = "node-identity-key"
 // - Proper error handling for corrupted or missing keys
 // - Requires DEFRA_KEYRING_SECRET environment variable or config
 
-// openKeyring opens a keyring from the config.
-// Returns an error if keyring cannot be opened (KeyringSecret is required).
-func openKeyring(cfg *Config) (keyring.Keyring, error) {
+// OpenKeyring opens the file-based keyring at {Store.Path}/keys using
+// KeyringSecret as the encryption secret. Returns an error if cfg is nil or
+// KeyringSecret is empty; callers that want a "no keyring → fall back" flow
+// should detect that error at their own call site rather than relying on a
+// silent nil return.
+func OpenKeyring(cfg *Config) (keyring.Keyring, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("config cannot be nil")
 	}
@@ -99,13 +102,13 @@ func openKeyring(cfg *Config) (keyring.Keyring, error) {
 // getOrCreateNodeIdentity retrieves an existing node identity from keyring or creates a new one
 func getOrCreateNodeIdentity(cfg *Config) (identity.Identity, error) {
 	// Open keyring (required, no fallback)
-	kr, err := openKeyring(cfg)
+	kr, err := OpenKeyring(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open keyring: %w", err)
 	}
 
 	// Try to load existing identity from keyring
-	identityBytes, err := kr.Get(nodeIdentityKeyName)
+	identityBytes, err := kr.Get(NodeIdentityKeyName)
 	if err != nil {
 		if !errors.Is(err, keyring.ErrNotFound) {
 			return nil, fmt.Errorf("failed to get identity from keyring: %w", err)
@@ -128,7 +131,7 @@ func getOrCreateNodeIdentity(cfg *Config) (identity.Identity, error) {
 
 	// Load existing identity from keyring
 	logger.Sugar.Info("Loading existing DefraDB identity from keyring")
-	return loadNodeIdentityFromKeyring(identityBytes)
+	return LoadIdentityFromBytes(identityBytes)
 }
 
 // saveNodeIdentityToKeyring saves the private key bytes of a node identity to the keyring
@@ -156,7 +159,7 @@ func saveNodeIdentityToKeyring(kr keyring.Keyring, nodeIdentity identity.Identit
 	identityBytes := append([]byte(keyType+":"), keyBytes...)
 
 	// Save to keyring
-	if err := kr.Set(nodeIdentityKeyName, identityBytes); err != nil {
+	if err := kr.Set(NodeIdentityKeyName, identityBytes); err != nil {
 		return fmt.Errorf("failed to save identity to keyring: %w", err)
 	}
 
@@ -164,9 +167,10 @@ func saveNodeIdentityToKeyring(kr keyring.Keyring, nodeIdentity identity.Identit
 	return nil
 }
 
-// loadNodeIdentityFromKeyring loads a node identity from keyring bytes
-func loadNodeIdentityFromKeyring(identityBytes []byte) (identity.Identity, error) {
-	// Parse the format: "keyType:rawKeyBytes"
+// LoadIdentityFromBytes parses identity bytes in the keyring's "keyType:rawKeyBytes"
+// format (the same format DefraDB CLI writes) and rebuilds the FullIdentity.
+// Pre-prefix bytes are assumed to be secp256k1 for backward compatibility.
+func LoadIdentityFromBytes(identityBytes []byte) (identity.Identity, error) {
 	sepPos := bytes.Index(identityBytes, []byte(":"))
 	if sepPos == -1 {
 		// Old format without key type prefix, assume secp256k1
@@ -177,22 +181,30 @@ func loadNodeIdentityFromKeyring(identityBytes []byte) (identity.Identity, error
 	keyType := string(identityBytes[:sepPos])
 	keyBytes := identityBytes[sepPos+1:]
 
-	// Reconstruct private key from bytes
 	privateKey, err := crypto.PrivateKeyFromBytes(crypto.KeyType(keyType), keyBytes)
 	if err != nil {
 		var emptyIdentity identity.Identity
 		return emptyIdentity, fmt.Errorf("failed to reconstruct private key: %w", err)
 	}
 
-	// Reconstruct identity from private key
 	fullIdentity, err := identity.FromPrivateKey(privateKey)
 	if err != nil {
 		var emptyIdentity identity.Identity
 		return emptyIdentity, fmt.Errorf("failed to reconstruct identity from private key: %w", err)
 	}
 
-	logger.Sugar.Info("DefraDB identity successfully loaded from keyring")
 	return fullIdentity, nil
+}
+
+// LoadIdentityFromKeyring fetches the node-identity entry from kr and parses it
+// into an Identity. Convenience wrapper for callers that already hold an open
+// keyring and don't need the create-if-missing branch.
+func LoadIdentityFromKeyring(kr keyring.Keyring) (identity.Identity, error) {
+	identityBytes, err := kr.Get(NodeIdentityKeyName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get identity from keyring: %w", err)
+	}
+	return LoadIdentityFromBytes(identityBytes)
 }
 
 // GetOrCreateNodeIdentity retrieves an existing node identity from keyring or creates a new one.
@@ -210,9 +222,11 @@ func GetIdentityContext(ctx context.Context, cfg *Config) (context.Context, erro
 	return identity.WithContext(ctx, immutable.Some[identity.Identity](nodeIdentity)), nil
 }
 
-// createLibP2PKeyFromIdentity creates a LibP2P private key from a DefraDB identity
-// This ensures the LibP2P peer ID is deterministically derived from the same identity
-func createLibP2PKeyFromIdentity(nodeIdentity identity.Identity) (libp2pcrypto.PrivKey, error) {
+// CreateLibP2PKeyFromIdentity derives a deterministic libp2p Ed25519 private
+// key from a DefraDB secp256k1 identity. The 32-byte secp256k1 key bytes are
+// used as the seed, so the libp2p peer ID stays stable across restarts and
+// matches across every component that calls this with the same identity.
+func CreateLibP2PKeyFromIdentity(nodeIdentity identity.Identity) (libp2pcrypto.PrivKey, error) {
 	// Cast to FullIdentity to access private key
 	fullIdentity, ok := nodeIdentity.(identity.FullIdentity)
 	if !ok {
@@ -267,7 +281,7 @@ func StartDefraInstance(cfg *Config, schemaApplier SchemaApplier, nodeOpts []opt
 	}
 
 	// Create LibP2P private key from the same identity to ensure consistent peer ID
-	libp2pPrivKey, err := createLibP2PKeyFromIdentity(nodeIdentity)
+	libp2pPrivKey, err := CreateLibP2PKeyFromIdentity(nodeIdentity)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating LibP2P private key from identity: %v", err)
 	}
@@ -536,7 +550,7 @@ func (c *Client) Start(ctx context.Context) error {
 	}
 
 	// Create LibP2P private key from the same identity to ensure consistent peer ID
-	libp2pPrivKey, err := createLibP2PKeyFromIdentity(nodeIdentity)
+	libp2pPrivKey, err := CreateLibP2PKeyFromIdentity(nodeIdentity)
 	if err != nil {
 		return fmt.Errorf("error creating LibP2P private key from identity: %v", err)
 	}

--- a/pkg/defradb/defra.go
+++ b/pkg/defradb/defra.go
@@ -1,0 +1,696 @@
+package defradb
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	libp2pcrypto "github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
+	"github.com/sourcenetwork/defradb/acp/identity"
+	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/crypto"
+	"github.com/sourcenetwork/defradb/keyring"
+	"github.com/sourcenetwork/defradb/node"
+	"github.com/sourcenetwork/immutable"
+	"github.com/sourcenetwork/immutable/enumerable"
+)
+
+var DefaultConfig *Config = &Config{
+	DefraDB: DefraDBConfig{
+		Url:           "http://localhost:9181",
+		KeyringSecret: os.Getenv("DEFRA_KEYRING_SECRET"),
+		P2P: DefraP2PConfig{
+			Enabled:             true,
+			BootstrapPeers:      requiredPeers,
+			ListenAddr:          defaultListenAddress,
+			MaxRetries:          5,
+			RetryBaseDelayMs:    1000,
+			ReconnectIntervalMs: 60000,
+			EnableAutoReconnect: true,
+		},
+		Store: DefraStoreConfig{
+			Path: ".defra",
+		},
+	},
+	Logger: LoggerConfig{
+		Development: false,
+		LogsDir:     "./logs",
+	},
+}
+
+var requiredPeers []string = []string{} // Here, we can add some "big peers" to give nodes a starting place when building their peer network
+const defaultListenAddress string = "/ip4/127.0.0.1/tcp/9171"
+const nodeIdentityKeyName string = "node-identity-key"
+
+// Key Management Implementation Notes:
+//
+// This implementation provides persistent DefraDB identity management using the keyring:
+// 1. Extracting private key bytes from generated FullIdentity
+// 2. Storing the raw key bytes in encrypted keyring storage (file-based keyring)
+// 3. Reconstructing the same identity from stored private key bytes on subsequent runs
+// 4. Ensuring the same cryptographic identity is used across application restarts
+//
+// Current Status: FULLY FUNCTIONAL
+// - Private keys are properly extracted and stored in keyring
+// - Identities are reconstructed from keyring, maintaining consistency
+// - Keys are encrypted using PBES2_HS512_A256KW algorithm
+// - Comprehensive error handling and logging
+//
+// Security Features:
+// - Keys stored in encrypted keyring (default: {storePath}/keys/)
+// - Encryption key derived from KeyringSecret
+// - Proper error handling for corrupted or missing keys
+// - Requires DEFRA_KEYRING_SECRET environment variable or config
+
+// openKeyring opens a keyring from the config.
+// Returns an error if keyring cannot be opened (KeyringSecret is required).
+func openKeyring(cfg *Config) (keyring.Keyring, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("config cannot be nil")
+	}
+	if cfg.DefraDB.KeyringSecret == "" {
+		return nil, fmt.Errorf("KeyringSecret is required for keyring-based key management")
+	}
+
+	// Use file-based keyring (default for DefraDB)
+	// Keyring path defaults to "keys" directory in store path, or "keys" in current dir
+	keyringPath := filepath.Join(cfg.DefraDB.Store.Path, "keys")
+	if cfg.DefraDB.Store.Path == "" {
+		keyringPath = "keys"
+	}
+
+	// Ensure directory exists
+	if err := os.MkdirAll(keyringPath, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create keyring directory: %w", err)
+	}
+
+	secret := []byte(cfg.DefraDB.KeyringSecret)
+	return keyring.OpenFileKeyring(keyringPath, secret)
+}
+
+// getOrCreateNodeIdentity retrieves an existing node identity from keyring or creates a new one
+func getOrCreateNodeIdentity(cfg *Config) (identity.Identity, error) {
+	// Open keyring (required, no fallback)
+	kr, err := openKeyring(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open keyring: %w", err)
+	}
+
+	// Try to load existing identity from keyring
+	identityBytes, err := kr.Get(nodeIdentityKeyName)
+	if err != nil {
+		if !errors.Is(err, keyring.ErrNotFound) {
+			return nil, fmt.Errorf("failed to get identity from keyring: %w", err)
+		}
+
+		// Key not found, create new identity
+		logger.Sugar.Info("Generating new DefraDB identity")
+		nodeIdentity, err := identity.Generate(crypto.KeyTypeSecp256k1)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate new identity: %w", err)
+		}
+
+		// Save the new identity to keyring
+		if err := saveNodeIdentityToKeyring(kr, nodeIdentity); err != nil {
+			return nil, fmt.Errorf("failed to save identity to keyring: %w", err)
+		}
+
+		return nodeIdentity, nil
+	}
+
+	// Load existing identity from keyring
+	logger.Sugar.Info("Loading existing DefraDB identity from keyring")
+	return loadNodeIdentityFromKeyring(identityBytes)
+}
+
+// saveNodeIdentityToKeyring saves the private key bytes of a node identity to the keyring
+func saveNodeIdentityToKeyring(kr keyring.Keyring, nodeIdentity identity.Identity) error {
+	// Cast to FullIdentity to access private key
+	fullIdentity, ok := nodeIdentity.(identity.FullIdentity)
+	if !ok {
+		return fmt.Errorf("identity is not a FullIdentity, cannot extract private key")
+	}
+
+	// Get the private key from the identity
+	privateKey := fullIdentity.PrivateKey()
+	if privateKey == nil {
+		return fmt.Errorf("failed to get private key from identity")
+	}
+
+	// Get raw key bytes
+	keyBytes := privateKey.Raw()
+	if len(keyBytes) == 0 {
+		return fmt.Errorf("private key has no raw bytes")
+	}
+
+	// Format: "keyType:rawKeyBytes" (same format as DefraDB CLI)
+	keyType := string(privateKey.Type())
+	identityBytes := append([]byte(keyType+":"), keyBytes...)
+
+	// Save to keyring
+	if err := kr.Set(nodeIdentityKeyName, identityBytes); err != nil {
+		return fmt.Errorf("failed to save identity to keyring: %w", err)
+	}
+
+	logger.Sugar.Info("DefraDB identity private key saved to keyring")
+	return nil
+}
+
+// loadNodeIdentityFromKeyring loads a node identity from keyring bytes
+func loadNodeIdentityFromKeyring(identityBytes []byte) (identity.Identity, error) {
+	// Parse the format: "keyType:rawKeyBytes"
+	sepPos := bytes.Index(identityBytes, []byte(":"))
+	if sepPos == -1 {
+		// Old format without key type prefix, assume secp256k1
+		identityBytes = append([]byte(crypto.KeyTypeSecp256k1+":"), identityBytes...)
+		sepPos = len(crypto.KeyTypeSecp256k1)
+	}
+
+	keyType := string(identityBytes[:sepPos])
+	keyBytes := identityBytes[sepPos+1:]
+
+	// Reconstruct private key from bytes
+	privateKey, err := crypto.PrivateKeyFromBytes(crypto.KeyType(keyType), keyBytes)
+	if err != nil {
+		var emptyIdentity identity.Identity
+		return emptyIdentity, fmt.Errorf("failed to reconstruct private key: %w", err)
+	}
+
+	// Reconstruct identity from private key
+	fullIdentity, err := identity.FromPrivateKey(privateKey)
+	if err != nil {
+		var emptyIdentity identity.Identity
+		return emptyIdentity, fmt.Errorf("failed to reconstruct identity from private key: %w", err)
+	}
+
+	logger.Sugar.Info("DefraDB identity successfully loaded from keyring")
+	return fullIdentity, nil
+}
+
+// GetOrCreateNodeIdentity retrieves an existing node identity from keyring or creates a new one.
+// This is an exported version of getOrCreateNodeIdentity for use by external packages.
+func GetOrCreateNodeIdentity(cfg *Config) (identity.Identity, error) {
+	return getOrCreateNodeIdentity(cfg)
+}
+
+// GetIdentityContext returns a context with the node identity attached.
+func GetIdentityContext(ctx context.Context, cfg *Config) (context.Context, error) {
+	nodeIdentity, err := getOrCreateNodeIdentity(cfg)
+	if err != nil {
+		return ctx, fmt.Errorf("failed to get node identity: %w", err)
+	}
+	return identity.WithContext(ctx, immutable.Some[identity.Identity](nodeIdentity)), nil
+}
+
+// createLibP2PKeyFromIdentity creates a LibP2P private key from a DefraDB identity
+// This ensures the LibP2P peer ID is deterministically derived from the same identity
+func createLibP2PKeyFromIdentity(nodeIdentity identity.Identity) (libp2pcrypto.PrivKey, error) {
+	// Cast to FullIdentity to access private key
+	fullIdentity, ok := nodeIdentity.(identity.FullIdentity)
+	if !ok {
+		return nil, fmt.Errorf("identity is not a FullIdentity, cannot extract private key")
+	}
+
+	// Get the private key from the identity
+	privateKey := fullIdentity.PrivateKey()
+	if privateKey == nil {
+		return nil, fmt.Errorf("failed to get private key from identity")
+	}
+
+	// Get raw key bytes
+	keyBytes := privateKey.Raw()
+	if len(keyBytes) == 0 {
+		return nil, fmt.Errorf("private key has no raw bytes")
+	}
+
+	// DefraDB expects Ed25519 keys, but DefraDB identities use secp256k1
+	// We need to derive an Ed25519 key deterministically from the secp256k1 key
+	// Use the secp256k1 key bytes as seed for Ed25519 key generation
+	if len(keyBytes) != 32 {
+		return nil, fmt.Errorf("expected 32-byte secp256k1 key, got %d bytes", len(keyBytes))
+	}
+
+	// Generate Ed25519 key from secp256k1 seed
+	libp2pPrivKey, _, err := libp2pcrypto.GenerateEd25519Key(strings.NewReader(string(keyBytes)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate Ed25519 key from identity seed: %w", err)
+	}
+
+	return libp2pPrivKey, nil
+}
+
+func StartDefraInstance(cfg *Config, schemaApplier SchemaApplier, nodeOpts []options.Enumerable[options.NodeOptions], replicationFilter client.ReplicationFilter, collectionsOfInterest ...string) (*node.Node, *NetworkHandler, error) {
+	ctx := context.Background()
+
+	if cfg == nil {
+		return nil, nil, fmt.Errorf("config cannot be nil")
+	}
+	cfg.DefraDB.P2P.BootstrapPeers = append(cfg.DefraDB.P2P.BootstrapPeers, requiredPeers...)
+	if len(cfg.DefraDB.P2P.ListenAddr) == 0 {
+		cfg.DefraDB.P2P.ListenAddr = defaultListenAddress
+	}
+
+	logger.Init(cfg.Logger.Development, cfg.Logger.LogsDir)
+
+	// Use persistent identity from keyring (required, no fallback)
+	nodeIdentity, err := getOrCreateNodeIdentity(cfg)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error getting or creating identity: %w", err)
+	}
+
+	// Create LibP2P private key from the same identity to ensure consistent peer ID
+	libp2pPrivKey, err := createLibP2PKeyFromIdentity(nodeIdentity)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error creating LibP2P private key from identity: %v", err)
+	}
+
+	// Get raw bytes for P2P private key configuration (DefraDB 0.20 API TBD)
+	libp2pKeyBytes, err := libp2pPrivKey.Raw()
+	if err != nil {
+		return nil, nil, fmt.Errorf("error getting LibP2P private key bytes: %v", err)
+	}
+
+	// Get real IP address to replace loopback addresses
+	ipAddress, err := getLANIP()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get LAN IP address: %v", err)
+	}
+
+	// Replace loopback addresses in URL with real IP
+	defraUrl := cfg.DefraDB.Url
+	defraUrl = strings.Replace(defraUrl, "http://localhost", ipAddress, 1)
+	defraUrl = strings.Replace(defraUrl, "http://127.0.0.1", ipAddress, 1)
+	defraUrl = strings.Replace(defraUrl, "localhost", ipAddress, 1)
+	defraUrl = strings.Replace(defraUrl, "127.0.0.1", ipAddress, 1)
+
+	// Replace loopback addresses in listen address with real IP
+	listenAddress := cfg.DefraDB.P2P.ListenAddr
+	if len(listenAddress) > 0 {
+		listenAddress = strings.Replace(listenAddress, "127.0.0.1", ipAddress, 1)
+		listenAddress = strings.Replace(listenAddress, "localhost", ipAddress, 1)
+	}
+
+	// Create defra node options using builder pattern
+	nb := options.Node().
+		SetDisableAPI(false).
+		SetDisableP2P(false) // Enable P2P networking
+	nb.P2P().SetEnablePubSub(true)
+	nb.Store().SetPath(cfg.DefraDB.Store.Path)
+	nb.HTTP().SetAddress(defraUrl)
+	nb.DB().SetNodeIdentity(nodeIdentity)
+
+	// Apply badger memory configuration if specified
+	var storeOpts []func(*options.NodeOptions)
+	if cfg.DefraDB.Store.BlockCacheMB > 0 {
+		size := cfg.DefraDB.Store.BlockCacheMB << 20
+		storeOpts = append(storeOpts, func(o *options.NodeOptions) { o.Store.BadgerBlockCacheSize = size })
+		logger.Sugar.Infof("Badger block cache size: %dMB", cfg.DefraDB.Store.BlockCacheMB)
+	}
+	if cfg.DefraDB.Store.MemTableMB > 0 {
+		size := cfg.DefraDB.Store.MemTableMB << 20
+		storeOpts = append(storeOpts, func(o *options.NodeOptions) { o.Store.BadgerMemTableSize = size })
+		logger.Sugar.Infof("Badger memtable size: %dMB", cfg.DefraDB.Store.MemTableMB)
+	}
+	if cfg.DefraDB.Store.IndexCacheMB > 0 {
+		size := cfg.DefraDB.Store.IndexCacheMB << 20
+		storeOpts = append(storeOpts, func(o *options.NodeOptions) { o.Store.BadgerIndexCacheSize = size })
+		logger.Sugar.Infof("Badger index cache size: %dMB", cfg.DefraDB.Store.IndexCacheMB)
+	}
+	if cfg.DefraDB.Store.NumCompactors > 0 {
+		n := cfg.DefraDB.Store.NumCompactors
+		storeOpts = append(storeOpts, func(o *options.NodeOptions) { o.Store.BadgerNumCompactors = n })
+		logger.Sugar.Infof("Badger num compactors: %d", cfg.DefraDB.Store.NumCompactors)
+	}
+	if cfg.DefraDB.Store.NumLevelZeroTables > 0 {
+		n := cfg.DefraDB.Store.NumLevelZeroTables
+		storeOpts = append(storeOpts, func(o *options.NodeOptions) { o.Store.BadgerNumLevelZeroTables = n })
+		logger.Sugar.Infof("Badger L0 tables before compaction: %d", cfg.DefraDB.Store.NumLevelZeroTables)
+	}
+	if cfg.DefraDB.Store.NumLevelZeroTablesStall > 0 {
+		n := cfg.DefraDB.Store.NumLevelZeroTablesStall
+		storeOpts = append(storeOpts, func(o *options.NodeOptions) { o.Store.BadgerNumLevelZeroTablesStall = n })
+		logger.Sugar.Infof("Badger L0 tables stall threshold: %d", cfg.DefraDB.Store.NumLevelZeroTablesStall)
+	}
+	vlogSizeMB := cfg.DefraDB.Store.ValueLogFileSizeMB
+	if vlogSizeMB <= 0 {
+		vlogSizeMB = 64
+	}
+	nb.Store().SetBadgerFileSize(vlogSizeMB << 20)
+	logger.Sugar.Infof("Badger value log file size: %dMB", vlogSizeMB)
+
+	// Add P2P configuration options
+	if len(listenAddress) > 0 {
+		nb.P2P().SetListenAddresses(listenAddress)
+		logger.Sugar.Infof("P2P Listen Address configured: %s", listenAddress)
+	}
+
+	if len(libp2pKeyBytes) > 0 {
+		nb.P2P().SetPrivateKey(libp2pKeyBytes)
+		logger.Sugar.Info("P2P Private Key configured for consistent peer ID")
+	}
+
+	// Collect all options: builder + badger extras + user-provided options
+	allOpts := []options.Enumerable[options.NodeOptions]{nb}
+	if len(storeOpts) > 0 {
+		allOpts = append(allOpts, enumerable.New(storeOpts))
+	}
+	allOpts = append(allOpts, nodeOpts...)
+
+	defraNode, err := node.New(ctx, allOpts...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create defra node: %v ", err)
+	}
+
+	if replicationFilter != nil {
+		defraNode.ReplicationFilter = replicationFilter
+	}
+
+	err = defraNode.Start(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to start defra node: %v ", err)
+	}
+
+	err = schemaApplier.ApplySchema(ctx, defraNode)
+	if err != nil {
+		if strings.Contains(err.Error(), "collection already exists") {
+			logger.Sugar.Warnf("Failed to apply schema: %v\nProceeding...", err)
+		} else {
+			defer defraNode.Close(ctx)
+			return nil, nil, fmt.Errorf("failed to apply schema: %v", err)
+		}
+	}
+
+	err = defraNode.DB.CreateP2PCollections(ctx, collectionsOfInterest)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to add collections of interest %v: %w", collectionsOfInterest, err)
+	}
+
+	// Create network handler
+	networkHandler := NewNetworkHandler(defraNode, cfg)
+
+	// Conditionally start P2P networking based on config
+	if cfg.DefraDB.P2P.Enabled {
+		err = networkHandler.StartNetwork()
+		if err != nil {
+			logger.Sugar.Warnf("Failed to start P2P network: %v", err)
+			// Don't fail completely, just log the warning
+		}
+	} else {
+		logger.Sugar.Info("🔇 P2P networking disabled by configuration")
+	}
+
+	return defraNode, networkHandler, nil
+}
+
+// A simple wrapper on StartDefraInstance that changes the configured defra store path to a temp directory for the test
+func StartDefraInstanceWithTestConfig(t *testing.T, cfg *Config, schemaApplier SchemaApplier, collectionsOfInterest ...string) (*node.Node, error) {
+	ipAddress, err := getLANIP()
+	if err != nil {
+		return nil, err
+	}
+	listenAddress := fmt.Sprintf("/ip4/%s/tcp/0", ipAddress)
+	defraUrl := fmt.Sprintf("%s:0", ipAddress)
+	if cfg == nil {
+		cfg = DefaultConfig
+	}
+	cfg.DefraDB.Store.Path = t.TempDir()
+	cfg.DefraDB.Url = defraUrl
+	cfg.DefraDB.P2P.ListenAddr = listenAddress
+	cfg.DefraDB.KeyringSecret = "testSecret"
+	node, _, err := StartDefraInstance(cfg, schemaApplier, nil, nil, collectionsOfInterest...)
+	return node, err
+}
+
+// Subscribe creates a GraphQL subscription for real-time updates.
+//
+// This function uses non-blocking sends to prevent slow consumers from blocking subscription processing.
+func Subscribe[T any](ctx context.Context, defraNode *node.Node, subscription string) (<-chan T, error) {
+	result := defraNode.DB.ExecRequest(ctx, subscription)
+
+	if result.Subscription == nil {
+		// Check if there are GraphQL errors that explain why subscription is nil
+		if result.GQL.Errors != nil {
+			return nil, fmt.Errorf("subscription failed with GraphQL errors: %v", result.GQL.Errors)
+		}
+		return nil, fmt.Errorf("subscription channel is nil - DefraDB may not support subscriptions for this query: %s", subscription)
+	}
+
+	resultChan := make(chan T, 100000)
+
+	go func() {
+		defer close(resultChan)
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case gqlResult, ok := <-result.Subscription:
+				if !ok {
+					return
+				}
+
+				if gqlResult.Errors != nil {
+					// log errors but continue
+					logger.Sugar.Errorf("failed to subscribe: %s , errors: %v", subscription, gqlResult.Errors)
+					continue
+				}
+				// Parse and send typed result
+				var typedResult T
+				if err := marshalUnmarshal(gqlResult.Data, &typedResult); err == nil {
+					// Non-blocking send to prevent slow consumers from blocking subscription processing
+					select {
+					case resultChan <- typedResult:
+					case <-ctx.Done():
+						return
+					default:
+						logger.Sugar.Warnf("subscription buffer full, dropping event for query: %s", subscription)
+					}
+				} else {
+					logger.Sugar.Errorf("failed to parse subscription data: %v, raw data: %+v", err, gqlResult.Data)
+				}
+			}
+		}
+	}()
+
+	return resultChan, nil
+}
+
+// marshalUnmarshal converts a generic interface{} to a specific typed struct
+// using JSON marshal/unmarshal. This is the same pattern used throughout the query client.
+func marshalUnmarshal(data interface{}, target interface{}) error {
+	dataBytes, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("failed to marshal data: %w", err)
+	}
+	return json.Unmarshal(dataBytes, target)
+}
+
+// ====================================================================
+// NEW CLIENT API - Clean alternative to StartDefraInstance
+// ====================================================================
+
+// Client provides a clean interface for DefraDB operations
+type Client struct {
+	node    *node.Node
+	network *NetworkHandler
+	config  *Config
+}
+
+// NewClient creates a new client instance (doesn't start anything)
+func NewClient(cfg *Config) (*Client, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("config cannot be nil")
+	}
+
+	return &Client{
+		config: cfg,
+	}, nil
+}
+
+// Start initializes key generation, node startup, and network handler
+func (c *Client) Start(ctx context.Context) error {
+	if c.node != nil {
+		return fmt.Errorf("client already started")
+	}
+
+	// Use the same core logic as StartDefraInstance but without schema
+	c.config.DefraDB.P2P.BootstrapPeers = append(c.config.DefraDB.P2P.BootstrapPeers, requiredPeers...)
+	if len(c.config.DefraDB.P2P.ListenAddr) == 0 {
+		c.config.DefraDB.P2P.ListenAddr = defaultListenAddress
+	}
+
+	logger.Init(c.config.Logger.Development, c.config.Logger.LogsDir)
+
+	// Use persistent identity from keyring (required, no fallback)
+	nodeIdentity, err := getOrCreateNodeIdentity(c.config)
+	if err != nil {
+		return fmt.Errorf("error getting or creating identity: %w", err)
+	}
+
+	// Create LibP2P private key from the same identity to ensure consistent peer ID
+	libp2pPrivKey, err := createLibP2PKeyFromIdentity(nodeIdentity)
+	if err != nil {
+		return fmt.Errorf("error creating LibP2P private key from identity: %v", err)
+	}
+
+	// Get raw bytes for P2P private key configuration
+	libp2pKeyBytes, err := libp2pPrivKey.Raw()
+	if err != nil {
+		return fmt.Errorf("error getting LibP2P private key bytes: %v", err)
+	}
+
+	// Get real IP address to replace loopback addresses
+	ipAddress, err := getLANIP()
+	if err != nil {
+		return fmt.Errorf("failed to get LAN IP address: %v", err)
+	}
+
+	// Replace loopback addresses in URL with real IP
+	defraUrl := c.config.DefraDB.Url
+	defraUrl = strings.Replace(defraUrl, "http://localhost", ipAddress, 1)
+	defraUrl = strings.Replace(defraUrl, "http://127.0.0.1", ipAddress, 1)
+	defraUrl = strings.Replace(defraUrl, "localhost", ipAddress, 1)
+	defraUrl = strings.Replace(defraUrl, "127.0.0.1", ipAddress, 1)
+
+	// Replace loopback addresses in listen address with real IP
+	listenAddress := c.config.DefraDB.P2P.ListenAddr
+	if len(listenAddress) > 0 {
+		listenAddress = strings.Replace(listenAddress, "127.0.0.1", ipAddress, 1)
+		listenAddress = strings.Replace(listenAddress, "localhost", ipAddress, 1)
+	}
+
+	// Create defra node options using builder pattern
+	nb := options.Node().
+		SetDisableAPI(false).
+		SetDisableP2P(false)
+	nb.P2P().SetEnablePubSub(true)
+	nb.Store().SetPath(c.config.DefraDB.Store.Path)
+	nb.HTTP().SetAddress(defraUrl)
+	nb.DB().SetNodeIdentity(nodeIdentity)
+
+	// Apply badger memory configuration if specified
+	var storeOpts []func(*options.NodeOptions)
+	if c.config.DefraDB.Store.BlockCacheMB > 0 {
+		size := c.config.DefraDB.Store.BlockCacheMB << 20
+		storeOpts = append(storeOpts, func(o *options.NodeOptions) { o.Store.BadgerBlockCacheSize = size })
+	}
+	if c.config.DefraDB.Store.MemTableMB > 0 {
+		size := c.config.DefraDB.Store.MemTableMB << 20
+		storeOpts = append(storeOpts, func(o *options.NodeOptions) { o.Store.BadgerMemTableSize = size })
+	}
+	if c.config.DefraDB.Store.IndexCacheMB > 0 {
+		size := c.config.DefraDB.Store.IndexCacheMB << 20
+		storeOpts = append(storeOpts, func(o *options.NodeOptions) { o.Store.BadgerIndexCacheSize = size })
+	}
+	if c.config.DefraDB.Store.NumCompactors > 0 {
+		n := c.config.DefraDB.Store.NumCompactors
+		storeOpts = append(storeOpts, func(o *options.NodeOptions) { o.Store.BadgerNumCompactors = n })
+	}
+	if c.config.DefraDB.Store.NumLevelZeroTables > 0 {
+		n := c.config.DefraDB.Store.NumLevelZeroTables
+		storeOpts = append(storeOpts, func(o *options.NodeOptions) { o.Store.BadgerNumLevelZeroTables = n })
+	}
+	if c.config.DefraDB.Store.NumLevelZeroTablesStall > 0 {
+		n := c.config.DefraDB.Store.NumLevelZeroTablesStall
+		storeOpts = append(storeOpts, func(o *options.NodeOptions) { o.Store.BadgerNumLevelZeroTablesStall = n })
+	}
+	{
+		vlogSizeMB := c.config.DefraDB.Store.ValueLogFileSizeMB
+		if vlogSizeMB <= 0 {
+			vlogSizeMB = 64
+		}
+		nb.Store().SetBadgerFileSize(vlogSizeMB << 20)
+	}
+
+	if len(listenAddress) > 0 {
+		nb.P2P().SetListenAddresses(listenAddress)
+		logger.Sugar.Infof("P2P Listen Address configured: %s", listenAddress)
+	}
+
+	if len(libp2pKeyBytes) > 0 {
+		nb.P2P().SetPrivateKey(libp2pKeyBytes)
+		logger.Sugar.Info("P2P Private Key configured for consistent peer ID")
+	}
+
+	// Collect all options
+	allOpts := []options.Enumerable[options.NodeOptions]{nb}
+	if len(storeOpts) > 0 {
+		allOpts = append(allOpts, enumerable.New(storeOpts))
+	}
+
+	c.node, err = node.New(ctx, allOpts...)
+	if err != nil {
+		return fmt.Errorf("failed to create defra node: %v", err)
+	}
+
+	err = c.node.Start(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to start defra node: %v", err)
+	}
+
+	// Create network handler
+	c.network = NewNetworkHandler(c.node, c.config)
+
+	if c.config.DefraDB.P2P.Enabled {
+		err = c.network.StartNetwork()
+		if err != nil {
+			logger.Sugar.Warnf("Failed to start P2P network: %v", err)
+		}
+	} else {
+		logger.Sugar.Info("🔇 P2P networking disabled by configuration")
+	}
+
+	return nil
+}
+
+// Stop cleanly shuts down the client
+func (c *Client) Stop(ctx context.Context) error {
+	if c.node == nil {
+		return nil
+	}
+
+	err := c.node.Close(ctx)
+	c.node = nil
+	c.network = nil
+	return err
+}
+
+// ApplySchema applies a GraphQL schema string to the started node
+func (c *Client) ApplySchema(ctx context.Context, schema string) error {
+	if c.node == nil {
+		return fmt.Errorf("client must be started before applying schema")
+	}
+
+	if len(schema) == 0 {
+		return fmt.Errorf("schema cannot be empty")
+	}
+
+	_, err := c.node.DB.AddSchema(ctx, schema)
+	if err != nil {
+		if strings.Contains(err.Error(), "collection already exists") {
+			logger.Sugar.Warnf("Failed to apply schema: %v\nProceeding...", err)
+			return nil
+		}
+		return fmt.Errorf("failed to apply schema: %v", err)
+	}
+
+	return nil
+}
+
+// GetNode returns the underlying DefraDB node
+func (c *Client) GetNode() *node.Node {
+	return c.node
+}
+
+// GetNetworkHandler returns the network handler
+func (c *Client) GetNetworkHandler() *NetworkHandler {
+	return c.network
+}

--- a/pkg/defradb/lan_ip.go
+++ b/pkg/defradb/lan_ip.go
@@ -1,0 +1,25 @@
+package defradb
+
+import (
+	"fmt"
+	"net"
+)
+
+// dialFunc abstracts net.Dial for testability.
+var dialFunc = net.Dial
+
+// getLANIP returns the local LAN IP by opening a UDP "connection" to a public
+// address. The dial does not actually transmit; the kernel selects the egress
+// interface and we read the local address back. Used by StartDefraInstance to
+// rewrite loopback addresses to the routable interface so peers can reach us.
+func getLANIP() (string, error) {
+	conn, err := dialFunc("udp", "8.8.8.8:80")
+	if err != nil {
+		return "", fmt.Errorf("Error retrieving ip address: %v", err)
+	}
+	defer conn.Close()
+
+	localAddr := conn.LocalAddr().(*net.UDPAddr)
+
+	return localAddr.IP.String(), nil
+}

--- a/pkg/defradb/network_handler.go
+++ b/pkg/defradb/network_handler.go
@@ -1,0 +1,499 @@
+package defradb
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
+	"github.com/sourcenetwork/defradb/event"
+	"github.com/sourcenetwork/defradb/node"
+)
+
+// NetworkHandler manages P2P networking for DefraDB
+type NetworkHandler struct {
+	node *node.Node
+	cfg  *Config
+
+	// State management
+	hostRunning   bool
+	networkActive bool
+
+	// Peer management
+	peers          map[string]*PeerState
+	peersMu        sync.RWMutex
+	bootstrapPeers []string
+
+	// Reconnection management
+	reconnectTicker *time.Ticker
+	reconnectStop   chan struct{}
+
+	// Context management
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+// NewNetworkHandler creates a new network handler
+func NewNetworkHandler(defraNode *node.Node, cfg *Config) *NetworkHandler {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	peers := make(map[string]*PeerState)
+	for _, addr := range cfg.DefraDB.P2P.BootstrapPeers {
+		peers[addr] = &PeerState{
+			Address: addr,
+			State:   StateDisconnected,
+		}
+	}
+
+	if cfg.DefraDB.P2P.MaxRetries == 0 {
+		cfg.DefraDB.P2P.MaxRetries = 5
+	}
+	if cfg.DefraDB.P2P.RetryBaseDelayMs == 0 {
+		cfg.DefraDB.P2P.RetryBaseDelayMs = 1000
+	}
+	if cfg.DefraDB.P2P.ReconnectIntervalMs == 0 {
+		cfg.DefraDB.P2P.ReconnectIntervalMs = 60000
+	}
+
+	return &NetworkHandler{
+		node:           defraNode,
+		cfg:            cfg,
+		hostRunning:    true,
+		networkActive:  false,
+		peers:          peers,
+		bootstrapPeers: cfg.DefraDB.P2P.BootstrapPeers,
+		ctx:            ctx,
+		cancel:         cancel,
+	}
+}
+
+// StartNetwork activates P2P networking and begins connection attempts
+func (nh *NetworkHandler) StartNetwork() error {
+	nh.peersMu.Lock()
+	defer nh.peersMu.Unlock()
+
+	if nh.networkActive {
+		logger.Sugar.Info("P2P network already active")
+		return nil
+	}
+
+	logger.Sugar.Info("Starting P2P network connections...")
+
+	var connectedCount int
+	for addr := range nh.peers {
+		if err := nh.connectWithRetryLocked(addr); err != nil {
+			logger.Sugar.Warnf("Failed to connect to peer %s: %v", addr, err)
+		} else {
+			connectedCount++
+		}
+	}
+
+	nh.networkActive = true
+
+	nh.startReconnectionLoop()
+
+	logger.Sugar.Infof("P2P network activated, connected to %d/%d peers", connectedCount, len(nh.peers))
+	return nil
+}
+
+// StopNetwork deactivates P2P networking gracefully
+func (nh *NetworkHandler) StopNetwork() error {
+	nh.peersMu.Lock()
+
+	if !nh.networkActive {
+		nh.peersMu.Unlock()
+		logger.Sugar.Info("P2P network already inactive")
+		return nil
+	}
+
+	logger.Sugar.Info("Stopping P2P network connections...")
+
+	if nh.reconnectStop != nil {
+		close(nh.reconnectStop)
+		nh.reconnectStop = nil
+	}
+
+	nh.cancel()
+
+	nh.networkActive = false
+
+	for _, peer := range nh.peers {
+		peer.State = StateDisconnected
+		peer.ConnectedAt = time.Time{}
+	}
+
+	nh.peersMu.Unlock()
+
+	nh.wg.Wait()
+
+	// Create new context for future use
+	nh.ctx, nh.cancel = context.WithCancel(context.Background())
+
+	logger.Sugar.Info("P2P network deactivated")
+	return nil
+}
+
+// IsNetworkActive returns whether P2P networking is currently active
+func (nh *NetworkHandler) IsNetworkActive() bool {
+	nh.peersMu.RLock()
+	defer nh.peersMu.RUnlock()
+	return nh.networkActive
+}
+
+// IsHostRunning returns whether the host is running
+func (nh *NetworkHandler) IsHostRunning() bool {
+	nh.peersMu.RLock()
+	defer nh.peersMu.RUnlock()
+	return nh.hostRunning
+}
+
+// SetHostRunning updates the host running state
+func (nh *NetworkHandler) SetHostRunning(running bool) {
+	nh.peersMu.Lock()
+	defer nh.peersMu.Unlock()
+	nh.hostRunning = running
+}
+
+// ToggleNetwork switches P2P networking on/off
+func (nh *NetworkHandler) ToggleNetwork() error {
+	if nh.IsNetworkActive() {
+		return nh.StopNetwork()
+	}
+	return nh.StartNetwork()
+}
+
+// connectWithRetryLocked attempts to connect to a peer with exponential backoff
+func (nh *NetworkHandler) connectWithRetryLocked(peerAddr string) error {
+	peer, exists := nh.peers[peerAddr]
+	if !exists {
+		return fmt.Errorf("peer not found: %s", peerAddr)
+	}
+
+	maxRetries := nh.cfg.DefraDB.P2P.MaxRetries
+	baseDelay := time.Duration(nh.cfg.DefraDB.P2P.RetryBaseDelayMs) * time.Millisecond
+
+	peer.State = StateConnecting
+	peer.RetryCount = 0
+
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		peer.LastAttempt = time.Now()
+		peer.RetryCount = attempt + 1
+
+		nh.peersMu.Unlock()
+		err := connectToPeers(nh.ctx, nh.node, []string{peerAddr})
+		nh.peersMu.Lock()
+
+		if err == nil {
+			peer.State = StateConnected
+			peer.ConnectedAt = time.Now()
+			peer.LastError = nil
+			logger.Sugar.Infof("Connected to peer %s on attempt %d", peerAddr, attempt+1)
+			return nil
+		}
+
+		peer.LastError = err
+
+		select {
+		case <-nh.ctx.Done():
+			peer.State = StateDisconnected
+			return nh.ctx.Err()
+		default:
+		}
+
+		delay := baseDelay * time.Duration(1<<attempt)
+		if delay > 30*time.Second {
+			delay = 30 * time.Second
+		}
+
+		logger.Sugar.Debugf("Connection attempt %d/%d to %s failed: %v. Retrying in %v",
+			attempt+1, maxRetries, peerAddr, err, delay)
+
+		nh.peersMu.Unlock()
+		select {
+		case <-nh.ctx.Done():
+			nh.peersMu.Lock()
+			peer.State = StateDisconnected
+			return nh.ctx.Err()
+		case <-time.After(delay):
+		}
+		nh.peersMu.Lock()
+	}
+
+	peer.State = StateFailed
+	return fmt.Errorf("failed to connect to peer %s after %d retries: %w", peerAddr, maxRetries, peer.LastError)
+}
+
+// startReconnectionLoop starts the background reconnection goroutine
+func (nh *NetworkHandler) startReconnectionLoop() {
+	if !nh.cfg.DefraDB.P2P.EnableAutoReconnect {
+		return
+	}
+	interval := time.Duration(nh.cfg.DefraDB.P2P.ReconnectIntervalMs) * time.Millisecond
+	nh.reconnectStop = make(chan struct{})
+	nh.reconnectTicker = time.NewTicker(interval)
+	nh.wg.Add(1)
+	go func() {
+		defer nh.wg.Done()
+		defer nh.reconnectTicker.Stop()
+		for {
+			select {
+			case <-nh.reconnectStop:
+				return
+			case <-nh.ctx.Done():
+				return
+			case <-nh.reconnectTicker.C:
+				nh.checkPeerHealth()
+				nh.reconnectDisconnectedPeers()
+			}
+		}
+	}()
+	nh.startNoPeersEventListener()
+}
+
+// startNoPeersEventListener subscribes to P2PNoPeers events and triggers immediate reconnection
+func (nh *NetworkHandler) startNoPeersEventListener() {
+	if nh.node == nil || nh.node.DB == nil {
+		return
+	}
+	sub, err := nh.node.DB.Events().Subscribe(event.P2PNoPeersName)
+	if err != nil {
+		logger.Sugar.Warnf("Failed to subscribe to P2PNoPeers events: %v", err)
+		return
+	}
+	nh.wg.Add(1)
+	go func() {
+		defer nh.wg.Done()
+		for {
+			select {
+			case <-nh.reconnectStop:
+				return
+			case <-nh.ctx.Done():
+				return
+			case msg, ok := <-sub.Message():
+				if !ok {
+					return
+				}
+				if _, ok := msg.Data.(event.P2PNoPeers); ok {
+					nh.forceReconnectAll()
+				}
+			}
+		}
+	}()
+	logger.Sugar.Info("P2PNoPeers event listener started")
+}
+
+// forceReconnectAll marks all peers as disconnected and triggers immediate reconnection
+func (nh *NetworkHandler) forceReconnectAll() {
+	nh.peersMu.Lock()
+	for _, peer := range nh.peers {
+		if peer.State == StateConnected {
+			peer.State = StateDisconnected
+			peer.ConnectedAt = time.Time{}
+			peer.LastError = fmt.Errorf("P2P mesh lost - no active peers")
+		}
+	}
+	nh.peersMu.Unlock()
+	nh.reconnectDisconnectedPeers()
+}
+
+// checkPeerHealth verifies that peers we think are connected are still connected
+func (nh *NetworkHandler) checkPeerHealth() {
+	if nh.node == nil || nh.node.DB == nil {
+		return
+	}
+
+	peers, err := nh.node.DB.ActivePeers(nh.ctx)
+	if err != nil {
+		logger.Sugar.Debugf("Failed to get peer info from DefraDB: %v", err)
+		return
+	}
+
+	connectedPeers := make(map[string]bool)
+	for _, peerAddr := range peers {
+		connectedPeers[peerAddr] = true
+		if peerID := extractPeerID(peerAddr); peerID != "" {
+			connectedPeers[peerID] = true
+		}
+	}
+
+	nh.peersMu.Lock()
+	defer nh.peersMu.Unlock()
+
+	for addr, peer := range nh.peers {
+		if peer.State != StateConnected {
+			continue
+		}
+
+		stillConnected := false
+		if connectedPeers[addr] {
+			stillConnected = true
+		} else {
+			trackedPeerID := extractPeerID(addr)
+			if trackedPeerID != "" && connectedPeers[trackedPeerID] {
+				stillConnected = true
+			}
+		}
+
+		if !stillConnected {
+			peer.State = StateDisconnected
+			peer.ConnectedAt = time.Time{}
+			peer.LastError = fmt.Errorf("peer disconnected: no longer in active peer list")
+		}
+	}
+}
+
+// extractPeerID extracts the peer ID from a multiaddr string
+func extractPeerID(multiaddr string) string {
+	const p2pPrefix = "/p2p/"
+	for i := len(multiaddr) - len(p2pPrefix); i >= 0; i-- {
+		if multiaddr[i:i+len(p2pPrefix)] == p2pPrefix {
+			return multiaddr[i+len(p2pPrefix):]
+		}
+	}
+	return ""
+}
+
+// reconnectDisconnectedPeers attempts to reconnect to all disconnected or failed peers
+func (nh *NetworkHandler) reconnectDisconnectedPeers() {
+	nh.peersMu.RLock()
+	disconnectedPeers := []string{}
+	for addr, state := range nh.peers {
+		if state.State == StateDisconnected || state.State == StateFailed {
+			disconnectedPeers = append(disconnectedPeers, addr)
+		}
+	}
+	nh.peersMu.RUnlock()
+	if len(disconnectedPeers) == 0 {
+		return
+	}
+	logger.Sugar.Debugf("Attempting to reconnect to %d disconnected peers", len(disconnectedPeers))
+	for _, peerAddr := range disconnectedPeers {
+		nh.wg.Add(1)
+		go func(addr string) {
+			defer nh.wg.Done()
+			nh.attemptReconnect(addr)
+		}(peerAddr)
+	}
+}
+
+// attemptReconnect attempts to reconnect to a single peer
+func (nh *NetworkHandler) attemptReconnect(peerAddr string) {
+	nh.peersMu.Lock()
+	defer nh.peersMu.Unlock()
+	peer, exists := nh.peers[peerAddr]
+	if !exists {
+		return
+	}
+	if peer.State == StateConnected || peer.State == StateConnecting || peer.State == StateReconnecting {
+		return
+	}
+	peer.State = StateReconnecting
+	if err := nh.connectWithRetryLocked(peerAddr); err != nil {
+		logger.Sugar.Warnf("Reconnection to peer %s failed: %v", peerAddr, err)
+	}
+}
+
+// AddPeer adds a new peer at runtime
+func (nh *NetworkHandler) AddPeer(peerAddr string) error {
+	nh.peersMu.Lock()
+	defer nh.peersMu.Unlock()
+	if _, exists := nh.peers[peerAddr]; exists {
+		return fmt.Errorf("peer already exists: %s", peerAddr)
+	}
+	nh.peers[peerAddr] = &PeerState{
+		Address: peerAddr,
+		State:   StateDisconnected,
+	}
+	logger.Sugar.Infof("Added new peer: %s", peerAddr)
+	if nh.networkActive {
+		nh.wg.Add(1)
+		go func() {
+			defer nh.wg.Done()
+			nh.attemptReconnect(peerAddr)
+		}()
+	}
+	return nil
+}
+
+// RemovePeer removes a peer from the handler
+func (nh *NetworkHandler) RemovePeer(peerAddr string) error {
+	nh.peersMu.Lock()
+	defer nh.peersMu.Unlock()
+	if _, exists := nh.peers[peerAddr]; !exists {
+		return fmt.Errorf("peer not found: %s", peerAddr)
+	}
+	delete(nh.peers, peerAddr)
+	logger.Sugar.Infof("Removed peer: %s", peerAddr)
+	return nil
+}
+
+// GetPeers returns a copy of all peer states
+func (nh *NetworkHandler) GetPeers() map[string]PeerState {
+	nh.peersMu.RLock()
+	defer nh.peersMu.RUnlock()
+	result := make(map[string]PeerState)
+	for k, v := range nh.peers {
+		result[k] = v.Copy()
+	}
+	return result
+}
+
+// GetConnectedPeers returns a list of connected peer addresses
+func (nh *NetworkHandler) GetConnectedPeers() []string {
+	nh.peersMu.RLock()
+	defer nh.peersMu.RUnlock()
+	connected := []string{}
+	for addr, state := range nh.peers {
+		if state.State == StateConnected {
+			connected = append(connected, addr)
+		}
+	}
+	return connected
+}
+
+// GetPeerState returns the state of a specific peer
+func (nh *NetworkHandler) GetPeerState(peerAddr string) (PeerState, bool) {
+	nh.peersMu.RLock()
+	defer nh.peersMu.RUnlock()
+	if peer, exists := nh.peers[peerAddr]; exists {
+		return peer.Copy(), true
+	}
+	return PeerState{}, false
+}
+
+// GetConnectionStats returns connection statistics
+func (nh *NetworkHandler) GetConnectionStats() ConnectionStats {
+	nh.peersMu.RLock()
+	defer nh.peersMu.RUnlock()
+	stats := ConnectionStats{
+		TotalPeers:    len(nh.peers),
+		NetworkActive: nh.networkActive,
+		HostRunning:   nh.hostRunning,
+	}
+	for _, peer := range nh.peers {
+		switch peer.State {
+		case StateConnected:
+			stats.ConnectedPeers++
+		case StateConnecting, StateReconnecting:
+			stats.ConnectingPeers++
+		case StateFailed:
+			stats.FailedPeers++
+		case StateDisconnected:
+			stats.DisconnectedPeers++
+		}
+	}
+	return stats
+}
+
+// ConnectionStats provides summary statistics about peer connections
+type ConnectionStats struct {
+	TotalPeers        int  `json:"total_peers"`
+	ConnectedPeers    int  `json:"connected_peers"`
+	ConnectingPeers   int  `json:"connecting_peers"`
+	DisconnectedPeers int  `json:"disconnected_peers"`
+	FailedPeers       int  `json:"failed_peers"`
+	NetworkActive     bool `json:"network_active"`
+	HostRunning       bool `json:"host_running"`
+}

--- a/pkg/defradb/network_state.go
+++ b/pkg/defradb/network_state.go
@@ -1,0 +1,71 @@
+package defradb
+
+import (
+	"time"
+)
+
+// ConnectionState represents the current state of a peer connection
+type ConnectionState int
+
+const (
+	// StateDisconnected: Not connected to the peer
+	StateDisconnected ConnectionState = iota
+	// StateConnecting: Attempting to establish connection
+	StateConnecting
+	// StateConnected: Successfully connected to the peer
+	StateConnected
+	// StateReconnecting: Lost connection, attempting to reconnect
+	StateReconnecting
+	// StateFailed: Connection failed after max retries
+	StateFailed
+)
+
+// String returns a human-readable representation of the connection state
+func (s ConnectionState) String() string {
+	switch s {
+	case StateDisconnected:
+		return "DISCONNECTED"
+	case StateConnecting:
+		return "CONNECTING"
+	case StateConnected:
+		return "CONNECTED"
+	case StateReconnecting:
+		return "RECONNECTING"
+	case StateFailed:
+		return "FAILED"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// PeerState tracks the connection state of an individual peer
+type PeerState struct {
+	Address     string          // Peer address in multiaddr format
+	State       ConnectionState // Current connection state
+	LastAttempt time.Time       // Time of last connection attempt
+	RetryCount  int             // Number of retry attempts
+	LastError   error           // Last error encountered during connection
+	ConnectedAt time.Time       // Time when connection was established (zero if not connected)
+}
+
+// IsConnected returns true if the peer is currently connected
+func (p *PeerState) IsConnected() bool {
+	return p.State == StateConnected
+}
+
+// IsReachable returns true if the peer can potentially be reached
+func (p *PeerState) IsReachable() bool {
+	return p.State != StateFailed
+}
+
+// Copy returns a copy of the PeerState
+func (p *PeerState) Copy() PeerState {
+	return PeerState{
+		Address:     p.Address,
+		State:       p.State,
+		LastAttempt: p.LastAttempt,
+		RetryCount:  p.RetryCount,
+		LastError:   p.LastError,
+		ConnectedAt: p.ConnectedAt,
+	}
+}

--- a/pkg/defradb/peers.go
+++ b/pkg/defradb/peers.go
@@ -1,0 +1,70 @@
+package defradb
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/node"
+)
+
+func BootstrapIntoPeers(configuredBootstrapPeers []string) ([]client.PeerInfo, []error) {
+	peers := []client.PeerInfo{}
+	errors := []error{}
+
+	for i, peer := range configuredBootstrapPeers {
+		parts := strings.Split(peer, "/p2p/")
+		if len(parts) != 2 {
+			errors = append(errors, fmt.Errorf("peer at index %d is invalid and will be skipped. Given: %v", i, configuredBootstrapPeers))
+			continue
+		}
+		address := parts[0]
+		peerID := parts[1]
+
+		peerInfo := client.PeerInfo{
+			Addresses: []string{address},
+			ID:        peerID,
+		}
+		peers = append(peers, peerInfo)
+	}
+
+	return peers, errors
+}
+
+func PeersIntoBootstrap(peers []client.PeerInfo) ([]string, []error) {
+	bootstrapPeers := []string{}
+	errors := []error{}
+
+	for i, peer := range peers {
+		if peer.ID == "" {
+			errors = append(errors, fmt.Errorf("peer at index %d has empty ID and will be skipped", i))
+			continue
+		}
+
+		if len(peer.Addresses) == 0 {
+			errors = append(errors, fmt.Errorf("peer at index %d has no addresses and will be skipped", i))
+			continue
+		}
+
+		// Use the first address if multiple addresses are provided
+		address := peer.Addresses[0]
+		bootstrapPeer := fmt.Sprintf("%s/p2p/%s", address, peer.ID)
+		bootstrapPeers = append(bootstrapPeers, bootstrapPeer)
+	}
+
+	return bootstrapPeers, errors
+}
+
+func connectToPeers(ctx context.Context, defraNode *node.Node, peers []string) error {
+	if len(peers) == 0 {
+		return nil
+	}
+
+	err := defraNode.DB.Connect(ctx, peers)
+	if err != nil {
+		return fmt.Errorf("error connecting to peer: %v", err)
+	}
+
+	return nil
+}

--- a/pkg/defradb/query.go
+++ b/pkg/defradb/query.go
@@ -1,0 +1,236 @@
+package defradb
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/sourcenetwork/defradb/node"
+)
+
+// queryClient provides a clean interface for executing GraphQL queries against DefraDB using the direct client
+type queryClient struct {
+	defraNode *node.Node
+}
+
+// newQueryClient creates a new GraphQL query client using the Defra node directly
+func newQueryClient(defraNode *node.Node) (*queryClient, error) {
+	if defraNode == nil {
+		return nil, fmt.Errorf("defraNode parameter cannot be nil")
+	}
+
+	return &queryClient{
+		defraNode: defraNode,
+	}, nil
+}
+
+// query executes a GraphQL query using the Defra client directly and returns the raw result
+func (c *queryClient) query(ctx context.Context, query string) (interface{}, error) {
+	if query == "" {
+		return nil, fmt.Errorf("query parameter is empty")
+	}
+
+	result := c.defraNode.DB.ExecRequest(ctx, query)
+	gqlResult := result.GQL
+
+	if len(gqlResult.Errors) > 0 {
+		return nil, fmt.Errorf("graphql errors: %v", gqlResult.Errors)
+	}
+
+	return gqlResult.Data, nil
+}
+
+// queryAndUnmarshal executes a GraphQL query and unmarshals the result into the provided interface
+func (c *queryClient) queryAndUnmarshal(ctx context.Context, query string, result interface{}) error {
+	data, err := c.query(ctx, query)
+	if err != nil {
+		return err
+	}
+
+	// Convert the data to JSON and then unmarshal into the result
+	dataBytes, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("failed to marshal data: %w", err)
+	}
+
+	return json.Unmarshal(dataBytes, result)
+}
+
+// getDataField extracts the data from a GraphQL response
+// For the Defra client, the data is returned directly, not wrapped in a "data" field
+func (c *queryClient) getDataField(ctx context.Context, query string) (map[string]interface{}, error) {
+	data, err := c.query(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute query: %w", err)
+	}
+
+	dataMap, ok := data.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("unexpected data format: %T", data)
+	}
+
+	return dataMap, nil
+}
+
+// queryInto executes a GraphQL query and unmarshals the result into a struct of the specified type
+func (c *queryClient) queryInto(ctx context.Context, query string, result interface{}) error {
+	data, err := c.query(ctx, query)
+	if err != nil {
+		return err
+	}
+
+	// Convert the data to JSON and then unmarshal into the result
+	dataBytes, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("failed to marshal data: %w", err)
+	}
+
+	return json.Unmarshal(dataBytes, result)
+}
+
+// queryDataInto executes a GraphQL query and unmarshals only the "data" field into a struct
+// This function handles both single objects and arrays in the response
+func (c *queryClient) queryDataInto(ctx context.Context, query string, result interface{}) error {
+	data, err := c.query(ctx, query)
+	if err != nil {
+		return fmt.Errorf("failed to execute query: %w", err)
+	}
+
+	// Check if result is expecting a slice (array) or single object
+	resultValue := reflect.ValueOf(result)
+	if resultValue.Kind() != reflect.Ptr {
+		return fmt.Errorf("result must be a pointer")
+	}
+
+	resultElem := resultValue.Elem()
+
+	// If result is a slice, find the first array in data and unmarshal it
+	if resultElem.Kind() == reflect.Slice {
+		if dataMap, ok := data.(map[string]interface{}); ok {
+			for _, value := range dataMap {
+				// Try different array types
+				if array, ok := value.([]interface{}); ok {
+					// Convert the array to JSON and unmarshal into result
+					arrayBytes, err := json.Marshal(array)
+					if err != nil {
+						return fmt.Errorf("failed to marshal array: %w", err)
+					}
+					return json.Unmarshal(arrayBytes, result)
+				}
+
+				// Try []map[string]interface{} type
+				if array, ok := value.([]map[string]interface{}); ok {
+					// Convert the array to JSON and unmarshal into result
+					arrayBytes, err := json.Marshal(array)
+					if err != nil {
+						return fmt.Errorf("failed to marshal array: %w", err)
+					}
+					return json.Unmarshal(arrayBytes, result)
+				}
+			}
+		}
+		// Fallback: try to unmarshal the entire data object
+		dataBytes, err := json.Marshal(data)
+		if err != nil {
+			return fmt.Errorf("failed to marshal data: %w", err)
+		}
+		return json.Unmarshal(dataBytes, result)
+	}
+
+	// If result is a single struct, find the first array in data and get its first element
+	if dataMap, ok := data.(map[string]interface{}); ok {
+		for _, value := range dataMap {
+			// Try different array types
+			if array, ok := value.([]interface{}); ok && len(array) > 0 {
+				// Convert the first element to JSON and unmarshal into result
+				firstElementBytes, err := json.Marshal(array[0])
+				if err != nil {
+					return fmt.Errorf("failed to marshal first element: %w", err)
+				}
+				return json.Unmarshal(firstElementBytes, result)
+			}
+
+			// Try []map[string]interface{} type
+			if array, ok := value.([]map[string]interface{}); ok && len(array) > 0 {
+				// Convert the first element to JSON and unmarshal into result
+				firstElementBytes, err := json.Marshal(array[0])
+				if err != nil {
+					return fmt.Errorf("failed to marshal first element: %w", err)
+				}
+				return json.Unmarshal(firstElementBytes, result)
+			}
+		}
+	}
+
+	// Fallback: try to unmarshal the entire data object
+	dataBytes, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("failed to marshal data: %w", err)
+	}
+	return json.Unmarshal(dataBytes, result)
+}
+
+// wrapQueryIfNeeded automatically wraps a query with "query { }" if it doesn't already start with "query", "mutation", or "subscription"
+func wrapQueryIfNeeded(query string) string {
+	// Trim whitespace to check the actual start
+	trimmed := strings.TrimSpace(query)
+
+	// Check if query already starts with GraphQL operation keywords (case insensitive)
+	lowerTrimmed := strings.ToLower(trimmed)
+
+	if strings.HasPrefix(lowerTrimmed, "query ") || lowerTrimmed == "query" {
+		return query // Return original query as-is
+	}
+
+	if strings.HasPrefix(lowerTrimmed, "mutation ") || lowerTrimmed == "mutation" {
+		return query // Return original query as-is
+	}
+
+	if strings.HasPrefix(lowerTrimmed, "subscription ") || lowerTrimmed == "subscription" {
+		return query // Return original query as-is
+	}
+
+	// Check if query is already wrapped in curly braces but doesn't start with a keyword
+	// This handles cases like "{ Block { __typename } }" which should be wrapped as "query { Block { __typename } }"
+	if len(trimmed) >= 2 && trimmed[0] == '{' && trimmed[len(trimmed)-1] == '}' {
+		// Extract the content inside the braces
+		innerContent := strings.TrimSpace(trimmed[1 : len(trimmed)-1])
+		// Wrap with "query" keyword
+		return fmt.Sprintf("query { %s }", innerContent)
+	}
+
+	// Wrap the query with "query { }"
+	return fmt.Sprintf("query { %s }", strings.TrimSpace(query))
+}
+
+// QuerySingle executes a GraphQL query and returns a single item of the specified type
+// This is useful when you expect a single object back (not an array)
+func QuerySingle[T any](ctx context.Context, defraNode *node.Node, query string) (T, error) {
+	var result T
+	client, err := newQueryClient(defraNode)
+	if err != nil {
+		return result, err
+	}
+
+	// Auto-wrap query if it doesn't start with "query"
+	wrappedQuery := wrapQueryIfNeeded(query)
+	err = client.queryDataInto(ctx, wrappedQuery, &result)
+	return result, err
+}
+
+// QueryArray executes a GraphQL query and returns an array of the specified type
+// This is useful when you expect an array of objects back
+func QueryArray[T any](ctx context.Context, defraNode *node.Node, query string) ([]T, error) {
+	var result []T
+	client, err := newQueryClient(defraNode)
+	if err != nil {
+		return result, err
+	}
+
+	// Auto-wrap query if it doesn't start with "query"
+	wrappedQuery := wrapQueryIfNeeded(query)
+	err = client.queryDataInto(ctx, wrappedQuery, &result)
+	return result, err
+}

--- a/pkg/defradb/schema.go
+++ b/pkg/defradb/schema.go
@@ -1,0 +1,38 @@
+package defradb
+
+import (
+	"context"
+
+	"github.com/sourcenetwork/defradb/node"
+)
+
+// SchemaApplier is implemented by types that know how to install a GraphQL
+// schema on a freshly-started DefraDB node. StartDefraInstance invokes
+// ApplySchema once during boot, after the node has started.
+type SchemaApplier interface {
+	ApplySchema(ctx context.Context, defraNode *node.Node) error
+}
+
+// MockSchemaApplierThatSucceeds is a test helper that satisfies SchemaApplier
+// without touching the database. Use it in tests that don't care about schema.
+type MockSchemaApplierThatSucceeds struct{}
+
+func (schema *MockSchemaApplierThatSucceeds) ApplySchema(ctx context.Context, defraNode *node.Node) error {
+	return nil
+}
+
+// SchemaApplierFromProvidedSchema applies a schema string supplied by the caller.
+type SchemaApplierFromProvidedSchema struct {
+	ProvidedSchema string
+}
+
+func NewSchemaApplierFromProvidedSchema(schema string) *SchemaApplierFromProvidedSchema {
+	return &SchemaApplierFromProvidedSchema{
+		ProvidedSchema: schema,
+	}
+}
+
+func (schema *SchemaApplierFromProvidedSchema) ApplySchema(ctx context.Context, defraNode *node.Node) error {
+	_, err := defraNode.DB.AddSchema(ctx, string(schema.ProvidedSchema))
+	return err
+}

--- a/pkg/defradb/writer.go
+++ b/pkg/defradb/writer.go
@@ -1,0 +1,77 @@
+package defradb
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/sourcenetwork/defradb/node"
+)
+
+func PostMutation[T any](ctx context.Context, defraNode *node.Node, query string) (*T, error) {
+	if !strings.Contains(query, "mutation") {
+		return nil, fmt.Errorf("Query must be a mutation, given: %s", query)
+	}
+
+	result := defraNode.DB.ExecRequest(ctx, query)
+	gqlResult := result.GQL
+	if gqlResult.Data == nil {
+		return nil, fmt.Errorf("Encountered errors posting mutation: %v", gqlResult.Errors)
+	}
+
+	if len(gqlResult.Errors) > 0 {
+		err := fmt.Errorf("Error posting mutation %s", query)
+		for _, gqlError := range gqlResult.Errors {
+			err = fmt.Errorf("%w: %w", err, gqlError)
+		}
+		return nil, err
+	}
+
+	// The GraphQL response data is a map[string]interface{} containing the mutation result
+	// We need to find the first array in the data and extract the first element
+	data, ok := gqlResult.Data.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("unexpected data format: %T", gqlResult.Data)
+	}
+
+	// Find the first array in the data (mutation results are typically arrays)
+	for _, value := range data {
+
+		// Try different array types
+		if array, ok := value.([]interface{}); ok && len(array) > 0 {
+			// Convert the first element to JSON and unmarshal into result
+			firstElementBytes, err := json.Marshal(array[0])
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal first element: %w", err)
+			}
+
+			var result T
+			err = json.Unmarshal(firstElementBytes, &result)
+			if err != nil {
+				return nil, fmt.Errorf("failed to unmarshal result: %w", err)
+			}
+
+			return &result, nil
+		}
+
+		// Try []map[string]interface{} type
+		if array, ok := value.([]map[string]interface{}); ok && len(array) > 0 {
+			// Convert the first element to JSON and unmarshal into result
+			firstElementBytes, err := json.Marshal(array[0])
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal first element: %w", err)
+			}
+
+			var result T
+			err = json.Unmarshal(firstElementBytes, &result)
+			if err != nil {
+				return nil, fmt.Errorf("failed to unmarshal result: %w", err)
+			}
+
+			return &result, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no array data found in mutation result")
+}

--- a/pkg/host/DocumentProvenanceService_test.go
+++ b/pkg/host/DocumentProvenanceService_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/logger"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
 	"github.com/stretchr/testify/require"
 )
 

--- a/pkg/host/attestationHandler.go
+++ b/pkg/host/attestationHandler.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/logger"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
 	attestationService "github.com/shinzonetwork/shinzo-host-client/pkg/attestation"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/constants"
 	"github.com/sourcenetwork/defradb/client"

--- a/pkg/host/attestationHandler_test.go
+++ b/pkg/host/attestationHandler_test.go
@@ -13,8 +13,8 @@ import (
 
 	gocid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/defra"
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/logger"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/defradb"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
 	"github.com/shinzonetwork/shinzo-host-client/config"
 	attestationService "github.com/shinzonetwork/shinzo-host-client/pkg/attestation"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/constants"
@@ -553,7 +553,7 @@ func TestRetryableErrorDetection(t *testing.T) {
 func TestInitKnownCollectionIDs_WithRealDefraDB(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -595,7 +595,7 @@ func TestInitKnownCollectionIDs_NilDB(t *testing.T) {
 func TestStartEventBusListener_WithRealDefraDB_WritesDoc(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -646,7 +646,7 @@ func TestStartEventBusListener_WithRealDefraDB_WritesDoc(t *testing.T) {
 func TestStartEventBusListener_WithRealDefraDB(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -681,7 +681,7 @@ func TestStartEventBusListener_WithRealDefraDB(t *testing.T) {
 func TestProcessBlockSignatureFromEventBus_WithRealDefraDB_InvalidDocID(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -696,7 +696,7 @@ func TestProcessBlockSignatureFromEventBus_WithRealDefraDB_InvalidDocID(t *testi
 func TestProcessBlockSignatureFromEventBus_WithRealDefraDB_NonExistentDoc(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -715,7 +715,7 @@ func TestProcessBlockSignatureFromEventBus_WithRealDefraDB_NonExistentDoc(t *tes
 func TestProcessBlockSignatureDocument_WithRealDefraDB(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -768,7 +768,7 @@ func TestProcessBlockSignatureDocument_WithRealDefraDB(t *testing.T) {
 func TestProcessBlockSignatureDocument_WithVerifier(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -822,7 +822,7 @@ func TestProcessBlockSignatureDocument_WithVerifier(t *testing.T) {
 func TestProcessDocumentAttestationBatch_WithVersionData(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -928,7 +928,7 @@ func TestProcessDocumentAttestationBatch_MultipleDocsWithMixedVersionData(t *tes
 func TestProcessAttestationsFromBlockSignature_WithRealDefraDB(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -966,7 +966,7 @@ func TestProcessAttestationsFromBlockSignature_WithRealDefraDB(t *testing.T) {
 func TestProcessAttestationsFromBlockSignature_WithRealDefraDB_NoCIDs(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -996,7 +996,7 @@ func TestProcessAttestationsFromBlockSignature_WithRealDefraDB_NoCIDs(t *testing
 func TestProcessBlockSignatureDocument_WithCIDs(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -1044,7 +1044,7 @@ func TestProcessBlockSignatureDocument_WithCIDs(t *testing.T) {
 func TestProcessBlockSignatureDocument_ZeroBlockNumber(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -1083,7 +1083,7 @@ func TestProcessBlockSignatureDocument_ZeroBlockNumber(t *testing.T) {
 func TestProcessBlockSignatureDocument_EmptyMerkleRoot(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -1126,7 +1126,7 @@ func makeTestCID(data string) string {
 func TestProcessBlockSignatureDocument_WithValidSignatureAndCIDs(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -1206,7 +1206,7 @@ func TestProcessBlockSignatureDocument_WithValidSignatureAndCIDs(t *testing.T) {
 func TestProcessBlockSignatureFromEventBus_WithRealDefraDB_FullPath(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -1248,7 +1248,7 @@ func TestProcessBlockSignatureFromEventBus_WithRealDefraDB_FullPath(t *testing.T
 func TestProcessAttestationsFromBlockSignature_ExistedPath(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -1287,7 +1287,7 @@ func TestProcessAttestationsFromBlockSignature_ExistedPath(t *testing.T) {
 func TestProcessAttestationsFromBlockSignature_MultipleIndexers_PreservesBothIdentities(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -1337,7 +1337,7 @@ func TestProcessAttestationsFromBlockSignature_MultipleIndexers_PreservesBothIde
 func TestProcessBlockSignatureDocument_ValidSigCIDMismatch(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -1412,7 +1412,7 @@ func TestProcessBlockSignatureDocument_ValidSigCIDMismatch(t *testing.T) {
 func TestProcessBlockSignatureFromEventBus_ContextCancelledDuringRetry(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -1435,7 +1435,7 @@ func TestProcessBlockSignatureFromEventBus_ContextCancelledDuringRetry(t *testin
 func TestStartEventBusListener_WithMetricsAndCollections(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 

--- a/pkg/host/host.go
+++ b/pkg/host/host.go
@@ -15,10 +15,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/defra"
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/logger"
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/pruner"
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/signer"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/defradb"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/pruner"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/signer"
 	"github.com/shinzonetwork/shinzo-host-client/config"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/attestation"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/constants"
@@ -89,7 +89,7 @@ var DefaultConfig *config.Config = func() *config.Config {
 
 type Host struct {
 	DefraNode      *node.Node
-	NetworkHandler *defra.NetworkHandler // P2P network control
+	NetworkHandler *defradb.NetworkHandler // P2P network control
 
 	// signature verifier as a service
 	signatureVerifier      *attestation.DefraSignatureVerifier // Cached signature verifier for attestation processing
@@ -139,9 +139,9 @@ func StartHostingWithEventSubscription(cfg *config.Config) (*Host, error) {
 		replicationFilter = f
 	}
 
-	defraNode, networkHandler, err := defra.StartDefraInstance(
-		cfg.ToAppConfig(),
-		defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()),
+	defraNode, networkHandler, err := defradb.StartDefraInstance(
+		cfg.ToInternalConfig(),
+		defradb.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()),
 		nil,
 		replicationFilter,
 		constants.AllCollections...,
@@ -485,7 +485,7 @@ func (h *Host) GetPeerInfo() (*server.P2PInfo, error) {
 		logger.Sugar.Warnf("Failed to get peer info from DefraDB: %v", err)
 		return p2pInfo, nil
 	}
-	ownPeers, _ := defra.BootstrapIntoPeers(ownAddresses)
+	ownPeers, _ := defradb.BootstrapIntoPeers(ownAddresses)
 
 	if len(ownPeers) > 0 {
 		var addresses []string
@@ -503,7 +503,7 @@ func (h *Host) GetPeerInfo() (*server.P2PInfo, error) {
 	if err != nil {
 		activePeerStrings = nil // P2P not ready, treat as no peers
 	}
-	activePeers, _ := defra.BootstrapIntoPeers(activePeerStrings)
+	activePeers, _ := defradb.BootstrapIntoPeers(activePeerStrings)
 
 	// Deduplicate peers by ID and merge addresses
 	peerMap := make(map[string]*server.PeerInfo)
@@ -526,13 +526,13 @@ func (h *Host) GetPeerInfo() (*server.P2PInfo, error) {
 
 func (h *Host) SignMessages(message string) (server.DefraPKRegistration, server.PeerIDRegistration, error) {
 	// Use the signer package approach like the indexer
-	signedMsg, err := signer.SignWithDefraKeys(message, h.DefraNode, h.config.ToAppConfig())
+	signedMsg, err := signer.SignWithDefraKeys(message, h.DefraNode, h.config.ToInternalConfig())
 	if err != nil {
 		return server.DefraPKRegistration{}, server.PeerIDRegistration{}, err
 	}
 
 	// Sign with peer ID
-	peerSignedMsg, err := signer.SignWithP2PKeys(message, h.DefraNode, h.config.ToAppConfig())
+	peerSignedMsg, err := signer.SignWithP2PKeys(message, h.DefraNode, h.config.ToInternalConfig())
 	if err != nil {
 		return server.DefraPKRegistration{}, server.PeerIDRegistration{}, err
 	}
@@ -558,11 +558,11 @@ func (h *Host) SignMessages(message string) (server.DefraPKRegistration, server.
 }
 
 func (h *Host) GetNodePublicKey() (string, error) {
-	return signer.GetDefraPublicKey(h.DefraNode, h.config.ToAppConfig())
+	return signer.GetDefraPublicKey(h.DefraNode, h.config.ToInternalConfig())
 }
 
 func (h *Host) GetPeerPublicKey() (string, error) {
-	return signer.GetP2PPublicKey(h.DefraNode, h.config.ToAppConfig())
+	return signer.GetP2PPublicKey(h.DefraNode, h.config.ToInternalConfig())
 }
 
 func incrementPort(apiURL string) (string, error) {
@@ -636,7 +636,9 @@ func (h *Host) GetMetricsHandler() http.Handler {
 	return h.metrics
 }
 
-// waitForDefraDB waits for a DefraDB instance to be ready by using app-sdk's QuerySingle
+// waitForDefraDB polls the embedded DefraDB node until a trivial schema query
+// succeeds. Returns an error after maxAttempts seconds if the node never
+// responds, e.g. because schema setup failed upstream.
 func waitForDefraDB(ctx context.Context, defraNode *node.Node) error {
 	fmt.Println("Waiting for defra...")
 	maxAttempts := 30
@@ -645,7 +647,7 @@ func waitForDefraDB(ctx context.Context, defraNode *node.Node) error {
 	query := `{ ` + constants.CollectionBlock + ` { __typename } }`
 
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		_, err := defra.QuerySingle[map[string]interface{}](ctx, defraNode, query)
+		_, err := defradb.QuerySingle[map[string]interface{}](ctx, defraNode, query)
 		if err == nil {
 			fmt.Println("Defra is responsive!")
 			return nil

--- a/pkg/host/host_test.go
+++ b/pkg/host/host_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/defra"
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/logger"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/defradb"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
 	"github.com/shinzonetwork/shinzo-host-client/config"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/server"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/shinzohub"
@@ -145,7 +145,7 @@ func TestDefaultConfig(t *testing.T) {
 func TestHost_IsHealthy(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -169,7 +169,7 @@ func TestHost_IsHealthy_NoDefraNode(t *testing.T) {
 func TestHost_IsHealthy_NoPipeline(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -223,7 +223,7 @@ func TestHost_GetLastProcessedTime_NoMetrics(t *testing.T) {
 func TestHost_GetActiveViewNames(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -255,7 +255,7 @@ func TestHost_GetPeerInfo(t *testing.T) {
 func TestHost_Close(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 
 	cleanupCalled := false
@@ -292,7 +292,7 @@ func TestHost_WithRealDefraDB(t *testing.T) {
 	ctx := context.Background()
 
 	// Create a real DefraDB instance with the indexer schema
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(indexerschema.GetSchema()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(indexerschema.GetSchema()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -333,7 +333,7 @@ func TestHost_WithRealDefraDB(t *testing.T) {
 func TestHost_ViewManagerIntegration(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -388,7 +388,7 @@ func TestView_HasLenses_Integration(t *testing.T) {
 
 func TestHost_GetPeerInfo_NetworkHandlerNonNilDefraNodeNil(t *testing.T) {
 	host := &Host{
-		NetworkHandler: &defra.NetworkHandler{},
+		NetworkHandler: &defradb.NetworkHandler{},
 		DefraNode:      nil,
 	}
 
@@ -568,7 +568,7 @@ func TestHost_ProcessViewRegistrationEvent_NilViewManager_ReturnsError(t *testin
 func TestHost_ProcessViewRegistrationEvent_MissingQuery(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -589,7 +589,7 @@ func TestHost_ProcessViewRegistrationEvent_MissingQuery(t *testing.T) {
 func TestHost_ProcessViewRegistrationEvent_MissingSDL(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -615,7 +615,7 @@ func TestHost_ProcessViewRegistrationEvent_MissingSDL(t *testing.T) {
 func TestHost_ProcessViewRegistrationEvent_EmptyQuery(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -641,7 +641,7 @@ func TestHost_ProcessViewRegistrationEvent_EmptyQuery(t *testing.T) {
 func TestHost_ProcessViewRegistrationEvent_EmptySDL(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -1014,11 +1014,11 @@ func TestHost_GetPeerPublicKey_NilDefraNode(t *testing.T) {
 func TestHost_GetPeerInfo_WithDefraDB(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
-	nh := &defra.NetworkHandler{}
+	nh := &defradb.NetworkHandler{}
 	h := &Host{
 		DefraNode:      defraNode,
 		NetworkHandler: nh,
@@ -1037,7 +1037,7 @@ func TestHost_GetPeerInfo_WithDefraDB(t *testing.T) {
 func TestHost_ProcessViewRegistrationEvent_WithLenses(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -1079,7 +1079,7 @@ func TestHost_ProcessViewRegistrationEvent_WithLenses(t *testing.T) {
 func TestHost_ProcessViewRegistrationEvent_WithViewManager(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -1119,7 +1119,7 @@ func TestHost_ProcessViewRegistrationEvent_WithViewManager(t *testing.T) {
 func TestHost_RegisterViewWithManager_WithViewManager(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -1150,7 +1150,7 @@ func TestHost_RegisterViewWithManager_WithViewManager(t *testing.T) {
 func TestHost_Close_WithViewManager(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 
 	vm := view.NewViewManager(defraNode, t.TempDir())
@@ -1208,11 +1208,11 @@ func TestHost_GetPeerInfo_WithP2PEnabled(t *testing.T) {
 	ctx := context.Background()
 
 	// Start a DefraDB instance that includes P2P
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(indexerschema.GetSchema()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(indexerschema.GetSchema()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
-	nh := &defra.NetworkHandler{}
+	nh := &defradb.NetworkHandler{}
 	h := &Host{
 		DefraNode:      defraNode,
 		NetworkHandler: nh,
@@ -1234,7 +1234,7 @@ func TestHost_GetPeerInfo_WithP2PEnabled(t *testing.T) {
 func TestHost_SignMessages_WithRealDefraDB(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(indexerschema.GetSchema()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(indexerschema.GetSchema()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -1262,7 +1262,7 @@ func TestHost_SignMessages_WithRealDefraDB(t *testing.T) {
 func TestHost_GetNodePublicKey_WithRealDefraDB(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(indexerschema.GetSchema()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(indexerschema.GetSchema()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -1283,7 +1283,7 @@ func TestHost_GetNodePublicKey_WithRealDefraDB(t *testing.T) {
 func TestHost_GetPeerPublicKey_WithRealDefraDB(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(indexerschema.GetSchema()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(indexerschema.GetSchema()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -1307,7 +1307,7 @@ func TestHost_GetPeerPublicKey_WithRealDefraDB(t *testing.T) {
 
 func TestHandleIncomingEvents_HostRegisteredEvent_WithoutNetworkHandler(t *testing.T) {
 	// NetworkHandler is nil — exercises the entity event parsing and nil-check branch
-	// (cannot use bare &defra.NetworkHandler{} because AddPeer panics on uninitialized maps)
+	// (cannot use bare &defradb.NetworkHandler{} because AddPeer panics on uninitialized maps)
 	h := &Host{}
 	ch := make(chan shinzohub.ShinzoEvent, 1)
 
@@ -1377,7 +1377,7 @@ func TestHandleIncomingEvents_UnknownEventType(t *testing.T) {
 func TestHandleIncomingEvents_ViewRegisteredEvent_WithLenses(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -1434,7 +1434,7 @@ func TestHandleIncomingEvents_ViewRegisteredEvent_WithLenses(t *testing.T) {
 func TestHandleIncomingEvents_ViewRegisteredEvent_WithViewManager(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -1488,7 +1488,7 @@ func TestApplySchema_WithRealDefraDB(t *testing.T) {
 	ctx := context.Background()
 
 	// Start with mock schema applier (no schema applied yet)
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -1508,7 +1508,7 @@ func TestApplySchema_WithRealDefraDB(t *testing.T) {
 func TestWaitForDefraDB_WithRealDefraDB(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -1595,7 +1595,7 @@ func TestStartHosting_NilConfig(t *testing.T) {
 func TestHandleIncomingEvents_ViewRegisteredEvent_WithBase64Lens(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -1656,7 +1656,7 @@ func TestHandleIncomingEvents_ViewRegisteredEvent_WithBase64Lens(t *testing.T) {
 func TestHandleIncomingEvents_ViewRegisteredEvent_NoLenses_WithViewManager(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -1706,7 +1706,7 @@ func TestHandleIncomingEvents_ViewRegisteredEvent_NoLenses_WithViewManager(t *te
 func TestHost_Close_Full(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
 
 	metrics := server.NewHostMetrics()

--- a/pkg/host/peer_discovery.go
+++ b/pkg/host/peer_discovery.go
@@ -13,7 +13,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/sec"
 	ma "github.com/multiformats/go-multiaddr"
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/logger"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
 )
 
 // DefaultPeerDiscoveryTimeout is the default timeout for discovering a peer's ID.

--- a/pkg/host/processingPipeline.go
+++ b/pkg/host/processingPipeline.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/logger"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
 )
 
 const (

--- a/pkg/host/processingPipeline_test.go
+++ b/pkg/host/processingPipeline_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/logger"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
 	attestationService "github.com/shinzonetwork/shinzo-host-client/pkg/attestation"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/server"
 	"github.com/stretchr/testify/require"

--- a/pkg/host/shinzohub_view_fetching_test.go
+++ b/pkg/host/shinzohub_view_fetching_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/defra"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/defradb"
 	"github.com/stretchr/testify/require"
 )
 
@@ -88,7 +88,7 @@ func TestHostIntegration_ShinzoHubViewFetching(t *testing.T) {
 		t.Logf("🔍 Executing known query for %s", viewName)
 		t.Logf("📄 Query: %s", query)
 		
-		results, err := defra.QueryArray[map[string]interface{}](ctx, h.DefraNode, query)
+		results, err := defradb.QueryArray[map[string]interface{}](ctx, h.DefraNode, query)
 		if err != nil {
 			t.Logf("⚠️ %s query error: %v", viewName, err)
 			continue

--- a/pkg/host/snapshot_bootstrap.go
+++ b/pkg/host/snapshot_bootstrap.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"sort"
 
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/logger"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
 	attestationService "github.com/shinzonetwork/shinzo-host-client/pkg/attestation"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/constants"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/snapshot"

--- a/pkg/host/snapshot_bootstrap_test.go
+++ b/pkg/host/snapshot_bootstrap_test.go
@@ -8,8 +8,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/defra"
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/logger"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/defradb"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
 	hostConfig "github.com/shinzonetwork/shinzo-host-client/config"
 	localschema "github.com/shinzonetwork/shinzo-host-client/pkg/schema"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/snapshot"
@@ -230,7 +230,7 @@ func TestBootstrapFromSnapshots_NoSnapshotsAvailable(t *testing.T) {
 	defer server.Close()
 
 	ctx := context.Background()
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -254,7 +254,7 @@ func TestBootstrapFromSnapshots_ListSnapshotsFails(t *testing.T) {
 	defer server.Close()
 
 	ctx := context.Background()
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -286,7 +286,7 @@ func TestBootstrapFromSnapshots_NoNeededSnapshots(t *testing.T) {
 	defer server.Close()
 
 	ctx := context.Background()
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -318,7 +318,7 @@ func TestBootstrapFromSnapshots_NilSignature(t *testing.T) {
 	defer server.Close()
 
 	ctx := context.Background()
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -362,7 +362,7 @@ func TestBootstrapFromSnapshots_DownloadFails(t *testing.T) {
 	defer server.Close()
 
 	ctx := context.Background()
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -385,7 +385,7 @@ func TestBootstrapFromSnapshots_DownloadFails(t *testing.T) {
 func TestGetExistingBlockRange_EmptyDB(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -401,7 +401,7 @@ func TestGetExistingBlockRange_EmptyDB(t *testing.T) {
 func TestCreateSnapshotAttestation_NoBlockSigMerkleRoots(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -419,7 +419,7 @@ func TestCreateSnapshotAttestation_NoBlockSigMerkleRoots(t *testing.T) {
 func TestCreateSnapshotAttestation_WithMerkleRoots(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -455,7 +455,7 @@ func TestCreateSnapshotAttestation_RecordFormat(t *testing.T) {
 func TestGetExistingBlockRange_WithBlocksInDB(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -482,7 +482,7 @@ func TestGetExistingBlockRange_WithBlocksInDB(t *testing.T) {
 func TestGetExistingBlockRange_SingleBlock(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -511,7 +511,7 @@ func TestGetExistingBlockRange_SingleBlock(t *testing.T) {
 func TestCreateSnapshotAttestation_SuccessVerifyRecord(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -577,7 +577,7 @@ func TestFindCoveringSnapshots_MixedSignedAndExisting(t *testing.T) {
 func TestCreateSnapshotAttestation_NilBlockSigMerkleRoots(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -625,7 +625,7 @@ func TestBootstrapFromSnapshots_DownloadSucceeds_ImportFails(t *testing.T) {
 	defer svr.Close()
 
 	ctx := context.Background()
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 

--- a/pkg/logger/zap.go
+++ b/pkg/logger/zap.go
@@ -1,0 +1,64 @@
+package logger
+
+import (
+	"os"
+	"path/filepath"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// Sugar is the package-level sugared logger. Call Init before first use; until
+// then it is nil and call sites will panic on dereference.
+var Sugar *zap.SugaredLogger
+
+// Init builds a tee'd zap logger that writes to stdout and, when logsDir is
+// writable, also to logsDir/logfile.log (all levels) and logsDir/errorfile.log
+// (error and above). Falls back to stdout-only when the directory or files
+// cannot be opened.
+func Init(development bool, logsDir string) {
+	var zapLevel zapcore.Level
+	if development {
+		zapLevel = zap.DebugLevel
+	} else {
+		zapLevel = zap.InfoLevel
+	}
+
+	encoderConfig := zap.NewDevelopmentEncoderConfig()
+	encoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
+
+	consoleWriter := zapcore.Lock(os.Stdout)
+
+	var cores []zapcore.Core
+
+	if err := os.MkdirAll(logsDir, 0755); err == nil {
+		logFile := filepath.Join(logsDir, "logfile.log")
+		errorFile := filepath.Join(logsDir, "errorfile.log")
+
+		if logFileWriter, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666); err == nil {
+			consoleCore := zapcore.NewCore(zapcore.NewConsoleEncoder(encoderConfig), consoleWriter, zapLevel)
+			cores = append(cores, consoleCore)
+
+			logFileCore := zapcore.NewCore(zapcore.NewConsoleEncoder(encoderConfig), zapcore.AddSync(logFileWriter), zapLevel)
+			cores = append(cores, logFileCore)
+
+			if errorFileWriter, err := os.OpenFile(errorFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666); err == nil {
+				errorCore := zapcore.NewCore(
+					zapcore.NewConsoleEncoder(encoderConfig),
+					zapcore.AddSync(errorFileWriter),
+					zapcore.ErrorLevel,
+				)
+				cores = append(cores, errorCore)
+			}
+		} else {
+			consoleCore := zapcore.NewCore(zapcore.NewConsoleEncoder(encoderConfig), consoleWriter, zapLevel)
+			cores = append(cores, consoleCore)
+		}
+	} else {
+		consoleCore := zapcore.NewCore(zapcore.NewConsoleEncoder(encoderConfig), consoleWriter, zapLevel)
+		cores = append(cores, consoleCore)
+	}
+
+	core := zapcore.NewTee(cores...)
+	Sugar = zap.New(core).Sugar()
+}

--- a/pkg/pruner/config.go
+++ b/pkg/pruner/config.go
@@ -1,0 +1,54 @@
+package pruner
+
+// Config represents pruner configuration for removing old documents.
+type Config struct {
+	Enabled         bool  `yaml:"enabled"`
+	MaxBlocks       int64 `yaml:"max_blocks"`      // Number of blocks to retain
+	DocsPerBlock    int   `yaml:"docs_per_block"`  // Average docs per block (~1057 on Ethereum mainnet)
+	PruneThreshold  int64 `yaml:"prune_threshold"` // Deprecated: kept for backward compatibility, unused by pruner
+	IntervalSeconds int   `yaml:"interval_seconds"`
+	PruneHistory    bool  `yaml:"prune_history"`
+}
+
+// CollectionConfig defines which collections to prune and how.
+type CollectionConfig struct {
+	// BlockCollection is the name of the block collection (e.g. "Ethereum__Mainnet__Block").
+	BlockCollection string
+	// BlockNumberField is the field name for block number in the block collection (e.g. "number").
+	BlockNumberField string
+	// DependentCollections are collections that reference blocks via "blockNumber" field,
+	// listed in deletion order (deleted before the block collection).
+	DependentCollections []string
+}
+
+// DefaultCollectionConfig returns the default Ethereum mainnet collection config.
+func DefaultCollectionConfig() CollectionConfig {
+	return CollectionConfig{
+		BlockCollection:  "Ethereum__Mainnet__Block",
+		BlockNumberField: "number",
+		DependentCollections: []string{
+			"Ethereum__Mainnet__BatchSignature",
+			"Ethereum__Mainnet__AccessListEntry",
+			"Ethereum__Mainnet__Log",
+			"Ethereum__Mainnet__Transaction",
+		},
+	}
+}
+
+// MaxDocs returns the effective maximum document count: max_blocks * docs_per_block.
+func (c *Config) MaxDocs() int64 {
+	return c.MaxBlocks * int64(c.DocsPerBlock)
+}
+
+// SetDefaults fills in zero-value fields with sensible defaults.
+func (c *Config) SetDefaults() {
+	if c.MaxBlocks <= 0 {
+		c.MaxBlocks = 10000
+	}
+	if c.DocsPerBlock <= 0 {
+		c.DocsPerBlock = 1000
+	}
+	if c.IntervalSeconds <= 0 {
+		c.IntervalSeconds = 60
+	}
+}

--- a/pkg/pruner/docid_codec.go
+++ b/pkg/pruner/docid_codec.go
@@ -1,0 +1,60 @@
+package pruner
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// docID encoding helpers shared by every queue implementation. DefraDB
+// document IDs follow the form "<prefix>-<uuid-with-hyphens>"; storing them
+// in queue snapshots as fixed-size 16-byte UUIDs avoids the per-entry
+// overhead of carrying the prefix string. The prefix is captured the first
+// time a docID is parsed and reused thereafter.
+
+const uuidSize = 16
+
+// docIDPrefix is the constant version prefix shared by all DefraDB document IDs.
+var (
+	docIDPrefix     string
+	docIDPrefixOnce sync.Once
+)
+
+// extractUUID extracts the 16-byte UUID from a docID string. Captures the
+// docID prefix on first call so RestoreDocID can rebuild full IDs later.
+func extractUUID(docID string) ([uuidSize]byte, error) {
+	idx := strings.IndexByte(docID, '-')
+	if idx < 0 {
+		return [uuidSize]byte{}, fmt.Errorf("invalid docID format: %s", docID)
+	}
+	docIDPrefixOnce.Do(func() {
+		docIDPrefix = docID[:idx]
+	})
+	return parseUUIDHex(docID[idx+1:])
+}
+
+// parseUUIDHex parses a UUID string (with hyphens) into 16 raw bytes.
+func parseUUIDHex(uuidStr string) ([uuidSize]byte, error) {
+	clean := strings.ReplaceAll(uuidStr, "-", "")
+	if len(clean) != 32 {
+		return [uuidSize]byte{}, fmt.Errorf("invalid UUID: %s", uuidStr)
+	}
+	var result [uuidSize]byte
+	_, err := hex.Decode(result[:], []byte(clean))
+	return result, err
+}
+
+// formatUUID formats 16 raw bytes as a UUID string with hyphens.
+func formatUUID(b [uuidSize]byte) string {
+	h := hex.EncodeToString(b[:])
+	return h[:8] + "-" + h[8:12] + "-" + h[12:16] + "-" + h[16:20] + "-" + h[20:]
+}
+
+// RestoreDocID reconstructs a full docID string from packed UUID bytes.
+// Requires extractUUID to have been called at least once on a real docID
+// to capture the prefix; before that, this returns "-<uuid>" with an empty
+// prefix.
+func RestoreDocID(uuid [uuidSize]byte) string {
+	return docIDPrefix + "-" + formatUUID(uuid)
+}

--- a/pkg/pruner/event_queue.go
+++ b/pkg/pruner/event_queue.go
@@ -1,0 +1,300 @@
+package pruner
+
+import (
+	"encoding/gob"
+	"fmt"
+	"os"
+	"sync"
+)
+
+// eventEntry is a single tracked document from a P2P replication event.
+// Uses packed UUID (16 bytes) + 1 byte collection type for compact storage.
+type eventEntry struct {
+	Collection byte           // collection type enum
+	UUID       [uuidSize]byte // packed UUID (16 bytes)
+}
+
+// Collection type constants for compact storage.
+const (
+	colBlock    byte = 0
+	colTx       byte = 1
+	colLog      byte = 2
+	colALE      byte = 3
+	colBatchSig byte = 4
+)
+
+// eventQueueSnapshot is the serializable form of the event queue.
+type eventQueueSnapshot struct {
+	DocIDPrefix     string
+	Entries         []eventEntry
+	BlockCount      int
+	CollectionNames map[byte]string // maps enum → collection name
+}
+
+// EventQueue is a FIFO queue that tracks document IDs from P2P replication events.
+// Documents are stored in arrival order. When pruning, oldest entries are drained
+// until enough Block entries have been consumed.
+// Storage: 17 bytes per entry (1 byte collection type + 16 bytes UUID).
+type EventQueue struct {
+	mu              sync.Mutex
+	entries         []eventEntry
+	blockCount      int
+	filePath        string
+	collectionNames map[byte]string // maps enum → collection name
+	collectionEnums map[string]byte // maps collection name → enum
+}
+
+// NewEventQueue creates a new empty event queue.
+// blockCollection is the name of the Block collection (used to identify block entries).
+func NewEventQueue(collections CollectionConfig) *EventQueue {
+	q := &EventQueue{
+		entries:         make([]eventEntry, 0, 1024),
+		collectionNames: make(map[byte]string),
+		collectionEnums: make(map[string]byte),
+	}
+
+	// Register block collection
+	q.collectionNames[colBlock] = collections.BlockCollection
+	q.collectionEnums[collections.BlockCollection] = colBlock
+
+	// Register dependent collections with known enums
+	knownCollections := map[string]byte{
+		"Ethereum__Mainnet__Transaction":     colTx,
+		"Ethereum__Mainnet__Log":             colLog,
+		"Ethereum__Mainnet__AccessListEntry": colALE,
+		"Ethereum__Mainnet__BatchSignature":  colBatchSig,
+	}
+
+	for _, name := range collections.DependentCollections {
+		if enum, ok := knownCollections[name]; ok {
+			q.collectionNames[enum] = name
+			q.collectionEnums[name] = enum
+		}
+	}
+
+	return q
+}
+
+// Push adds a document to the queue. O(1) operation, no doc fetch needed.
+func (q *EventQueue) Push(collectionName, docID string) {
+	uuid, err := extractUUID(docID)
+	if err != nil {
+		return // skip invalid docIDs silently
+	}
+
+	colType, ok := q.collectionEnums[collectionName]
+	if !ok {
+		return // skip unknown collections
+	}
+
+	q.mu.Lock()
+	q.entries = append(q.entries, eventEntry{
+		Collection: colType,
+		UUID:       uuid,
+	})
+	if colType == colBlock {
+		q.blockCount++
+	}
+	q.mu.Unlock()
+}
+
+// DrainDocs removes `count` entries from the front of the FIFO queue.
+func (q *EventQueue) DrainDocs(count int) *DrainResult {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if len(q.entries) == 0 || count <= 0 {
+		return nil
+	}
+
+	if count > len(q.entries) {
+		count = len(q.entries)
+	}
+
+	drained := make([]eventEntry, count)
+	copy(drained, q.entries[:count])
+
+	remaining := make([]eventEntry, len(q.entries)-count)
+	copy(remaining, q.entries[count:])
+	q.entries = remaining
+
+	// Count blocks in drained set and update blockCount
+	blocksSeen := 0
+	for _, entry := range drained {
+		if entry.Collection == colBlock {
+			blocksSeen++
+		}
+	}
+	q.blockCount -= blocksSeen
+
+	// Group by collection name
+	result := &DrainResult{
+		DocIDsByCollection: make(map[string][]string),
+		BlockCount:         blocksSeen,
+	}
+
+	for _, entry := range drained {
+		name, ok := q.collectionNames[entry.Collection]
+		if !ok {
+			continue
+		}
+		docID := RestoreDocID(entry.UUID)
+		result.DocIDsByCollection[name] = append(result.DocIDsByCollection[name], docID)
+	}
+
+	return result
+}
+
+// DrainBlocks removes entries from the front until `count` Block entries
+// have been consumed. All non-Block entries between those blocks are also removed.
+// Returns a DrainResult with docIDs grouped by collection name.
+func (q *EventQueue) DrainBlocks(count int) *DrainResult {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if q.blockCount <= 0 || count <= 0 {
+		return nil
+	}
+
+	// Walk from front, count Block entries
+	blocksSeen := 0
+	cutoff := 0
+	for i, entry := range q.entries {
+		if entry.Collection == colBlock {
+			blocksSeen++
+			if blocksSeen >= count {
+				cutoff = i + 1
+				break
+			}
+		}
+	}
+
+	if cutoff == 0 {
+		return nil
+	}
+
+	// Drain entries [0, cutoff)
+	drained := make([]eventEntry, cutoff)
+	copy(drained, q.entries[:cutoff])
+
+	remaining := make([]eventEntry, len(q.entries)-cutoff)
+	copy(remaining, q.entries[cutoff:])
+	q.entries = remaining
+	q.blockCount -= blocksSeen
+
+	// Group by collection name
+	result := &DrainResult{
+		DocIDsByCollection: make(map[string][]string),
+		BlockCount:         blocksSeen,
+	}
+
+	for _, entry := range drained {
+		name, ok := q.collectionNames[entry.Collection]
+		if !ok {
+			continue
+		}
+		docID := RestoreDocID(entry.UUID)
+		result.DocIDsByCollection[name] = append(result.DocIDsByCollection[name], docID)
+	}
+
+	return result
+}
+
+// Len returns the total number of entries in the queue.
+func (q *EventQueue) Len() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return len(q.entries)
+}
+
+// BlockCount returns the number of Block entries in the queue.
+func (q *EventQueue) BlockCount() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.blockCount
+}
+
+// LoadFromFile loads queue entries from a gob-encoded file.
+func (q *EventQueue) LoadFromFile(path string) (int, error) {
+	q.filePath = path
+
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("failed to open queue file: %w", err)
+	}
+	defer f.Close()
+
+	var snap eventQueueSnapshot
+	if err := gob.NewDecoder(f).Decode(&snap); err != nil {
+		return 0, fmt.Errorf("failed to decode queue file: %w", err)
+	}
+
+	q.mu.Lock()
+	q.entries = snap.Entries
+	q.blockCount = snap.BlockCount
+	if snap.CollectionNames != nil {
+		for k, v := range snap.CollectionNames {
+			q.collectionNames[k] = v
+			q.collectionEnums[v] = k
+		}
+	}
+	count := len(q.entries)
+	q.mu.Unlock()
+
+	if snap.DocIDPrefix != "" {
+		docIDPrefixOnce.Do(func() {
+			docIDPrefix = snap.DocIDPrefix
+		})
+	}
+
+	return count, nil
+}
+
+// Save persists the queue to disk using atomic write.
+func (q *EventQueue) Save() error {
+	if q.filePath == "" {
+		return nil
+	}
+
+	q.mu.Lock()
+	snap := eventQueueSnapshot{
+		DocIDPrefix:     docIDPrefix,
+		Entries:         make([]eventEntry, len(q.entries)),
+		BlockCount:      q.blockCount,
+		CollectionNames: q.collectionNames,
+	}
+	copy(snap.Entries, q.entries)
+	q.mu.Unlock()
+
+	if len(snap.Entries) == 0 {
+		os.Remove(q.filePath)
+		return nil
+	}
+
+	tmpPath := q.filePath + ".tmp"
+	f, err := os.Create(tmpPath)
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+
+	if err := gob.NewEncoder(f).Encode(snap); err != nil {
+		f.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("failed to encode queue: %w", err)
+	}
+
+	if err := f.Close(); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("failed to close temp file: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, q.filePath); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("failed to rename temp file: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/pruner/pruner.go
+++ b/pkg/pruner/pruner.go
@@ -1,0 +1,557 @@
+package pruner
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
+	"github.com/sourcenetwork/defradb/node"
+)
+
+// Pruner handles periodic removal of old blockchain documents from DefraDB.
+// With an EventQueue set, it drains docIDs tracked from P2P replication
+// events. With no queue set or an underfilled queue, falls back to
+// filter-based pruning by block range.
+type Pruner struct {
+	cfg         *Config
+	collections CollectionConfig
+	defraNode   *node.Node
+	queue       PrunerQueue // EventQueue (the only implementation in host)
+	stopChan    chan struct{}
+	wg          sync.WaitGroup
+	mu          sync.RWMutex
+
+	// Metrics
+	lastPruneTime     time.Time
+	totalBlocksPruned int64
+	totalDocsPruned   int64
+	isRunning         bool
+}
+
+// Metrics holds pruning statistics.
+type Metrics struct {
+	Enabled           bool      `json:"enabled"`
+	IsRunning         bool      `json:"is_running"`
+	LastPruneTime     time.Time `json:"last_prune_time"`
+	TotalBlocksPruned int64     `json:"total_blocks_pruned"`
+	TotalDocsPruned   int64     `json:"total_docs_pruned"`
+}
+
+// NewPruner creates a new Pruner instance.
+func NewPruner(cfg *Config, defraNode *node.Node, collections ...CollectionConfig) *Pruner {
+	cols := DefaultCollectionConfig()
+	if len(collections) > 0 {
+		cols = collections[0]
+	}
+	return &Pruner{
+		cfg:         cfg,
+		collections: cols,
+		defraNode:   defraNode,
+		stopChan:    make(chan struct{}),
+	}
+}
+
+// SetQueue sets the queue implementation for queue-based pruning.
+func (p *Pruner) SetQueue(queue PrunerQueue) {
+	p.queue = queue
+}
+
+// Start begins the pruning loop in a background goroutine.
+func (p *Pruner) Start(ctx context.Context) error {
+	if !p.cfg.Enabled {
+		logger.Sugar.Info("Pruner is disabled")
+		return nil
+	}
+
+	if p.defraNode == nil {
+		logger.Sugar.Warn("Pruner requires embedded DefraDB node, skipping")
+		return nil
+	}
+
+	p.mu.Lock()
+	if p.isRunning {
+		p.mu.Unlock()
+		return nil
+	}
+	p.isRunning = true
+	p.mu.Unlock()
+
+	logger.Sugar.Debugf("Starting pruner (max_blocks=%d, docs_per_block=%d, max_docs=%d, interval=%ds)",
+		p.cfg.MaxBlocks, p.cfg.DocsPerBlock, p.cfg.MaxDocs(), p.cfg.IntervalSeconds)
+
+	p.wg.Add(1)
+	go p.pruneLoop(ctx)
+
+	return nil
+}
+
+// Stop signals the pruner to stop and waits for it to complete.
+func (p *Pruner) Stop() {
+	p.mu.Lock()
+	if !p.isRunning {
+		p.mu.Unlock()
+		return
+	}
+	p.mu.Unlock()
+
+	logger.Sugar.Infof("Pruner stopping, waiting for current operation to finish...")
+	close(p.stopChan)
+	p.wg.Wait()
+
+	// Save queue to disk for fast restart
+	if p.queue != nil {
+		queueLen := p.queue.Len()
+		logger.Sugar.Infof("Saving prune queue to disk (%d entries)...", queueLen)
+		if err := p.queue.Save(); err != nil {
+			logger.Sugar.Errorf("Failed to save prune queue: %v", err)
+		} else {
+			logger.Sugar.Infof("Prune queue saved successfully")
+		}
+	}
+
+	p.mu.Lock()
+	p.isRunning = false
+	p.mu.Unlock()
+
+	logger.Sugar.Info("Pruner stopped")
+}
+
+// GetMetrics returns current pruning statistics.
+func (p *Pruner) GetMetrics() Metrics {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	return Metrics{
+		Enabled:           p.cfg.Enabled,
+		IsRunning:         p.isRunning,
+		LastPruneTime:     p.lastPruneTime,
+		TotalBlocksPruned: p.totalBlocksPruned,
+		TotalDocsPruned:   p.totalDocsPruned,
+	}
+}
+
+// pruneLoop runs the periodic pruning check.
+func (p *Pruner) pruneLoop(ctx context.Context) {
+	defer p.wg.Done()
+
+	// Run startup cleanup only for indexer queues (no P2P) or when no queue is set.
+	// For event queues (hosts), skip startup cleanup — the DB may contain snapshot-
+	// imported data that should not be pruned. Only queue-tracked data gets pruned.
+	_, isEventQueue := p.queue.(*EventQueue)
+	if !isEventQueue {
+		logger.Sugar.Debugf("Running startup cleanup for pre-existing blocks...")
+		if err := p.startupCleanup(ctx); err != nil {
+			logger.Sugar.Errorf("Startup cleanup failed: %v", err)
+		}
+	} else {
+		logger.Sugar.Debugf("Skipping startup cleanup (event queue mode — only queue-tracked data is pruned)")
+	}
+
+	ticker := time.NewTicker(time.Duration(p.cfg.IntervalSeconds) * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-p.stopChan:
+			return
+		case <-ticker.C:
+			if err := p.runPrune(ctx); err != nil {
+				logger.Sugar.Errorf("Prune failed: %v", err)
+			}
+			p.runStorageGC()
+		}
+	}
+}
+
+// runPrune executes the appropriate pruning strategy based on queue type and state.
+func (p *Pruner) runPrune(ctx context.Context) error {
+	if p.queue == nil {
+		return p.filterBasedPrune(ctx)
+	}
+
+	switch q := p.queue.(type) {
+	case *EventQueue:
+		return p.runEventQueuePrune(ctx, q)
+	default:
+		return p.filterBasedPrune(ctx)
+	}
+}
+
+// runEventQueuePrune drains the EventQueue and purges by docIDs.
+// Uses doc-count threshold (max_blocks * docs_per_block) because P2P events
+// arrive in non-deterministic order — block docs may arrive before their
+// dependent docs (transactions, logs, etc.).
+func (p *Pruner) runEventQueuePrune(ctx context.Context, q *EventQueue) error {
+	totalDocs := int64(q.Len())
+	maxDocs := p.cfg.MaxDocs()
+
+	if totalDocs <= maxDocs {
+		// Queue is underfilled (e.g., after a crash restart where the queue was lost).
+		// Do NOT fall back to filter-based pruning — the DB may contain snapshot-
+		// imported data that should not be pruned. Only prune what the queue tracks.
+		return nil
+	}
+
+	excess := int(totalDocs - maxDocs)
+	result := q.DrainDocs(excess)
+	if result == nil {
+		return nil
+	}
+
+	logger.Sugar.Infof("Pruning %d docs (%d blocks) — queue had %d docs, keeping %d (max_blocks=%d × docs_per_block=%d)",
+		excess, result.BlockCount, totalDocs, maxDocs, p.cfg.MaxBlocks, p.cfg.DocsPerBlock)
+
+	return p.purgeFromDrainResult(ctx, result)
+}
+
+// purgeFromDrainResult deletes documents from a DrainResult.
+// Deletes dependent collections first, then the block collection last.
+func (p *Pruner) purgeFromDrainResult(ctx context.Context, result *DrainResult) error {
+	startTime := time.Now()
+	totalPurged := int64(0)
+
+	// Dependent collections first, block collection last
+	for _, colName := range p.collections.DependentCollections {
+		docIDs, ok := result.DocIDsByCollection[colName]
+		if !ok || len(docIDs) == 0 {
+			continue
+		}
+		purged, err := p.purgeByDocIDs(ctx, colName, docIDs)
+		if err != nil {
+			logger.Sugar.Errorf("Failed to purge %s: %v", colName, err)
+		} else {
+			totalPurged += purged
+		}
+	}
+
+	if blockIDs, ok := result.DocIDsByCollection[p.collections.BlockCollection]; ok && len(blockIDs) > 0 {
+		purged, err := p.purgeByDocIDs(ctx, p.collections.BlockCollection, blockIDs)
+		if err != nil {
+			logger.Sugar.Errorf("Failed to purge blocks: %v", err)
+		} else {
+			totalPurged += purged
+		}
+	}
+
+	elapsed := time.Since(startTime)
+	logger.Sugar.Infof("Prune complete: removed %d docs for %d blocks in %v",
+		totalPurged, result.BlockCount, elapsed)
+
+	p.mu.Lock()
+	p.totalBlocksPruned += int64(result.BlockCount)
+	p.totalDocsPruned += totalPurged
+	p.lastPruneTime = time.Now()
+	p.mu.Unlock()
+
+	return nil
+}
+
+// startupCleanup removes blocks left over from previous runs that aren't in the queue.
+func (p *Pruner) startupCleanup(ctx context.Context) error {
+	lowest, err := p.getLowestBlockNumber(ctx)
+	if err != nil {
+		return err
+	}
+
+	highest, err := p.getHighestBlockNumber(ctx)
+	if err != nil {
+		return err
+	}
+
+	if lowest == 0 && highest == 0 {
+		logger.Sugar.Debugf("No existing blocks in database")
+		return nil
+	}
+
+	currentCount := highest - lowest + 1
+	if currentCount <= p.cfg.MaxBlocks {
+		logger.Sugar.Debugf("Existing blocks %d-%d (count=%d) within limit (max_blocks=%d), no cleanup needed",
+			lowest, highest, currentCount, p.cfg.MaxBlocks)
+		return nil
+	}
+
+	toPrune := currentCount - p.cfg.MaxBlocks
+	cutoffBlock := lowest + toPrune - 1
+
+	logger.Sugar.Infof("Startup cleanup: pruning blocks %d-%d (%d blocks, keeping %d-%d)",
+		lowest, cutoffBlock, toPrune, cutoffBlock+1, highest)
+
+	totalPurged, err := p.pruneBlockRange(ctx, lowest, cutoffBlock)
+
+	if err != nil {
+		logger.Sugar.Errorf("Startup: failed to prune blocks %d-%d: %v", lowest, cutoffBlock, err)
+		return err
+	}
+
+	logger.Sugar.Infof("Startup cleanup complete: purged %d documents", totalPurged)
+
+	p.mu.Lock()
+	p.totalBlocksPruned += toPrune
+	p.totalDocsPruned += totalPurged
+	p.lastPruneTime = time.Now()
+	p.mu.Unlock()
+
+	return nil
+}
+
+// runStorageGC reclaims disk space from deleted entries by running Badger value log GC.
+func (p *Pruner) runStorageGC() {
+	if p.defraNode == nil {
+		return
+	}
+	startTime := time.Now()
+	if err := p.defraNode.RunStorageGC(); err != nil {
+		logger.Sugar.Debugf("Storage GC error (non-fatal): %v", err)
+	}
+	elapsed := time.Since(startTime)
+	if elapsed > time.Second {
+		logger.Sugar.Infof("Storage GC completed in %v", elapsed)
+	}
+}
+
+// filterBasedPrune checks the actual DB block count and prunes excess blocks.
+// Used by the indexer queue (no P2P) and as a fallback when the queue is underfilled.
+func (p *Pruner) filterBasedPrune(ctx context.Context) error {
+	highest, err := p.getHighestBlockNumber(ctx)
+	if err != nil || highest == 0 {
+		return nil
+	}
+
+	lowest, err := p.getLowestBlockNumber(ctx)
+	if err != nil || lowest == 0 {
+		return nil
+	}
+
+	dbBlockCount := highest - lowest + 1
+	if dbBlockCount <= p.cfg.MaxBlocks {
+		return nil
+	}
+
+	excess := dbBlockCount - p.cfg.MaxBlocks
+	cutoff := lowest + excess - 1
+
+	logger.Sugar.Infof("Filter-based prune: %d excess blocks (%d-%d), pruning %d-%d",
+		excess, lowest, highest, lowest, cutoff)
+
+	purged, err := p.pruneBlockRange(ctx, lowest, cutoff)
+	if err != nil {
+		return err
+	}
+
+	p.mu.Lock()
+	p.totalBlocksPruned += excess
+	p.totalDocsPruned += purged
+	p.lastPruneTime = time.Now()
+	p.mu.Unlock()
+
+	return nil
+}
+
+// pruneBlockRange removes all documents for blocks in [startBlock, endBlock].
+// Uses order+limit queries to get docIDs, then purges them.
+// Safe to call with concurrent P2P replication — merge handles missing blocks gracefully.
+func (p *Pruner) pruneBlockRange(ctx context.Context, startBlock, endBlock int64) (int64, error) {
+	totalPurged := int64(0)
+
+	logger.Sugar.Infof("pruneBlockRange: deleting blocks %d-%d (%d blocks)",
+		startBlock, endBlock, endBlock-startBlock+1)
+
+	// Dependent collections first, block collection last
+	for _, colName := range p.collections.DependentCollections {
+		docIDs, err := p.queryOldestDocIDs(ctx, colName, "blockNumber", endBlock)
+		if err != nil {
+			logger.Sugar.Warnf("pruneBlockRange: query failed for %s (skipping): %v", colName, err)
+			continue
+		}
+		if len(docIDs) > 0 {
+			purged, err := p.purgeByDocIDs(ctx, colName, docIDs)
+			if err != nil {
+				logger.Sugar.Warnf("pruneBlockRange: failed to purge %s: %v", colName, err)
+			} else {
+				totalPurged += purged
+			}
+		}
+	}
+
+	blockDocIDs, err := p.queryOldestDocIDs(ctx, p.collections.BlockCollection, p.collections.BlockNumberField, endBlock)
+	if err != nil {
+		return totalPurged, fmt.Errorf("query failed for blocks: %w", err)
+	}
+	if len(blockDocIDs) > 0 {
+		purged, err := p.purgeByDocIDs(ctx, p.collections.BlockCollection, blockDocIDs)
+		if err != nil {
+			return totalPurged, fmt.Errorf("failed to purge blocks: %w", err)
+		}
+		totalPurged += purged
+	}
+
+	logger.Sugar.Infof("pruneBlockRange: purged %d docs for blocks %d-%d", totalPurged, startBlock, endBlock)
+	return totalPurged, nil
+}
+
+// ─── Document operations ─────────────────────────────────────────────────────
+
+// queryOldestDocIDs queries for docIDs where fieldName <= maxBlockNumber using order+limit.
+// Works on P2P-replicated data where filter queries return empty results.
+func (p *Pruner) queryOldestDocIDs(ctx context.Context, collectionName, fieldName string, maxBlockNumber int64) ([]string, error) {
+	limit := 50000
+	query := fmt.Sprintf(`query {
+		%s(order: { %s: ASC }, limit: %d) {
+			_docID
+			%s
+		}
+	}`, collectionName, fieldName, limit, fieldName)
+
+	result := p.defraNode.DB.ExecRequest(ctx, query)
+	if len(result.GQL.Errors) > 0 {
+		return nil, fmt.Errorf("query failed for %s: %v", collectionName, result.GQL.Errors[0])
+	}
+
+	data, ok := result.GQL.Data.(map[string]any)
+	if !ok {
+		return nil, nil
+	}
+
+	// DefraDB may return []map[string]interface{} or []interface{} depending on context.
+	// In Go these are distinct types, so we must handle both.
+	raw := data[collectionName]
+
+	var docIDs []string
+
+	switch docs := raw.(type) {
+	case []map[string]interface{}:
+		for _, docMap := range docs {
+			bn, err := parseBlockNumber(docMap[fieldName])
+			if err != nil || bn > maxBlockNumber {
+				break // ordered ASC, so once we exceed maxBlockNumber we're done
+			}
+			if docID, ok := docMap["_docID"].(string); ok {
+				docIDs = append(docIDs, docID)
+			}
+		}
+	case []interface{}:
+		for _, doc := range docs {
+			docMap, ok := doc.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			bn, err := parseBlockNumber(docMap[fieldName])
+			if err != nil || bn > maxBlockNumber {
+				break
+			}
+			if docID, ok := docMap["_docID"].(string); ok {
+				docIDs = append(docIDs, docID)
+			}
+		}
+	default:
+		return nil, nil
+	}
+
+	return docIDs, nil
+}
+
+// purgeByDocIDs deletes documents by their docIDs.
+func (p *Pruner) purgeByDocIDs(ctx context.Context, collectionName string, docIDs []string) (int64, error) {
+	if len(docIDs) == 0 {
+		return 0, nil
+	}
+
+	startTime := time.Now()
+	logger.Sugar.Infof("Purging %d documents from %s", len(docIDs), collectionName)
+
+	col, err := p.defraNode.DB.GetCollectionByName(ctx, collectionName)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get collection %s: %w", collectionName, err)
+	}
+
+	result, err := col.PurgeByDocIDs(ctx, docIDs, p.cfg.PruneHistory)
+	if err != nil {
+		return 0, err
+	}
+
+	logger.Sugar.Infof("Purged %d/%d documents from %s in %v",
+		result.Count, len(docIDs), collectionName, time.Since(startTime))
+	return result.Count, nil
+}
+
+// ─── Block number queries ────────────────────────────────────────────────────
+
+func (p *Pruner) getLowestBlockNumber(ctx context.Context) (int64, error) {
+	query := `query {
+		` + p.collections.BlockCollection + ` (order: {` + p.collections.BlockNumberField + `: ASC}, limit: 1) {
+			` + p.collections.BlockNumberField + `
+		}
+	}`
+
+	result := p.defraNode.DB.ExecRequest(ctx, query)
+	if len(result.GQL.Errors) > 0 {
+		return 0, result.GQL.Errors[0]
+	}
+
+	return p.extractBlockNumber(result.GQL.Data)
+}
+
+func (p *Pruner) getHighestBlockNumber(ctx context.Context) (int64, error) {
+	query := `query {
+		` + p.collections.BlockCollection + ` (order: {` + p.collections.BlockNumberField + `: DESC}, limit: 1) {
+			` + p.collections.BlockNumberField + `
+		}
+	}`
+
+	result := p.defraNode.DB.ExecRequest(ctx, query)
+	if len(result.GQL.Errors) > 0 {
+		return 0, result.GQL.Errors[0]
+	}
+
+	return p.extractBlockNumber(result.GQL.Data)
+}
+
+func (p *Pruner) extractBlockNumber(gqlData any) (int64, error) {
+	data, ok := gqlData.(map[string]interface{})
+	if !ok {
+		return 0, nil
+	}
+
+	blocksRaw := data[p.collections.BlockCollection]
+
+	if blocksTyped, ok := blocksRaw.([]map[string]interface{}); ok {
+		if len(blocksTyped) == 0 {
+			return 0, nil
+		}
+		if number, ok := blocksTyped[0][p.collections.BlockNumberField]; ok {
+			return parseBlockNumber(number)
+		}
+		return 0, nil
+	}
+
+	blocks, ok := blocksRaw.([]interface{})
+	if !ok || len(blocks) == 0 {
+		return 0, nil
+	}
+
+	block, ok := blocks[0].(map[string]interface{})
+	if !ok {
+		return 0, nil
+	}
+
+	if number, ok := block[p.collections.BlockNumberField]; ok {
+		return parseBlockNumber(number)
+	}
+	return 0, nil
+}
+
+func parseBlockNumber(number interface{}) (int64, error) {
+	switch v := number.(type) {
+	case float64:
+		return int64(v), nil
+	case int64:
+		return v, nil
+	case int:
+		return int64(v), nil
+	}
+	return 0, nil
+}

--- a/pkg/pruner/queue.go
+++ b/pkg/pruner/queue.go
@@ -1,0 +1,20 @@
+package pruner
+
+// PrunerQueue is the interface for queue implementations used by the pruner.
+// Host's only implementation is EventQueue, a FIFO queue tracking docIDs
+// arriving from P2P replication events.
+type PrunerQueue interface {
+	// Len returns the total number of entries in the queue.
+	Len() int
+
+	// Save persists the queue to disk. No-op if no file path was set.
+	Save() error
+}
+
+// DrainResult holds docIDs grouped by collection name, ready for deletion.
+type DrainResult struct {
+	// DocIDsByCollection maps collection name → list of docIDs to delete.
+	DocIDsByCollection map[string][]string
+	// BlockCount is the number of blocks being drained.
+	BlockCount int
+}

--- a/pkg/server/health.go
+++ b/pkg/server/health.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/logger"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
 )
 
 //go:embed health_status_page.html

--- a/pkg/server/health_test.go
+++ b/pkg/server/health_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/logger"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
 	"github.com/stretchr/testify/require"
 )
 

--- a/pkg/server/metrics.go
+++ b/pkg/server/metrics.go
@@ -11,7 +11,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/logger"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/constants"
 )
 

--- a/pkg/shinzohub/events.go
+++ b/pkg/shinzohub/events.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/logger"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
 	"go.uber.org/zap"
 )
 

--- a/pkg/shinzohub/query.go
+++ b/pkg/shinzohub/query.go
@@ -9,7 +9,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/logger"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/view"
 	"github.com/sourcenetwork/defradb/node"
 )

--- a/pkg/shinzohub/view_processor_test.go
+++ b/pkg/shinzohub/view_processor_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/base64"
 	"testing"
 
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/defra"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/defradb"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/view"
 	"github.com/shinzonetwork/viewbundle-go"
 	"github.com/stretchr/testify/require"
@@ -91,7 +91,7 @@ func TestViewProcessor_ProcessViewFromWire_InvalidView(t *testing.T) {
 func TestViewProcessor_SetupViewInDefraDB(t *testing.T) {
 	// Create temporary DefraDB instance
 	ctx := context.Background()
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -124,7 +124,7 @@ func TestViewProcessor_SetupViewInDefraDB(t *testing.T) {
 func TestViewProcessor_SetupViewInDefraDB_WithoutLenses(t *testing.T) {
 	// Create temporary DefraDB instance
 	ctx := context.Background()
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -158,7 +158,7 @@ func TestViewProcessor_SetupViewInDefraDB_WithoutLenses(t *testing.T) {
 func TestViewProcessor_SetupViewInDefraDB_InvalidView(t *testing.T) {
 	// Create temporary DefraDB instance
 	ctx := context.Background()
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 

--- a/pkg/shinzohub/view_test.go
+++ b/pkg/shinzohub/view_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/defra"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/defradb"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/view"
 	"github.com/shinzonetwork/viewbundle-go"
 	"github.com/stretchr/testify/require"
@@ -147,7 +147,7 @@ func TestSubscribeToViewNoViewFailure(t *testing.T) {
 	testView, err := view.NewViewFromBundle(bundledView)
 	require.NoError(t, err)
 
-	myDefra, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	myDefra, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer myDefra.Close(ctx)
 
@@ -170,7 +170,7 @@ func TestSubscribeToInvalidViewFails(t *testing.T) {
 	testView, err := view.NewViewFromBundle(bundledView)
 	require.NoError(t, err)
 
-	myDefra, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	myDefra, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	err = testView.SubscribeTo(context.Background(), myDefra)
 	require.Error(t, err)

--- a/pkg/signer/signer.go
+++ b/pkg/signer/signer.go
@@ -1,0 +1,417 @@
+package signer
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	libp2pcrypto "github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/defradb"
+	"github.com/sourcenetwork/defradb/acp/identity"
+	"github.com/sourcenetwork/defradb/crypto"
+	"github.com/sourcenetwork/defradb/keyring"
+	"github.com/sourcenetwork/defradb/node"
+)
+
+const (
+	keyFileName         string = "defra_identity.key"
+	nodeIdentityKeyName string = "node-identity-key"
+)
+
+// Function variables for dependency injection in tests.
+var (
+	loadIdentityFromStoreFn    = loadIdentityFromStore
+	createLibP2PKeyFromIdentFn = createLibP2PKeyFromIdentity
+	identityFromPrivateKeyFn   = identity.FromPrivateKey
+	generateEd25519KeyFn       = libp2pcrypto.GenerateEd25519Key
+	ed25519PubKeyFromStringFn  = func(hex string) (crypto.PublicKey, error) {
+		return crypto.PublicKeyFromString(crypto.KeyTypeEd25519, hex)
+	}
+)
+
+// openKeyring opens a keyring from the config, if available.
+// Returns nil if keyring is not configured or cannot be opened.
+func openKeyring(cfg *defradb.Config) (keyring.Keyring, error) {
+	if cfg == nil || cfg.DefraDB.KeyringSecret == "" {
+		return nil, nil
+	}
+
+	// Use file-based keyring (default for DefraDB)
+	// Keyring path defaults to "keys" directory in store path, or "keys" in current dir
+	keyringPath := filepath.Join(cfg.DefraDB.Store.Path, "keys")
+	if cfg.DefraDB.Store.Path == "" {
+		keyringPath = "keys"
+	}
+
+	// Ensure directory exists
+	if err := os.MkdirAll(keyringPath, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create keyring directory: %w", err)
+	}
+
+	secret := []byte(cfg.DefraDB.KeyringSecret)
+	return keyring.OpenFileKeyring(keyringPath, secret)
+}
+
+// loadIdentityFromKeyring loads the DefraDB identity from the keyring.
+func loadIdentityFromKeyring(kr keyring.Keyring) (identity.FullIdentity, error) {
+	identityBytes, err := kr.Get(nodeIdentityKeyName)
+	if err != nil {
+		if errors.Is(err, keyring.ErrNotFound) {
+			return nil, fmt.Errorf("node identity not found in keyring")
+		}
+		return nil, fmt.Errorf("failed to get identity from keyring: %w", err)
+	}
+
+	// Parse the format: "keyType:rawKeyBytes"
+	sepPos := bytes.Index(identityBytes, []byte(":"))
+	if sepPos == -1 {
+		// Old format without key type prefix, assume secp256k1
+		identityBytes = append([]byte(crypto.KeyTypeSecp256k1+":"), identityBytes...)
+		sepPos = len(crypto.KeyTypeSecp256k1)
+	}
+
+	keyType := string(identityBytes[:sepPos])
+	keyBytes := identityBytes[sepPos+1:]
+
+	// Reconstruct private key from bytes
+	privateKey, err := crypto.PrivateKeyFromBytes(crypto.KeyType(keyType), keyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to reconstruct private key: %w", err)
+	}
+
+	// Reconstruct identity from private key
+	fullIdentity, err := identityFromPrivateKeyFn(privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to reconstruct identity from private key: %w", err)
+	}
+
+	return fullIdentity, nil
+}
+
+// loadIdentityFromFile loads the DefraDB identity from a file.
+func loadIdentityFromFile(storePath string) (identity.FullIdentity, error) {
+	keyPath := filepath.Join(storePath, keyFileName)
+
+	// Read the stored key file
+	keyHex, err := os.ReadFile(keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read key file at %s: %w", keyPath, err)
+	}
+
+	// Decode hex string to bytes
+	keyBytes, err := hex.DecodeString(strings.TrimSpace(string(keyHex)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode key hex: %w", err)
+	}
+
+	// Reconstruct private key from bytes
+	privateKey, err := crypto.PrivateKeyFromBytes(crypto.KeyTypeSecp256k1, keyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to reconstruct private key: %w", err)
+	}
+
+	// Reconstruct identity from private key
+	fullIdentity, err := identityFromPrivateKeyFn(privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to reconstruct identity from private key: %w", err)
+	}
+
+	return fullIdentity, nil
+}
+
+// loadIdentityFromStore loads the DefraDB identity, trying keyring first, then falling back to file.
+func loadIdentityFromStore(cfg *defradb.Config, storePath string) (identity.FullIdentity, error) {
+	// Try keyring first if config is available
+	if cfg != nil {
+		kr, err := openKeyring(cfg)
+		if err == nil && kr != nil {
+			identity, err := loadIdentityFromKeyring(kr)
+			if err == nil {
+				return identity, nil
+			}
+			// If keyring fails, fall through to file-based
+		}
+	}
+
+	// Fall back to file-based storage
+	return loadIdentityFromFile(storePath)
+}
+
+// createLibP2PKeyFromIdentity creates a LibP2P private key from a DefraDB identity.
+// This ensures the LibP2P peer ID is deterministically derived from the same identity.
+func createLibP2PKeyFromIdentity(nodeIdentity identity.Identity) (libp2pcrypto.PrivKey, error) {
+	// Cast to FullIdentity to access private key
+	fullIdentity, ok := nodeIdentity.(identity.FullIdentity)
+	if !ok {
+		return nil, fmt.Errorf("identity is not a FullIdentity, cannot extract private key")
+	}
+
+	// Get the private key from the identity
+	privateKey := fullIdentity.PrivateKey()
+	if privateKey == nil {
+		return nil, fmt.Errorf("failed to get private key from identity")
+	}
+
+	// Get raw key bytes
+	keyBytes := privateKey.Raw()
+	if len(keyBytes) == 0 {
+		return nil, fmt.Errorf("private key has no raw bytes")
+	}
+
+	// DefraDB expects Ed25519 keys, but DefraDB identities use secp256k1
+	// We need to derive an Ed25519 key deterministically from the secp256k1 key
+	// Use the secp256k1 key bytes as seed for Ed25519 key generation
+	if len(keyBytes) != 32 {
+		return nil, fmt.Errorf("expected 32-byte secp256k1 key, got %d bytes", len(keyBytes))
+	}
+
+	// Generate Ed25519 key from secp256k1 seed
+	libp2pPrivKey, _, err := generateEd25519KeyFn(strings.NewReader(string(keyBytes)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate Ed25519 key from identity seed: %w", err)
+	}
+
+	return libp2pPrivKey, nil
+}
+
+// getStorePath attempts to determine the store path from the config or node.
+// If config is provided and has a store path, it uses that.
+// Otherwise, it tries common locations and returns the first one that contains the key file.
+func getStorePath(_ *node.Node, cfg *defradb.Config) (string, error) {
+	// If config is provided and has a store path, use it
+	if cfg != nil && cfg.DefraDB.Store.Path != "" {
+		return cfg.DefraDB.Store.Path, nil
+	}
+
+	// Try common locations for file-based fallback
+	possiblePaths := []string{
+		".defra", // Default relative path
+		filepath.Join(os.Getenv("HOME"), ".defradb"), // Default DefraDB path
+	}
+
+	// Try each path to see if it contains the key file
+	for _, path := range possiblePaths {
+		keyPath := filepath.Join(path, keyFileName)
+		if _, err := os.Stat(keyPath); err == nil {
+			return path, nil
+		}
+	}
+
+	return "", fmt.Errorf("could not find defra_identity.key in any common location. Please ensure the key file exists or provide a store path in config")
+}
+
+// SignWithDefraKeys signs a message using the DefraDB identity's private key (secp256k1).
+// The signature is returned as a hex-encoded string.
+// If cfg is provided and has a KeyringSecret, it will use the keyring; otherwise falls back to file-based storage.
+func SignWithDefraKeys(message string, defraNode *node.Node, cfg *defradb.Config) (string, error) {
+	// Get the store path
+	storePath, err := getStorePath(defraNode, cfg)
+	if err != nil {
+		return "", fmt.Errorf("failed to get store path: %w", err)
+	}
+
+	// Load the identity from storage (tries keyring first, then file)
+	fullIdentity, err := loadIdentityFromStoreFn(cfg, storePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to load identity: %w", err)
+	}
+
+	// Get the private key
+	privateKey := fullIdentity.PrivateKey()
+	if privateKey == nil {
+		return "", fmt.Errorf("identity does not have a private key")
+	}
+
+	// Sign the message
+	signature, err := privateKey.Sign([]byte(message))
+	if err != nil {
+		return "", fmt.Errorf("failed to sign message: %w", err)
+	}
+
+	// Return hex-encoded signature
+	return hex.EncodeToString(signature), nil
+}
+
+// SignWithP2PKeys signs a message using the LibP2P private key (Ed25519) derived from the DefraDB identity.
+// The signature is returned as a hex-encoded string.
+// If cfg is provided and has a KeyringSecret, it will use the keyring; otherwise falls back to file-based storage.
+func SignWithP2PKeys(message string, defraNode *node.Node, cfg *defradb.Config) (string, error) {
+	// Get the store path
+	storePath, err := getStorePath(defraNode, cfg)
+	if err != nil {
+		return "", fmt.Errorf("failed to get store path: %w", err)
+	}
+
+	// Load the identity from storage (tries keyring first, then file)
+	fullIdentity, err := loadIdentityFromStoreFn(cfg, storePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to load identity: %w", err)
+	}
+
+	// Create LibP2P private key from the identity
+	libp2pPrivKey, err := createLibP2PKeyFromIdentFn(fullIdentity)
+	if err != nil {
+		return "", fmt.Errorf("failed to create LibP2P key from identity: %w", err)
+	}
+
+	// Extract the raw Ed25519 key bytes from LibP2P key
+	// LibP2P's Raw() may return 32 or 64 bytes depending on the key type
+	rawKeyBytes, err := libp2pPrivKey.Raw()
+	if err != nil {
+		return "", fmt.Errorf("failed to get raw key bytes from LibP2P key: %w", err)
+	}
+
+	// Ed25519.NewKeyFromSeed expects exactly 32 bytes (the seed)
+	// If we got 64 bytes, take only the first 32 bytes (the seed portion)
+	var ed25519Seed []byte
+	if len(rawKeyBytes) == 64 {
+		ed25519Seed = rawKeyBytes[:32]
+	} else if len(rawKeyBytes) == 32 {
+		ed25519Seed = rawKeyBytes
+	} else {
+		return "", fmt.Errorf("unexpected Ed25519 key length: expected 32 or 64 bytes, got %d", len(rawKeyBytes))
+	}
+
+	// Construct full ed25519.PrivateKey from seed (64 bytes: 32-byte seed + 32-byte public key)
+	ed25519PrivKey := ed25519.NewKeyFromSeed(ed25519Seed)
+
+	// Sign the message directly with the Ed25519 private key, mirroring the working example
+	signature := ed25519.Sign(ed25519PrivKey, []byte(message))
+
+	// Return hex-encoded signature
+	return hex.EncodeToString(signature), nil
+}
+
+// GetDefraPublicKey returns the DefraDB identity's public key as a hex-encoded string.
+// If cfg is provided and has a KeyringSecret, it will use the keyring; otherwise falls back to file-based storage.
+func GetDefraPublicKey(defraNode *node.Node, cfg *defradb.Config) (string, error) {
+	// Get the store path
+	storePath, err := getStorePath(defraNode, cfg)
+	if err != nil {
+		return "", fmt.Errorf("failed to get store path: %w", err)
+	}
+
+	// Load the identity from storage (tries keyring first, then file)
+	fullIdentity, err := loadIdentityFromStoreFn(cfg, storePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to load identity: %w", err)
+	}
+
+	// Get the public key
+	publicKey := fullIdentity.PublicKey()
+	if publicKey == nil {
+		return "", fmt.Errorf("identity does not have a public key")
+	}
+
+	// Return hex-encoded public key
+	return publicKey.String(), nil
+}
+
+// GetP2PPublicKey returns the LibP2P public key (Ed25519) derived from the DefraDB identity as a hex-encoded string.
+// If cfg is provided and has a KeyringSecret, it will use the keyring; otherwise falls back to file-based storage.
+func GetP2PPublicKey(defraNode *node.Node, cfg *defradb.Config) (string, error) {
+	// Get the store path
+	storePath, err := getStorePath(defraNode, cfg)
+	if err != nil {
+		return "", fmt.Errorf("failed to get store path: %w", err)
+	}
+
+	// Load the identity from storage (tries keyring first, then file)
+	fullIdentity, err := loadIdentityFromStoreFn(cfg, storePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to load identity: %w", err)
+	}
+
+	// Create LibP2P private key from the identity
+	libp2pPrivKey, err := createLibP2PKeyFromIdentFn(fullIdentity)
+	if err != nil {
+		return "", fmt.Errorf("failed to create LibP2P key from identity: %w", err)
+	}
+
+	// Get the public key from LibP2P key
+	libp2pPubKey := libp2pPrivKey.GetPublic()
+
+	// Extract the raw Ed25519 public key bytes
+	ed25519PubKeyBytes, err := libp2pPubKey.Raw()
+	if err != nil {
+		return "", fmt.Errorf("failed to get raw public key bytes: %w", err)
+	}
+
+	// Return hex-encoded public key
+	return hex.EncodeToString(ed25519PubKeyBytes), nil
+}
+
+// VerifyDefraSignature verifies a signature against a message using a DefraDB public key (secp256k1).
+// Parameters:
+//   - publicKeyHex: Hex-encoded secp256k1 public key
+//   - message: The original message that was signed
+//   - signatureHex: Hex-encoded DER signature
+//
+// Returns:
+//   - error: nil if verification succeeds, appropriate error otherwise
+func VerifyDefraSignature(publicKeyHex string, message string, signatureHex string) error {
+	// Decode hex strings
+	signatureBytes, err := hex.DecodeString(signatureHex)
+	if err != nil {
+		return fmt.Errorf("failed to decode signature hex: %w", err)
+	}
+
+	// Parse public key from hex string
+	publicKey, err := crypto.PublicKeyFromString(crypto.KeyTypeSecp256k1, publicKeyHex)
+	if err != nil {
+		return fmt.Errorf("failed to parse public key: %w", err)
+	}
+
+	// Verify the signature using the public key's Verify method
+	valid, err := publicKey.Verify([]byte(message), signatureBytes)
+	if err != nil {
+		return fmt.Errorf("failed to verify signature: %w", err)
+	}
+
+	if !valid {
+		return fmt.Errorf("signature verification failed")
+	}
+
+	return nil
+}
+
+// VerifyP2PSignature verifies a signature against a message using a LibP2P public key (Ed25519).
+// Parameters:
+//   - publicKeyHex: Hex-encoded Ed25519 public key
+//   - message: The original message that was signed
+//   - signatureHex: Hex-encoded Ed25519 signature
+//
+// Returns:
+//   - error: nil if verification succeeds, appropriate error otherwise
+func VerifyP2PSignature(publicKeyHex string, message string, signatureHex string) error {
+	// Decode hex strings
+	signatureBytes, err := hex.DecodeString(signatureHex)
+	if err != nil {
+		return fmt.Errorf("failed to decode signature hex: %w", err)
+	}
+
+	// Parse public key from hex string
+	publicKey, err := ed25519PubKeyFromStringFn(publicKeyHex)
+	if err != nil {
+		return fmt.Errorf("failed to parse public key: %w", err)
+	}
+
+	// Get the underlying Ed25519 public key
+	ed25519PubKey, ok := publicKey.Underlying().(ed25519.PublicKey)
+	if !ok {
+		return fmt.Errorf("public key is not Ed25519")
+	}
+
+	// Verify the signature using DefraDB's crypto package
+	err = crypto.VerifyEd25519(ed25519PubKey, []byte(message), signatureBytes)
+	if err != nil {
+		return fmt.Errorf("signature verification failed: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/signer/signer.go
+++ b/pkg/signer/signer.go
@@ -1,97 +1,31 @@
 package signer
 
 import (
-	"bytes"
 	"crypto/ed25519"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
-	libp2pcrypto "github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/defradb"
 	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/crypto"
-	"github.com/sourcenetwork/defradb/keyring"
 	"github.com/sourcenetwork/defradb/node"
 )
 
-const (
-	keyFileName         string = "defra_identity.key"
-	nodeIdentityKeyName string = "node-identity-key"
-)
+const keyFileName string = "defra_identity.key"
 
-// Function variables for dependency injection in tests.
+// Function variables for dependency injection in tests. Keyring access and
+// libp2p key derivation now route through pkg/defradb, so the signer-local
+// shims for those have been removed. The two left below cover the load-flow
+// orchestration and ed25519 public-key parsing in the verifier.
 var (
-	loadIdentityFromStoreFn    = loadIdentityFromStore
-	createLibP2PKeyFromIdentFn = createLibP2PKeyFromIdentity
-	identityFromPrivateKeyFn   = identity.FromPrivateKey
-	generateEd25519KeyFn       = libp2pcrypto.GenerateEd25519Key
-	ed25519PubKeyFromStringFn  = func(hex string) (crypto.PublicKey, error) {
+	loadIdentityFromStoreFn   = loadIdentityFromStore
+	ed25519PubKeyFromStringFn = func(hex string) (crypto.PublicKey, error) {
 		return crypto.PublicKeyFromString(crypto.KeyTypeEd25519, hex)
 	}
 )
-
-// openKeyring opens a keyring from the config, if available.
-// Returns nil if keyring is not configured or cannot be opened.
-func openKeyring(cfg *defradb.Config) (keyring.Keyring, error) {
-	if cfg == nil || cfg.DefraDB.KeyringSecret == "" {
-		return nil, nil
-	}
-
-	// Use file-based keyring (default for DefraDB)
-	// Keyring path defaults to "keys" directory in store path, or "keys" in current dir
-	keyringPath := filepath.Join(cfg.DefraDB.Store.Path, "keys")
-	if cfg.DefraDB.Store.Path == "" {
-		keyringPath = "keys"
-	}
-
-	// Ensure directory exists
-	if err := os.MkdirAll(keyringPath, 0755); err != nil {
-		return nil, fmt.Errorf("failed to create keyring directory: %w", err)
-	}
-
-	secret := []byte(cfg.DefraDB.KeyringSecret)
-	return keyring.OpenFileKeyring(keyringPath, secret)
-}
-
-// loadIdentityFromKeyring loads the DefraDB identity from the keyring.
-func loadIdentityFromKeyring(kr keyring.Keyring) (identity.FullIdentity, error) {
-	identityBytes, err := kr.Get(nodeIdentityKeyName)
-	if err != nil {
-		if errors.Is(err, keyring.ErrNotFound) {
-			return nil, fmt.Errorf("node identity not found in keyring")
-		}
-		return nil, fmt.Errorf("failed to get identity from keyring: %w", err)
-	}
-
-	// Parse the format: "keyType:rawKeyBytes"
-	sepPos := bytes.Index(identityBytes, []byte(":"))
-	if sepPos == -1 {
-		// Old format without key type prefix, assume secp256k1
-		identityBytes = append([]byte(crypto.KeyTypeSecp256k1+":"), identityBytes...)
-		sepPos = len(crypto.KeyTypeSecp256k1)
-	}
-
-	keyType := string(identityBytes[:sepPos])
-	keyBytes := identityBytes[sepPos+1:]
-
-	// Reconstruct private key from bytes
-	privateKey, err := crypto.PrivateKeyFromBytes(crypto.KeyType(keyType), keyBytes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to reconstruct private key: %w", err)
-	}
-
-	// Reconstruct identity from private key
-	fullIdentity, err := identityFromPrivateKeyFn(privateKey)
-	if err != nil {
-		return nil, fmt.Errorf("failed to reconstruct identity from private key: %w", err)
-	}
-
-	return fullIdentity, nil
-}
 
 // loadIdentityFromFile loads the DefraDB identity from a file.
 func loadIdentityFromFile(storePath string) (identity.FullIdentity, error) {
@@ -116,7 +50,7 @@ func loadIdentityFromFile(storePath string) (identity.FullIdentity, error) {
 	}
 
 	// Reconstruct identity from private key
-	fullIdentity, err := identityFromPrivateKeyFn(privateKey)
+	fullIdentity, err := identity.FromPrivateKey(privateKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to reconstruct identity from private key: %w", err)
 	}
@@ -124,59 +58,22 @@ func loadIdentityFromFile(storePath string) (identity.FullIdentity, error) {
 	return fullIdentity, nil
 }
 
-// loadIdentityFromStore loads the DefraDB identity, trying keyring first, then falling back to file.
+// loadIdentityFromStore loads the DefraDB identity, trying the keyring first
+// (via pkg/defradb's shared helpers) and falling back to the file-based store
+// if the keyring is unconfigured, missing the entry, or unreadable. The keyring
+// path is the modern DefraDB default; the file fallback supports older
+// installations that pre-date keyring storage.
 func loadIdentityFromStore(cfg *defradb.Config, storePath string) (identity.FullIdentity, error) {
-	// Try keyring first if config is available
 	if cfg != nil {
-		kr, err := openKeyring(cfg)
-		if err == nil && kr != nil {
-			identity, err := loadIdentityFromKeyring(kr)
-			if err == nil {
-				return identity, nil
+		if kr, err := defradb.OpenKeyring(cfg); err == nil {
+			if id, err := defradb.LoadIdentityFromKeyring(kr); err == nil {
+				if full, ok := id.(identity.FullIdentity); ok {
+					return full, nil
+				}
 			}
-			// If keyring fails, fall through to file-based
 		}
 	}
-
-	// Fall back to file-based storage
 	return loadIdentityFromFile(storePath)
-}
-
-// createLibP2PKeyFromIdentity creates a LibP2P private key from a DefraDB identity.
-// This ensures the LibP2P peer ID is deterministically derived from the same identity.
-func createLibP2PKeyFromIdentity(nodeIdentity identity.Identity) (libp2pcrypto.PrivKey, error) {
-	// Cast to FullIdentity to access private key
-	fullIdentity, ok := nodeIdentity.(identity.FullIdentity)
-	if !ok {
-		return nil, fmt.Errorf("identity is not a FullIdentity, cannot extract private key")
-	}
-
-	// Get the private key from the identity
-	privateKey := fullIdentity.PrivateKey()
-	if privateKey == nil {
-		return nil, fmt.Errorf("failed to get private key from identity")
-	}
-
-	// Get raw key bytes
-	keyBytes := privateKey.Raw()
-	if len(keyBytes) == 0 {
-		return nil, fmt.Errorf("private key has no raw bytes")
-	}
-
-	// DefraDB expects Ed25519 keys, but DefraDB identities use secp256k1
-	// We need to derive an Ed25519 key deterministically from the secp256k1 key
-	// Use the secp256k1 key bytes as seed for Ed25519 key generation
-	if len(keyBytes) != 32 {
-		return nil, fmt.Errorf("expected 32-byte secp256k1 key, got %d bytes", len(keyBytes))
-	}
-
-	// Generate Ed25519 key from secp256k1 seed
-	libp2pPrivKey, _, err := generateEd25519KeyFn(strings.NewReader(string(keyBytes)))
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate Ed25519 key from identity seed: %w", err)
-	}
-
-	return libp2pPrivKey, nil
 }
 
 // getStorePath attempts to determine the store path from the config or node.
@@ -254,7 +151,7 @@ func SignWithP2PKeys(message string, defraNode *node.Node, cfg *defradb.Config) 
 	}
 
 	// Create LibP2P private key from the identity
-	libp2pPrivKey, err := createLibP2PKeyFromIdentFn(fullIdentity)
+	libp2pPrivKey, err := defradb.CreateLibP2PKeyFromIdentity(fullIdentity)
 	if err != nil {
 		return "", fmt.Errorf("failed to create LibP2P key from identity: %w", err)
 	}
@@ -328,7 +225,7 @@ func GetP2PPublicKey(defraNode *node.Node, cfg *defradb.Config) (string, error) 
 	}
 
 	// Create LibP2P private key from the identity
-	libp2pPrivKey, err := createLibP2PKeyFromIdentFn(fullIdentity)
+	libp2pPrivKey, err := defradb.CreateLibP2PKeyFromIdentity(fullIdentity)
 	if err != nil {
 		return "", fmt.Errorf("failed to create LibP2P key from identity: %w", err)
 	}

--- a/pkg/snapshot/importer.go
+++ b/pkg/snapshot/importer.go
@@ -11,7 +11,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/logger"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/crypto"
 	"github.com/sourcenetwork/defradb/node"

--- a/pkg/snapshot/importer_test.go
+++ b/pkg/snapshot/importer_test.go
@@ -12,8 +12,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/defra"
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/logger"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/defradb"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/crypto"
 	"github.com/stretchr/testify/require"
@@ -667,7 +667,7 @@ func TestImportWithVerification_HappyPath(t *testing.T) {
 		BlockSigMerkleRoots: headerRoots,
 	})
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 
 	result, err := ImportWithVerification(ctx, defraNode, path, sig)
@@ -697,7 +697,7 @@ func TestImportWithVerification_HappyPathWithMatchingSigBlockRoots(t *testing.T)
 		BlockSigMerkleRoots: headerRoots,
 	})
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 
 	result, err := ImportWithVerification(ctx, defraNode, path, sig)
@@ -731,7 +731,7 @@ func TestImportWithVerification_HappyPathWithFieldMappings(t *testing.T) {
 		},
 	})
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 
 	result, err := ImportWithVerification(ctx, defraNode, path, sig)
@@ -810,7 +810,7 @@ func TestComputeSnapshotMerkleRoot_FiveRoots(t *testing.T) {
 func TestRebuildAllIndexes_EmptyCollections(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 
 	// Empty collections list should succeed without doing anything.
@@ -821,7 +821,7 @@ func TestRebuildAllIndexes_EmptyCollections(t *testing.T) {
 func TestRebuildAllIndexes_NonexistentCollection(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 
 	err = RebuildAllIndexes(ctx, defraNode, []string{"nonexistent_collection"})

--- a/pkg/view/lens_functions_test.go
+++ b/pkg/view/lens_functions_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/defra"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/defradb"
 	"github.com/shinzonetwork/viewbundle-go"
 	"github.com/stretchr/testify/require"
 )
@@ -16,7 +16,7 @@ import (
 // TestSetupLensInDefraDB_NoLenses tests when view has no lenses
 func TestSetupLensInDefraDB_NoLenses(t *testing.T) {
 	ctx := context.Background()
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -39,7 +39,7 @@ func TestSetupLensInDefraDB_NoLenses(t *testing.T) {
 // TestSetupLensInDefraDB_WithLenses tests lens setup with valid lenses
 func TestSetupLensInDefraDB_WithLenses(t *testing.T) {
 	ctx := context.Background()
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -403,7 +403,7 @@ func TestIsValidWASM_TooShort(t *testing.T) {
 // TestConfigureLens_WithoutLensCID tests view configuration without lens CID
 func TestConfigureLens_WithoutLensCID(t *testing.T) {
 	ctx := context.Background()
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -427,7 +427,7 @@ func TestConfigureLens_WithoutLensCID(t *testing.T) {
 // TestConfigureLens_WithLensCID tests view configuration with lens CID
 func TestConfigureLens_WithLensCID(t *testing.T) {
 	ctx := context.Background()
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 

--- a/pkg/view/viewManager.go
+++ b/pkg/view/viewManager.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/logger"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/constants"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/server"
 	"github.com/sourcenetwork/defradb/client"
@@ -284,7 +284,7 @@ func (vm *ViewManager) RegisterView(ctx context.Context, v *View) (err error) {
 
 // subscribeToSourceCollection subscribes to a source collection for real-time document updates
 func (vm *ViewManager) subscribeToSourceCollection(ctx context.Context, collectionName, viewName string) error {
-	// Implementation would use defra.Subscribe to listen for new documents
+	// Implementation would use defradb.Subscribe to listen for new documents
 	// and trigger view processing when source documents arrive
 	logger.Sugar.Infof("View %s subscribed to source collection %s", viewName, collectionName)
 	return nil

--- a/pkg/view/viewManager_test.go
+++ b/pkg/view/viewManager_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/defra"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/defradb"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/server"
 	"github.com/shinzonetwork/viewbundle-go"
 	"github.com/sourcenetwork/defradb/node"
@@ -14,7 +14,7 @@ import (
 func TestNewViewManager(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -31,7 +31,7 @@ func TestNewViewManager(t *testing.T) {
 func TestViewManager_GetActiveViewNames_Empty(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -44,7 +44,7 @@ func TestViewManager_GetActiveViewNames_Empty(t *testing.T) {
 func TestViewManager_GetViewCount_Empty(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -57,7 +57,7 @@ func TestViewManager_GetViewCount_Empty(t *testing.T) {
 func TestViewManager_LoadAndRegisterViews_NoViews(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -184,7 +184,7 @@ func TestView_BuildLensConfig(t *testing.T) {
 func TestViewManager_RegisterView_AlreadyExists(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -251,7 +251,7 @@ func MockViewManager(defraNode *node.Node, registryPath string) *ViewManager {
 func TestViewManager_SetMetricsCallback(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -280,7 +280,7 @@ func TestViewManager_SetMetricsCallback(t *testing.T) {
 func TestViewManager_QueueView(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -311,7 +311,7 @@ func TestViewManager_QueueView(t *testing.T) {
 func TestViewManager_LoadAndRegisterViews_ExternalViews(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -355,7 +355,7 @@ func TestViewManager_LoadAndRegisterViews_ExternalViews(t *testing.T) {
 func TestViewManager_LoadAndRegisterViews_ViewWithoutLenses(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -390,7 +390,7 @@ func TestViewManager_LoadAndRegisterViews_ViewWithoutLenses(t *testing.T) {
 func TestViewManager_RegisterView_ValidationFailure(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -414,7 +414,7 @@ func TestViewManager_RegisterView_ValidationFailure(t *testing.T) {
 func TestViewManager_RegisterView_QueryCorrection(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -482,7 +482,7 @@ func TestSuggestCorrectCollection(t *testing.T) {
 func TestViewManager_SubscribeToSourceCollection(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -521,7 +521,7 @@ func TestExtractWasmURLsFromViews_MixedURLs(t *testing.T) {
 func TestViewManager_LoadAndRegisterViews_Deduplication(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -574,7 +574,7 @@ func TestViewManager_LoadAndRegisterViews_Deduplication(t *testing.T) {
 func TestViewManager_RegisterView_WithBase64WASM(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -606,7 +606,7 @@ func TestViewManager_RegisterView_WithBase64WASM(t *testing.T) {
 func TestViewManager_RegisterView_CollectionNameCorrection(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -636,7 +636,7 @@ func TestViewManager_RegisterView_CollectionNameCorrection(t *testing.T) {
 func TestViewManager_Integration_CompleteFlow(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -730,7 +730,7 @@ func TestExtractCollectionFromQuery_ComplexQueries(t *testing.T) {
 func TestViewManager_RegisterView_NoLenses(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -763,7 +763,7 @@ func TestViewManager_RegisterView_NoLenses(t *testing.T) {
 func TestViewManager_RegisterView_WithFileURLs(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -792,7 +792,7 @@ func TestViewManager_RegisterView_WithFileURLs(t *testing.T) {
 func TestViewManager_LoadAndRegisterViews_LocalRegistryError(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -811,7 +811,7 @@ func TestViewManager_LoadAndRegisterViews_LocalRegistryError(t *testing.T) {
 func TestViewManager_ConcurrentAccess(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 
@@ -842,7 +842,7 @@ func TestViewManager_ConcurrentAccess(t *testing.T) {
 func TestViewManager_MetricsCallbackError(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 

--- a/pkg/view/view_test.go
+++ b/pkg/view/view_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/shinzonetwork/shinzo-app-sdk/pkg/defra"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/defradb"
 	"github.com/shinzonetwork/viewbundle-go"
 	"github.com/stretchr/testify/require"
 )
@@ -25,7 +25,7 @@ func TestView_SubscribeTo(t *testing.T) {
 	}
 
 	// Create a mock DefraDB node
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 	defer defraNode.Close(ctx)
 


### PR DESCRIPTION
## Description                                                                                 
                                                                                           
Removes shinzo-app-sdk dependency from the host. Inlines the four packages host consumes (pkg/logger, pkg/defradb, pkg/pruner, pkg/signer), switches all imports, drops the SDK from go.mod.                                                                                                                                                         
                                                                                              
## Changes                                                   

  - Inline pkg/logger (drop unused LogError).
  - Inline pkg/defradb (drop unused event_manager.go, optimized_client.go, connection_pool.go, SchemaApplierFromFile; absorb GetLANIP; slim config to fields actually used). 
  - Inline pkg/pruner (drop IndexerQueue; extract shared docID codec into docid_codec.go for EventQueue).
  - Inline pkg/signer (verbatim, *config.Config retyped to *defradb.Config).
  - Switch 32 host source files from shinzo-app-sdk to local imports. Rename ToAppConfig to ToInternalConfig.                                                                           
  - go mod tidy: drops shinzo-app-sdk and transitive joho/godotenv.                           

## Steps to Test

  1. Pull branch.                                                                             
  2. go build ./... && go build -tags integration ./integration/...
  3. go test -count=1 -short ./... (9 packages, all should pass).                             
  4. grep -rn shinzo-app-sdk --include='*.go' --include='*.mod' --include='*.sum' . should return nothing.

## Checklist
- [x] Code compiles / runs
- [x] Tests added / updated
- [x] Documentation updated if needed
- [x] PR is self-contained and focused
- [x] Code does not break any existing features
- [x] Code passes personal internal testing
