### PR TITLE
NewActions: release + multi network

### DIFF
--- a/.github/workflows/build-develop-images.yml
+++ b/.github/workflows/build-develop-images.yml
@@ -1,0 +1,67 @@
+name: Build develop images
+
+on:
+  push:
+    branches:
+      - develop
+      - develop-*-*
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-image:
+    name: Build image from branch
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Extract chain and network from branch name
+        id: meta
+        run: |
+          BRANCH="${{ github.ref_name }}"
+          if [[ "$BRANCH" == "develop" ]]; then
+            echo "chain=base" >> $GITHUB_OUTPUT
+            echo "network=mainnet" >> $GITHUB_OUTPUT
+          else
+            SUFFIX="${BRANCH#develop-}"
+            NETWORK="${SUFFIX##*-}"
+            CHAIN="${SUFFIX%-*}"
+            echo "chain=$CHAIN" >> $GITHUB_OUTPUT
+            echo "network=$NETWORK" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Get short SHA
+        id: short_sha
+        run: echo "sha=$(echo $GITHUB_SHA | cut -c1-7)" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:develop-${{ steps.meta.outputs.chain }}-${{ steps.meta.outputs.network }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:develop-${{ steps.meta.outputs.chain }}-${{ steps.meta.outputs.network }}-sha-${{ steps.short_sha.outputs.sha }}
+          build-args: |
+            CHAIN=${{ steps.meta.outputs.chain }}
+            NETWORK=${{ steps.meta.outputs.network }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*-*-*'  # matches v0.6.4-ethereum-mainnet, v1.0.0-polygon-testnet, etc.
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+      - run: make build
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+      - run: make build
+
+      - name: Extract chain and network from tag
+        id: meta
+        run: |
+          TAG="${{ github.ref_name }}"
+          SUFFIX="${TAG#v*.*.*-}"
+          NETWORK="${SUFFIX##*-}"
+          CHAIN="${SUFFIX%-*}"
+          echo "chain=$CHAIN" >> $GITHUB_OUTPUT
+          echo "network=$NETWORK" >> $GITHUB_OUTPUT
+
+      - name: Build and push Docker image
+        run: |
+          docker build -t ghcr.io/${{ github.repository }}:${{ github.ref_name }} \
+                       -t ghcr.io/${{ github.repository }}:${{ steps.meta.outputs.chain }}-${{ steps.meta.outputs.network }}-latest \
+                       --build-arg CHAIN=${{ steps.meta.outputs.chain }} \
+                       --build-arg NETWORK=${{ steps.meta.outputs.network }} .
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+          docker push ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+          docker push ghcr.io/${{ github.repository }}:${{ steps.meta.outputs.chain }}-${{ steps.meta.outputs.network }}-latest
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          files: bin/host
+          generate_release_notes: true
+          tag_name: ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description
PR ports the actions from indexer to the host. Actions are used to make new images when a branch is merged into develop or develop-*. Action for generating release notes when a tag "v*" is used.

## Changes
- new action for building images and tagging with branch name
- new action for a release

## Related Issue
https://github.com/shinzonetwork/shinzo-host-client/issues/213


## Checklist
- [x] Code compiles / runs
- [x] Tests added / updated
- [x] Documentation updated if needed
- [x] PR is self-contained and focused
- [x] Code does not break any existing features
- [x] Code passes personal internal testing
