### PR TITLE
Fmt/linter v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,67 @@
+version: "2"
+run:
+  timeout: 5m
+  modules-download-mode: readonly
+linters:
+  default: standard
+  enable:
+    - bodyclose
+    - canonicalheader
+    - containedctx
+    - contextcheck
+    - dogsled
+    - dupl
+    - dupword
+    - embeddedstructfieldcheck
+    - err113
+    - errcheck
+    - errname
+    - errorlint
+    - exhaustive
+    - exptostd
+    - funlen
+    - gocheckcompilerdirectives
+    - gochecknoglobals
+    - goconst
+    - gocritic
+    - godoclint
+    - godot
+    - gosec
+    - govet
+    - importas
+    - inamedparam
+    - ineffassign
+    - loggercheck
+    - misspell
+    - mnd
+    - modernize
+    - nilerr
+    - nilnil
+    - revive
+    - staticcheck
+    - tagalign
+    - unconvert
+    - unused
+    - wastedassign
+  settings:
+    funlen:
+      lines: 100
+    revive:
+      enable-default-rules: true
+      rules:
+        - name: package-comments
+          disabled: true
+  exclusions:
+    rules:
+      # Exclude some linters from running on tests files.
+      - path: _test\.go
+        linters:
+          - containedctx
+          - dupl
+          - gochecknoglobals
+          - mnd
+          - funlen
+
+formatters:
+  enable:
+    - gofumpt

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-playground build-branchable build-branchable-with-playground start deps-playground
+.PHONY: build build-playground build-branchable build-branchable-with-playground start deps-playground lint lint-fix
 
 build:
 	go build -o bin/host cmd/main.go
@@ -20,3 +20,11 @@ deps-playground:
 # Build with both branchable tag and playground enabled
 build-branchable-with-playground: deps-playground
 	go build -tags "branchable,hostplayground" -o bin/host cmd/main.go
+
+lint:
+	@echo "🔍 Running golangci-lint..."
+	@golangci-lint run ./...
+
+lint-fix:
+	@echo "🔧 Running golangci-lint with auto-fix..."
+	@golangci-lint run --fix ./...

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -30,15 +30,15 @@ func main() {
 	configPath := findConfigFile()
 	cfg, err := config.LoadConfig(configPath)
 	if err != nil {
-		panic(fmt.Errorf("Unable to load config: %v", err))
+		panic(fmt.Errorf("unable to load config: %w", err))
 	}
 
 	myHost, err := host.StartHosting(cfg)
 	if err != nil {
-		panic(fmt.Errorf("Failed to start hosting: %v", err))
+		panic(fmt.Errorf("failed to start hosting: %w", err))
 	}
 
-	defer myHost.Close(context.Background())
+	defer func() { _ = myHost.Close(context.Background()) }()
 
 	for {
 		time.Sleep(1 * time.Second) // Run forever unless stopped

--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -11,9 +12,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// CollectionName is the name of the collection where we store Shinzo-specific documents in DefraDB.
 const CollectionName = "shinzo"
 
-// DefraDBP2PConfig represents P2P configuration for DefraDB
+// DefraDBP2PConfig represents P2P configuration for DefraDB.
 type DefraDBP2PConfig struct {
 	Enabled                bool     `yaml:"enabled"`
 	BootstrapPeers         []string `yaml:"bootstrap_peers"`
@@ -25,7 +27,7 @@ type DefraDBP2PConfig struct {
 	PeerDiscoveryTimeoutMs int      `yaml:"peer_discovery_timeout_ms"` // Timeout for auto-discovering peer IDs (default: 10000)
 }
 
-// DefraDBStoreConfig represents store configuration for DefraDB
+// DefraDBStoreConfig represents store configuration for DefraDB.
 type DefraDBStoreConfig struct {
 	Path string `yaml:"path"`
 	// Badger memory configuration
@@ -40,19 +42,20 @@ type DefraDBStoreConfig struct {
 	ValueLogFileSizeMB int64 `yaml:"value_log_file_size_mb"`
 }
 
-// DefraDBConfig represents DefraDB configuration
+// DefraDBConfig represents DefraDB configuration.
 type DefraDBConfig struct {
-	Url           string             `yaml:"url"`
+	URL           string             `yaml:"url"`
 	KeyringSecret string             `yaml:"keyring_secret"`
 	P2P           DefraDBP2PConfig   `yaml:"p2p"`
 	Store         DefraDBStoreConfig `yaml:"store"`
 }
 
-// LoggerConfig represents logger configuration
+// LoggerConfig represents logger configuration.
 type LoggerConfig struct {
 	Development bool `yaml:"development"`
 }
 
+// Config represents the overall configuration for the Shinzo host application, including DefraDB, Shinzo-specific settings, logging, hosting, and pruning.
 type Config struct {
 	DefraDB    DefraDBConfig `yaml:"defradb"`
 	Shinzo     ShinzoConfig  `yaml:"shinzo"`
@@ -61,6 +64,7 @@ type Config struct {
 	Pruner     pruner.Config `yaml:"pruner"`
 }
 
+// ShinzoConfig represents configuration specific to the Shinzo host application.
 type ShinzoConfig struct {
 	MinimumAttestations int    `yaml:"minimum_attestations"`
 	HubBaseURL          string `yaml:"hub_base_url"`
@@ -130,6 +134,7 @@ type BlockRangeFilter struct {
 	MaxBlock uint64 `yaml:"max_block"` // Maximum block number (inclusive), 0 = no upper limit
 }
 
+// HostConfig represents configuration specific to the Shinzo host application.
 type HostConfig struct {
 	LensRegistryPath   string         `yaml:"lens_registry_path"`    // At this path, we will store the lens' wasm files
 	HealthServerPort   int            `yaml:"health_server_port"`    // Port for the health server (default: 8080)
@@ -153,10 +158,10 @@ type BlockRange struct {
 	End   int64 `yaml:"end"`
 }
 
-// LoadConfig loads configuration from a YAML file
+// LoadConfig loads configuration from a YAML file.
 func LoadConfig(path string) (*Config, error) {
 	// Load YAML config
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(filepath.Clean(path)) //nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to read config file: %w", err)
 	}
@@ -190,7 +195,7 @@ func (c *Config) ToAppConfig() *appConfig.Config {
 
 	return &appConfig.Config{
 		DefraDB: appConfig.DefraDBConfig{
-			Url:           c.DefraDB.Url,
+			URL:           c.DefraDB.URL,
 			KeyringSecret: c.DefraDB.KeyringSecret,
 			P2P: appConfig.DefraP2PConfig{
 				Enabled:             c.DefraDB.P2P.Enabled,

--- a/config/config.go
+++ b/config/config.go
@@ -195,7 +195,7 @@ func (c *Config) ToInternalConfig() *defradb.Config {
 	}
 
 	return &defradb.Config{
-		DefraDB: appConfig.DefraDBConfig{
+		DefraDB: defradb.DefraDBConfig{
 			URL:           c.DefraDB.URL,
 			KeyringSecret: c.DefraDB.KeyringSecret,
 			P2P: defradb.DefraP2PConfig{

--- a/config/config.go
+++ b/config/config.go
@@ -161,7 +161,7 @@ type BlockRange struct {
 // LoadConfig loads configuration from a YAML file.
 func LoadConfig(path string) (*Config, error) {
 	// Load YAML config
-	data, err := os.ReadFile(filepath.Clean(path)) //nolint:gosec
+	data, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read config file: %w", err)
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -27,7 +27,7 @@ shinzohub:
   rpc_url: "some url"
 `
 
-	err := os.WriteFile(configPath, []byte(configContent), 0644)
+	err := os.WriteFile(configPath, []byte(configContent), 0o600)
 	if err != nil {
 		t.Fatalf("Failed to write test config file: %v", err)
 	}
@@ -37,10 +37,10 @@ shinzohub:
 		t.Fatalf("LoadConfig failed: %v", err)
 	}
 
-	expectedUrl := "http://localhost:9181"
+	expectedURL := "http://localhost:9181"
 	// Test DefraDB config
-	if cfg.DefraDB.Url != expectedUrl {
-		t.Errorf("Expected url '%s', got '%s'", expectedUrl, cfg.DefraDB.Url)
+	if cfg.DefraDB.URL != expectedURL {
+		t.Errorf("Expected url '%s', got '%s'", expectedURL, cfg.DefraDB.URL)
 	}
 
 	// Test P2P config
@@ -59,14 +59,14 @@ defradb:
   keyring_secret: "original_secret"
 `
 
-	err := os.WriteFile(configPath, []byte(configContent), 0644)
+	err := os.WriteFile(configPath, []byte(configContent), 0o600)
 	if err != nil {
 		t.Fatalf("Failed to write test config file: %v", err)
 	}
 
 	// Set environment variables
-	os.Setenv("DEFRA_KEYRING_SECRET", "env_secret")
-	defer os.Unsetenv("DEFRA_KEYRING_SECRET")
+	_ = os.Setenv("DEFRA_KEYRING_SECRET", "env_secret")
+	defer func() { _ = os.Unsetenv("DEFRA_KEYRING_SECRET") }()
 
 	cfg, err := LoadConfig(configPath)
 	if err != nil {
@@ -85,7 +85,7 @@ func TestLoadConfig_EmptyConfig(t *testing.T) {
 
 	configContent := `{}`
 
-	err := os.WriteFile(configPath, []byte(configContent), 0644)
+	err := os.WriteFile(configPath, []byte(configContent), 0o600)
 	if err != nil {
 		t.Fatalf("Failed to write test config file: %v", err)
 	}
@@ -118,7 +118,7 @@ shinzo:
   minimum_attestations: "invalid yaml
 `
 
-	err := os.WriteFile(configPath, []byte(invalidContent), 0644)
+	err := os.WriteFile(configPath, []byte(invalidContent), 0o600)
 	if err != nil {
 		t.Fatalf("Failed to write test config file: %v", err)
 	}
@@ -132,7 +132,7 @@ shinzo:
 func TestToAppConfig(t *testing.T) {
 	cfg := &Config{
 		DefraDB: DefraDBConfig{
-			Url:           "localhost:9181",
+			URL:           "localhost:9181",
 			KeyringSecret: "secret123",
 			P2P: DefraDBP2PConfig{
 				Enabled:             true,
@@ -161,7 +161,7 @@ func TestToAppConfig(t *testing.T) {
 
 	appCfg := cfg.ToAppConfig()
 	require.NotNil(t, appCfg)
-	require.Equal(t, "localhost:9181", appCfg.DefraDB.Url)
+	require.Equal(t, "localhost:9181", appCfg.DefraDB.URL)
 	require.Equal(t, "secret123", appCfg.DefraDB.KeyringSecret)
 	require.True(t, appCfg.DefraDB.P2P.Enabled)
 	// Bootstrap peers should be empty (added after ViewManager init)
@@ -192,7 +192,7 @@ func TestLoadConfig_StartHeightEnvOverride(t *testing.T) {
 	tempDir := t.TempDir()
 	configPath := filepath.Join(tempDir, "config.yaml")
 
-	err := os.WriteFile(configPath, []byte("shinzo:\n  start_height: 100\n"), 0644)
+	err := os.WriteFile(configPath, []byte("shinzo:\n  start_height: 100\n"), 0o600)
 	require.NoError(t, err)
 
 	t.Setenv("START_HEIGHT", "500")
@@ -206,7 +206,7 @@ func TestLoadConfig_InvalidStartHeightEnv(t *testing.T) {
 	tempDir := t.TempDir()
 	configPath := filepath.Join(tempDir, "config.yaml")
 
-	err := os.WriteFile(configPath, []byte("shinzo:\n  start_height: 100\n"), 0644)
+	err := os.WriteFile(configPath, []byte("shinzo:\n  start_height: 100\n"), 0o600)
 	require.NoError(t, err)
 
 	t.Setenv("START_HEIGHT", "not_a_number")
@@ -220,7 +220,7 @@ func TestLoadConfig_BootstrapPeersEnvOverride(t *testing.T) {
 	tempDir := t.TempDir()
 	configPath := filepath.Join(tempDir, "config.yaml")
 
-	err := os.WriteFile(configPath, []byte("defradb:\n  p2p:\n    bootstrap_peers: []\n"), 0644)
+	err := os.WriteFile(configPath, []byte("defradb:\n  p2p:\n    bootstrap_peers: []\n"), 0o600)
 	require.NoError(t, err)
 
 	t.Setenv("BOOTSTRAP_PEERS", "peer1,peer2,peer3")

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/multiformats/go-multiaddr v0.16.1
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/rs/zerolog v1.34.0
-	github.com/shinzonetwork/shinzo-app-sdk v0.0.0-20260324214239-d756a4069836
+	github.com/shinzonetwork/shinzo-app-sdk v0.0.0-20260430194334-0d2dccd5c632
 	github.com/shinzonetwork/shinzo-indexer-client v0.0.0-20251219184827-5722330739e8
 	github.com/shinzonetwork/viewbundle-go v0.1.1
 	github.com/sourcenetwork/corelog v0.0.8

--- a/go.sum
+++ b/go.sum
@@ -2251,8 +2251,8 @@ github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNX
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/shazow/go-diff v0.0.0-20160112020656-b6b7b6733b8c/go.mod h1:/PevMnwAxekIXwN8qQyfc5gl2NlkB3CQlkizAbOkeBs=
-github.com/shinzonetwork/shinzo-app-sdk v0.0.0-20260324214239-d756a4069836 h1:4JTkSBJ9LymwuSO6QK4MCAcJ9t1UINmUWMftdVJE4hU=
-github.com/shinzonetwork/shinzo-app-sdk v0.0.0-20260324214239-d756a4069836/go.mod h1:jPCm2FVOLt3u6McMDxaE37Jputno2iIFxxJzc4bx8Q4=
+github.com/shinzonetwork/shinzo-app-sdk v0.0.0-20260430194334-0d2dccd5c632 h1:YJnKYJM/50EWgM/Nq/WeLWpSepM5Effdxyn85coxFHc=
+github.com/shinzonetwork/shinzo-app-sdk v0.0.0-20260430194334-0d2dccd5c632/go.mod h1:jPCm2FVOLt3u6McMDxaE37Jputno2iIFxxJzc4bx8Q4=
 github.com/shinzonetwork/shinzo-indexer-client v0.0.0-20251219184827-5722330739e8 h1:g+7aGWLyrrFFHWq7mch0b0Af2YXCNKR2xOTQ/Ed/z70=
 github.com/shinzonetwork/shinzo-indexer-client v0.0.0-20251219184827-5722330739e8/go.mod h1:IpuhmHiO6IYcutRGG+c1vvUvxYb2c8yqB1eyHOdXx3c=
 github.com/shinzonetwork/viewbundle-go v0.1.1 h1:GTSh7bYHqEzZSSJHAySdaciLDq+TyvBwY6jmyX9udYk=

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -33,7 +33,7 @@ func TestIntegration(t *testing.T) {
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
 	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0" // Use random available port
-	testConfig.DefraDB.Url = "localhost:0"
+	testConfig.DefraDB.URL = "localhost:0"
 	testConfig.DefraDB.KeyringSecret = "integration-test-secret"
 	testConfig.DefraDB.P2P.Enabled = true
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{

--- a/pkg/attestation/attestationRecordService.go
+++ b/pkg/attestation/attestationRecordService.go
@@ -202,7 +202,7 @@ func lookupExistingAttestation(ctx context.Context, defraNode *node.Node, col cl
 
 	docIDStr := extractDocIDFromResult(result.GQL.Data, constants.CollectionAttestationRecord)
 	if docIDStr == "" {
-		return &client.Document{}, nil
+		return nil, nil // was &client.Document{} — this caused the bug
 	}
 
 	docID, err := client.NewDocIDFromString(docIDStr)

--- a/pkg/attestation/attestationRecordService.go
+++ b/pkg/attestation/attestationRecordService.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/shinzonetwork/shinzo-host-client/pkg/defradb"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/constants"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/defradb"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/node"
 	"github.com/sourcenetwork/immutable"

--- a/pkg/attestation/attestationRecordService.go
+++ b/pkg/attestation/attestationRecordService.go
@@ -202,7 +202,7 @@ func lookupExistingAttestation(ctx context.Context, defraNode *node.Node, col cl
 
 	docIDStr := extractDocIDFromResult(result.GQL.Data, constants.CollectionAttestationRecord)
 	if docIDStr == "" {
-		return nil, ErrDocumentNotFound
+		return nil, nil // nolint:nilnil
 	}
 
 	docID, err := client.NewDocIDFromString(docIDStr)

--- a/pkg/attestation/attestationRecordService.go
+++ b/pkg/attestation/attestationRecordService.go
@@ -202,7 +202,7 @@ func lookupExistingAttestation(ctx context.Context, defraNode *node.Node, col cl
 
 	docIDStr := extractDocIDFromResult(result.GQL.Data, constants.CollectionAttestationRecord)
 	if docIDStr == "" {
-		return nil, nil // was &client.Document{} — this caused the bug
+		return nil, ErrDocumentNotFound
 	}
 
 	docID, err := client.NewDocIDFromString(docIDStr)

--- a/pkg/attestation/attestationRecordService.go
+++ b/pkg/attestation/attestationRecordService.go
@@ -3,6 +3,7 @@ package attestation
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 
@@ -13,21 +14,21 @@ import (
 	"github.com/sourcenetwork/immutable"
 )
 
-// AttestationRecord represents an attestation record with verified signatures
-type AttestationRecord = constants.AttestationRecord
+// Record represents an attestation record with verified signatures.
+type Record = constants.AttestationRecord
 
-// Version represents a version with signature information
+// Version represents a version with signature information.
 type Version = constants.Version
 
-// Signature represents a cryptographic signature
+// Signature represents a cryptographic signature.
 type Signature = constants.Signature
 
-// CreateAttestationRecord creates an attestation record after verifying signatures
-func CreateAttestationRecord(ctx context.Context, verifier SignatureVerifier, docId string, sourceDocIds []string, docType string, versions []Version, maxConcurrentVerifications int) (*AttestationRecord, error) {
+// CreateAttestationRecord creates an attestation record after verifying signatures.
+func CreateAttestationRecord(ctx context.Context, verifier SignatureVerifier, docID string, sourceDocIDs []string, docType string, versions []Version, maxConcurrentVerifications int) (*Record, error) {
 	if len(versions) == 0 {
 		return &constants.AttestationRecord{
-			AttestedDocId: docId,
-			SourceDocIds:  sourceDocIds,
+			AttestedDocID: docID,
+			SourceDocIDs:  sourceDocIDs,
 			CIDs:          []string{},
 			DocType:       docType,
 			VoteCount:     1,
@@ -65,8 +66,8 @@ func CreateAttestationRecord(ctx context.Context, verifier SignatureVerifier, do
 	}
 
 	return &constants.AttestationRecord{
-		AttestedDocId: docId,
-		SourceDocIds:  sourceDocIds,
+		AttestedDocID: docID,
+		SourceDocIDs:  sourceDocIDs,
 		CIDs:          cids,
 		DocType:       docType,
 		VoteCount:     1,
@@ -75,20 +76,20 @@ func CreateAttestationRecord(ctx context.Context, verifier SignatureVerifier, do
 
 // PostAttestationRecord posts the attestation record to DefraDB using read-modify-write
 // to correctly merge source_doc lists when multiple indexers attest to the same block.
-func PostAttestationRecord(ctx context.Context, defraNode *node.Node, record *AttestationRecord) error {
+func PostAttestationRecord(ctx context.Context, defraNode *node.Node, record *Record) error {
 	col, err := defraNode.DB.GetCollectionByName(ctx, constants.CollectionAttestationRecord)
 	if err != nil {
 		return fmt.Errorf("failed to get attestation collection: %w", err)
 	}
 
-	existingDoc, err := lookupExistingAttestation(ctx, defraNode, col, record.AttestedDocId)
+	existingDoc, err := lookupExistingAttestation(ctx, defraNode, col, record.AttestedDocID)
 	if err != nil {
 		return fmt.Errorf("failed to lookup existing attestation: %w", err)
 	}
 
 	if existingDoc != nil {
 		// Merge source_doc identities
-		mergedSources := mergeStringListField(existingDoc, "source_doc", record.SourceDocIds)
+		mergedSources := mergeStringListField(existingDoc, "source_doc", record.SourceDocIDs)
 		sourcesAny := make([]any, len(mergedSources))
 		for i, s := range mergedSources {
 			sourcesAny[i] = s
@@ -115,8 +116,8 @@ func PostAttestationRecord(ctx context.Context, defraNode *node.Node, record *At
 	}
 
 	// Create new document
-	sourceDocsAny := make([]any, len(record.SourceDocIds))
-	for i, s := range record.SourceDocIds {
+	sourceDocsAny := make([]any, len(record.SourceDocIDs))
+	for i, s := range record.SourceDocIDs {
 		sourceDocsAny[i] = s
 	}
 	cidsAny := make([]any, len(record.CIDs))
@@ -125,7 +126,7 @@ func PostAttestationRecord(ctx context.Context, defraNode *node.Node, record *At
 	}
 
 	data := map[string]any{
-		"attested_doc": record.AttestedDocId,
+		"attested_doc": record.AttestedDocID,
 		"source_doc":   sourceDocsAny,
 		"CIDs":         cidsAny,
 		"doc_type":     record.DocType,
@@ -201,7 +202,7 @@ func lookupExistingAttestation(ctx context.Context, defraNode *node.Node, col cl
 
 	docIDStr := extractDocIDFromResult(result.GQL.Data, constants.CollectionAttestationRecord)
 	if docIDStr == "" {
-		return nil, nil
+		return &client.Document{}, nil
 	}
 
 	docID, err := client.NewDocIDFromString(docIDStr)
@@ -244,7 +245,7 @@ func extractDocIDFromResult(data any, collectionName string) string {
 }
 
 // PostAttestationRecordsBatch posts multiple attestation records.
-func PostAttestationRecordsBatch(ctx context.Context, defraNode *node.Node, records []*AttestationRecord) error {
+func PostAttestationRecordsBatch(ctx context.Context, defraNode *node.Node, records []*Record) error {
 	if len(records) == 0 {
 		return nil
 	}
@@ -259,7 +260,7 @@ func PostAttestationRecordsBatch(ctx context.Context, defraNode *node.Node, reco
 		if record == nil || len(record.CIDs) == 0 {
 			continue
 		}
-		attestedDocIDs = append(attestedDocIDs, record.AttestedDocId)
+		attestedDocIDs = append(attestedDocIDs, record.AttestedDocID)
 	}
 
 	if len(attestedDocIDs) == 0 {
@@ -282,10 +283,10 @@ func PostAttestationRecordsBatch(ctx context.Context, defraNode *node.Node, reco
 			continue
 		}
 
-		existingDoc, exists := existingByAttestedDoc[record.AttestedDocId]
+		existingDoc, exists := existingByAttestedDoc[record.AttestedDocID]
 		if exists {
 			// Merge source_doc identities
-			mergedSources := mergeStringListField(existingDoc, "source_doc", record.SourceDocIds)
+			mergedSources := mergeStringListField(existingDoc, "source_doc", record.SourceDocIDs)
 			sourcesAny := make([]any, len(mergedSources))
 			for i, s := range mergedSources {
 				sourcesAny[i] = s
@@ -312,13 +313,13 @@ func PostAttestationRecordsBatch(ctx context.Context, defraNode *node.Node, reco
 			for i, cid := range record.CIDs {
 				cidsAny[i] = cid
 			}
-			sourceDocsAny := make([]any, len(record.SourceDocIds))
-			for i, s := range record.SourceDocIds {
+			sourceDocsAny := make([]any, len(record.SourceDocIDs))
+			for i, s := range record.SourceDocIDs {
 				sourceDocsAny[i] = s
 			}
 
 			data := map[string]any{
-				"attested_doc": record.AttestedDocId,
+				"attested_doc": record.AttestedDocID,
 				"source_doc":   sourceDocsAny,
 				"CIDs":         cidsAny,
 				"doc_type":     record.DocType,
@@ -327,7 +328,7 @@ func PostAttestationRecordsBatch(ctx context.Context, defraNode *node.Node, reco
 
 			doc, err := client.NewDocFromMap(ctx, data, col.Version())
 			if err != nil {
-				return fmt.Errorf("failed to create document for attestation %s: %w", record.AttestedDocId, err)
+				return fmt.Errorf("failed to create document for attestation %s: %w", record.AttestedDocID, err)
 			}
 			docs = append(docs, doc)
 		}
@@ -336,9 +337,8 @@ func PostAttestationRecordsBatch(ctx context.Context, defraNode *node.Node, reco
 	return col.SaveMany(ctx, docs)
 }
 
-// HandleDocumentAttestation is the main handler for processing document attestations
+// HandleDocumentAttestation is the main handler for processing document attestations.
 func HandleDocumentAttestation(ctx context.Context, verifier SignatureVerifier, defraNode *node.Node, docID string, docType string, versions []Version, maxConcurrentVerifications int) error {
-
 	if len(versions) == 0 {
 		return nil
 	}
@@ -358,7 +358,7 @@ func HandleDocumentAttestation(ctx context.Context, verifier SignatureVerifier, 
 	return nil
 }
 
-// DocumentAttestationInput represents input for batch attestation processing
+// DocumentAttestationInput represents input for batch attestation processing.
 type DocumentAttestationInput struct {
 	DocID    string
 	DocType  string
@@ -371,7 +371,7 @@ func HandleDocumentAttestationBatch(ctx context.Context, verifier SignatureVerif
 		return nil
 	}
 
-	records := make([]*AttestationRecord, 0, len(inputs))
+	records := make([]*Record, 0, len(inputs))
 	for _, input := range inputs {
 		if len(input.Versions) == 0 {
 			continue
@@ -391,8 +391,8 @@ func HandleDocumentAttestationBatch(ctx context.Context, verifier SignatureVerif
 	return PostAttestationRecordsBatch(ctx, defraNode, records)
 }
 
-// CheckExistingAttestation checks if an attestation already exists for a document
-func CheckExistingAttestation(ctx context.Context, defraNode *node.Node, docID string, docType string) ([]AttestationRecord, error) {
+// CheckExistingAttestation checks if an attestation already exists for a document.
+func CheckExistingAttestation(ctx context.Context, defraNode *node.Node, docID string, docType string) ([]Record, error) {
 	// Query the general attestation collection for this specific document
 	query := fmt.Sprintf(`
 		query {
@@ -407,7 +407,7 @@ func CheckExistingAttestation(ctx context.Context, defraNode *node.Node, docID s
 		}
 	`, constants.CollectionAttestationRecord, docID, docType)
 
-	existing, err := defra.QueryArray[AttestationRecord](ctx, defraNode, query)
+	existing, err := defra.QueryArray[Record](ctx, defraNode, query)
 	if err != nil {
 		if strings.Contains(err.Error(), "No attestation records found") {
 			return nil, nil // No existing attestation, not an error
@@ -418,7 +418,7 @@ func CheckExistingAttestation(ctx context.Context, defraNode *node.Node, docID s
 	return existing, nil
 }
 
-// ExtractVersionsFromDocument extracts version/signature information from a document based on its type
+// ExtractVersionsFromDocument extracts version/signature information from a document based on its type.
 func ExtractVersionsFromDocument(docData map[string]any) ([]Version, error) {
 	// Try to extract version information from the document data
 	// The document data should contain the version field with signatures
@@ -455,8 +455,8 @@ func ExtractVersionsFromDocument(docData map[string]any) ([]Version, error) {
 					}
 
 					// Extract CollectionVersionId
-					if collectionVersionId, ok := versionMap["collectionVersionId"].(string); ok {
-						version.CollectionVersionId = collectionVersionId
+					if collectionVersionID, ok := versionMap["collectionVersionId"].(string); ok {
+						version.CollectionVersionID = collectionVersionID
 					}
 
 					versions = append(versions, version)
@@ -476,22 +476,22 @@ func ExtractVersionsFromDocument(docData map[string]any) ([]Version, error) {
 // ========================================
 
 // MergeAttestationRecords merges two attestation records with the same attested document
-// This is useful when multiple sources attest to the same document and you want to combine their CIDs
-func MergeAttestationRecords(record1, record2 *AttestationRecord) (*AttestationRecord, error) {
-	if record1.AttestedDocId != record2.AttestedDocId {
-		return nil, fmt.Errorf("cannot merge records with different attested document IDs: %s vs %s", record1.AttestedDocId, record2.AttestedDocId)
+// This is useful when multiple sources attest to the same document and you want to combine their CIDs.
+func MergeAttestationRecords(record1, record2 *Record) (*Record, error) {
+	if record1.AttestedDocID != record2.AttestedDocID {
+		return nil, fmt.Errorf("%s vs %s: %w", record1.AttestedDocID, record2.AttestedDocID, ErrDifferentAttestedDocIDs)
 	}
 
 	// Merge source doc identities, avoiding duplicates
 	sourceSet := make(map[string]bool)
 	var mergedSources []string
-	for _, s := range record1.SourceDocIds {
+	for _, s := range record1.SourceDocIDs {
 		if !sourceSet[s] {
 			mergedSources = append(mergedSources, s)
 			sourceSet[s] = true
 		}
 	}
-	for _, s := range record2.SourceDocIds {
+	for _, s := range record2.SourceDocIDs {
 		if !sourceSet[s] {
 			mergedSources = append(mergedSources, s)
 			sourceSet[s] = true
@@ -499,9 +499,9 @@ func MergeAttestationRecords(record1, record2 *AttestationRecord) (*AttestationR
 	}
 
 	// Create merged record
-	merged := &AttestationRecord{
-		AttestedDocId: record1.AttestedDocId,
-		SourceDocIds:  mergedSources,
+	merged := &Record{
+		AttestedDocID: record1.AttestedDocID,
+		SourceDocIDs:  mergedSources,
 		CIDs:          make([]string, 0),
 	}
 
@@ -547,7 +547,7 @@ func IsDocumentAttestedViaBlock(ctx context.Context, defraNode *node.Node, block
 		}
 	`, constants.CollectionAttestationRecord, blockAttestedID)
 
-	records, err := defra.QueryArray[AttestationRecord](ctx, defraNode, query)
+	records, err := defra.QueryArray[Record](ctx, defraNode, query)
 	if err != nil {
 		if strings.Contains(err.Error(), "No attestation records found") {
 			return false, nil
@@ -560,10 +560,8 @@ func IsDocumentAttestedViaBlock(ctx context.Context, defraNode *node.Node, block
 	}
 
 	for _, record := range records {
-		for _, cid := range record.CIDs {
-			if cid == documentCID {
-				return true, nil
-			}
+		if slices.Contains(record.CIDs, documentCID) {
+			return true, nil
 		}
 	}
 
@@ -572,7 +570,7 @@ func IsDocumentAttestedViaBlock(ctx context.Context, defraNode *node.Node, block
 
 // GetBlockAttestations retrieves all attestation records for a specific block height.
 // With multiple indexers, different merkle roots produce separate attestation records.
-func GetBlockAttestations(ctx context.Context, defraNode *node.Node, blockNumber int64) ([]AttestationRecord, error) {
+func GetBlockAttestations(ctx context.Context, defraNode *node.Node, blockNumber int64) ([]Record, error) {
 	blockPrefix := fmt.Sprintf("block:%d:", blockNumber)
 
 	query := fmt.Sprintf(`
@@ -588,7 +586,7 @@ func GetBlockAttestations(ctx context.Context, defraNode *node.Node, blockNumber
 		}
 	`, constants.CollectionAttestationRecord, blockPrefix)
 
-	records, err := defra.QueryArray[AttestationRecord](ctx, defraNode, query)
+	records, err := defra.QueryArray[Record](ctx, defraNode, query)
 	if err != nil {
 		if strings.Contains(err.Error(), "No attestation records found") {
 			return nil, nil
@@ -603,14 +601,14 @@ func GetBlockAttestations(ctx context.Context, defraNode *node.Node, blockNumber
 // UTILITY FUNCTIONS
 // ========================================
 
-// GetAttestationRecordsByViewName queries attestation records for a specific view
-func GetAttestationRecordsByViewName(ctx context.Context, defraNode *node.Node, viewName string, viewDocIds []string) ([]AttestationRecord, error) {
+// GetAttestationRecordsByViewName queries attestation records for a specific view.
+func GetAttestationRecordsByViewName(ctx context.Context, defraNode *node.Node, viewName string, viewDocIDs []string) ([]Record, error) {
 	collectionName := fmt.Sprintf("Ethereum__Mainnet__AttestationRecord_%s", viewName)
 
-	if len(viewDocIds) > 0 {
+	if len(viewDocIDs) > 0 {
 		// Build a comma-separated list of quoted doc IDs for GraphQL _in filter
-		quoted := make([]string, 0, len(viewDocIds))
-		for _, id := range viewDocIds {
+		quoted := make([]string, 0, len(viewDocIDs))
+		for _, id := range viewDocIDs {
 			quoted = append(quoted, fmt.Sprintf("\"%s\"", id))
 		}
 		inList := strings.Join(quoted, ", ")
@@ -626,20 +624,19 @@ func GetAttestationRecordsByViewName(ctx context.Context, defraNode *node.Node, 
 			}
 		`, collectionName, inList)
 
-		return defra.QueryArray[AttestationRecord](ctx, defraNode, query)
-	} else {
-		// Query all records for this view
-		query := fmt.Sprintf(`
-			query {
-				%s {
-					_docID
-					attested_doc
-					source_doc
-					CIDs
-				}
-			}
-		`, collectionName)
-
-		return defra.QueryArray[AttestationRecord](ctx, defraNode, query)
+		return defra.QueryArray[Record](ctx, defraNode, query)
 	}
+	// Query all records for this view
+	query := fmt.Sprintf(`
+		query {
+			%s {
+				_docID
+				attested_doc
+				source_doc
+				CIDs
+			}
+		}
+	`, collectionName)
+
+	return defra.QueryArray[Record](ctx, defraNode, query)
 }

--- a/pkg/attestation/attestationRecordService_test.go
+++ b/pkg/attestation/attestationRecordService_test.go
@@ -621,14 +621,14 @@ func TestPostAttestationRecord_NewDocument_CreatesSingleRecord(t *testing.T) {
 
 	query := fmt.Sprintf(`
 		query {
-			%s(filter: {attested_doc: {_eq: testDocID}}) {
+			%s(filter: {attested_doc: {_eq: "%s"}}) {
 				_docID
 				attested_doc
 				source_doc
 				CIDs
 			}
 		}
-	`, constants.CollectionAttestationRecord)
+	`, constants.CollectionAttestationRecord, testDocID)
 
 	results, err := defra.QueryArray[Record](t.Context(), defraNode, query)
 	require.NoError(t, err)
@@ -676,14 +676,14 @@ func TestPostAttestationRecord_OldDocument_DuplicateCreateIsHandled(t *testing.T
 
 	query := fmt.Sprintf(`
 		query {
-			%s(filter: {attested_doc: {_eq: testDocID}}) {
+			%s(filter: {attested_doc: {_eq: "%s"}}) {
 				_docID
 				attested_doc
 				source_doc
 				CIDs
 			}
 		}
-	`, constants.CollectionAttestationRecord)
+	`, constants.CollectionAttestationRecord, testDocID)
 
 	results, err := defra.QueryArray[Record](t.Context(), defraNode, query)
 	require.NoError(t, err)

--- a/pkg/attestation/attestationRecordService_test.go
+++ b/pkg/attestation/attestationRecordService_test.go
@@ -13,14 +13,14 @@ import (
 func TestCreateAttestationRecord_AllSignaturesValid(t *testing.T) {
 	ctx := context.Background()
 	verifier := &MockSignatureVerifier{
-		verifyFunc: func(ctx context.Context, cid string, signature Signature) error {
+		verifyFunc: func(_ context.Context, _ string, _ Signature) error {
 			// All signatures are valid
 			return nil
 		},
 	}
 
-	docId := "doc-123"
-	sourceDocId := "source-doc-456"
+	docID := testDocID
+	sourceDocID := testSourceDocID
 	versions := []Version{
 		{
 			CID: "cid-1",
@@ -48,11 +48,11 @@ func TestCreateAttestationRecord_AllSignaturesValid(t *testing.T) {
 		},
 	}
 
-	record, err := CreateAttestationRecord(ctx, verifier, docId, []string{sourceDocId}, "TestDoc", versions, 50)
+	record, err := CreateAttestationRecord(ctx, verifier, docID, []string{sourceDocID}, "TestDoc", versions, 50)
 	require.NoError(t, err)
 	require.NotNil(t, record)
-	require.Equal(t, docId, record.AttestedDocId)
-	require.Equal(t, []string{sourceDocId}, record.SourceDocIds)
+	require.Equal(t, docID, record.AttestedDocID)
+	require.Equal(t, []string{sourceDocID}, record.SourceDocIDs)
 	require.Len(t, record.CIDs, 3)
 	require.Contains(t, record.CIDs, "cid-1")
 	require.Contains(t, record.CIDs, "cid-2")
@@ -62,17 +62,17 @@ func TestCreateAttestationRecord_AllSignaturesValid(t *testing.T) {
 func TestCreateAttestationRecord_SomeSignaturesInvalid(t *testing.T) {
 	ctx := context.Background()
 	verifier := &MockSignatureVerifier{
-		verifyFunc: func(ctx context.Context, cid string, signature Signature) error {
+		verifyFunc: func(_ context.Context, cid string, _ Signature) error {
 			// Only cid-1 and cid-3 are valid
 			if cid == "cid-2" {
-				return fmt.Errorf("invalid signature")
+				return errInvalidSignature
 			}
 			return nil
 		},
 	}
 
-	docId := "doc-123"
-	sourceDocId := "source-doc-456"
+	docID := testDocID
+	sourceDocID := testSourceDocID
 	versions := []Version{
 		{
 			CID: "cid-1",
@@ -100,11 +100,11 @@ func TestCreateAttestationRecord_SomeSignaturesInvalid(t *testing.T) {
 		},
 	}
 
-	record, err := CreateAttestationRecord(ctx, verifier, docId, []string{sourceDocId}, "TestDoc", versions, 50)
+	record, err := CreateAttestationRecord(ctx, verifier, docID, []string{sourceDocID}, "TestDoc", versions, 50)
 	require.NoError(t, err)
 	require.NotNil(t, record)
-	require.Equal(t, docId, record.AttestedDocId)
-	require.Equal(t, []string{sourceDocId}, record.SourceDocIds)
+	require.Equal(t, docID, record.AttestedDocID)
+	require.Equal(t, []string{sourceDocID}, record.SourceDocIDs)
 	require.Len(t, record.CIDs, 2)
 	require.Contains(t, record.CIDs, "cid-1")
 	require.NotContains(t, record.CIDs, "cid-2")
@@ -114,14 +114,14 @@ func TestCreateAttestationRecord_SomeSignaturesInvalid(t *testing.T) {
 func TestCreateAttestationRecord_AllSignaturesInvalid(t *testing.T) {
 	ctx := context.Background()
 	verifier := &MockSignatureVerifier{
-		verifyFunc: func(ctx context.Context, cid string, signature Signature) error {
+		verifyFunc: func(_ context.Context, _ string, _ Signature) error {
 			// All signatures are invalid
-			return fmt.Errorf("invalid signature")
+			return errInvalidSignature
 		},
 	}
 
-	docId := "doc-123"
-	sourceDocId := "source-doc-456"
+	docID := testDocID
+	sourceDocID := testSourceDocID
 	versions := []Version{
 		{
 			CID: "cid-1",
@@ -141,11 +141,11 @@ func TestCreateAttestationRecord_AllSignaturesInvalid(t *testing.T) {
 		},
 	}
 
-	record, err := CreateAttestationRecord(ctx, verifier, docId, []string{sourceDocId}, "TestDoc", versions, 50)
+	record, err := CreateAttestationRecord(ctx, verifier, docID, []string{sourceDocID}, "TestDoc", versions, 50)
 	require.NoError(t, err)
 	require.NotNil(t, record)
-	require.Equal(t, docId, record.AttestedDocId)
-	require.Equal(t, []string{sourceDocId}, record.SourceDocIds)
+	require.Equal(t, docID, record.AttestedDocID)
+	require.Equal(t, []string{sourceDocID}, record.SourceDocIDs)
 	require.Len(t, record.CIDs, 0)
 }
 
@@ -153,15 +153,15 @@ func TestCreateAttestationRecord_EmptyVersions(t *testing.T) {
 	ctx := context.Background()
 	verifier := &MockSignatureVerifier{}
 
-	docId := "doc-123"
-	sourceDocId := "source-doc-456"
+	docID := testDocID
+	sourceDocID := testSourceDocID
 	versions := []Version{}
 
-	record, err := CreateAttestationRecord(ctx, verifier, docId, []string{sourceDocId}, "TestDoc", versions, 50)
+	record, err := CreateAttestationRecord(ctx, verifier, docID, []string{sourceDocID}, "TestDoc", versions, 50)
 	require.NoError(t, err)
 	require.NotNil(t, record)
-	require.Equal(t, docId, record.AttestedDocId)
-	require.Equal(t, []string{sourceDocId}, record.SourceDocIds)
+	require.Equal(t, docID, record.AttestedDocID)
+	require.Equal(t, []string{sourceDocID}, record.SourceDocIDs)
 	require.Len(t, record.CIDs, 0)
 }
 
@@ -169,34 +169,22 @@ func TestPostAttestationRecord(t *testing.T) {
 	ctx := context.Background()
 
 	// Define schema inline for this test
-	testSchema := `
-		type TestDoc {
-			name: String
-		}
-
-		type Ethereum__Mainnet__AttestationRecord {
-			attested_doc: String @index
-			source_doc: [String]
-			CIDs: [String]
-			doc_type: String @index
-			vote_count: Int @crdt(type: pcounter)
-		}
-	`
+	testSchema := testDocAndAttestationSchema
 
 	// Create and start client using new API with test config
 	testConfig := defra.DefaultConfig
-	testConfig.DefraDB.Store.Path = t.TempDir()                          // Use temp directory for test data
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing" // Set test keyring secret
-	testConfig.DefraDB.Url = "localhost:0"                               // Use random available port for API
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"             // Use random available port for P2P
-	testConfig.DefraDB.P2P.Enabled = false                               // Disable P2P networking for testing
-	testConfig.DefraDB.P2P.BootstrapPeers = []string{}                   // No bootstrap peers
+	testConfig.DefraDB.Store.Path = t.TempDir() // Use temp directory for test data
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
+	testConfig.DefraDB.P2P.Enabled = false             // Disable P2P networking for testing
+	testConfig.DefraDB.P2P.BootstrapPeers = []string{} // No bootstrap peers
 
 	client, err := defra.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	// Apply schema using the new Client method
 	err = client.ApplySchema(ctx, testSchema)
@@ -206,7 +194,7 @@ func TestPostAttestationRecord(t *testing.T) {
 
 	type TestDoc struct {
 		Name    string    `json:"name"`
-		DocId   string    `json:"_docID"`
+		DocID   string    `json:"_docID"`
 		Version []Version `json:"_version"`
 	}
 
@@ -231,18 +219,18 @@ func TestPostAttestationRecord(t *testing.T) {
 	testDocResult, err := defra.PostMutation[TestDoc](t.Context(), defraNode, createTestDocMutation)
 	require.NoError(t, err)
 	require.NotNil(t, testDocResult)
-	require.Greater(t, len(testDocResult.DocId), 0)
+	require.Greater(t, len(testDocResult.DocID), 0)
 	require.Len(t, testDocResult.Version, 1)
 
 	testVersions := testDocResult.Version
 
-	attestedDocId := "attested-doc-123" // This would be the View doc created after processing the view
-	sourceDocId := testDocResult.DocId
+	attestedDocID := "attested-doc-123" // This would be the View doc created after processing the view
+	sourceDocID := testDocResult.DocID
 
 	// Manually create attestation record with the necessary data - we don't use CreateAttestationRecord because we don't want any validation
-	attestationRecord := &AttestationRecord{
-		AttestedDocId: attestedDocId,
-		SourceDocIds:   []string{sourceDocId},
+	attestationRecord := &Record{
+		AttestedDocID: attestedDocID,
+		SourceDocIDs:  []string{sourceDocID},
 		CIDs:          []string{},
 	}
 	for _, version := range testVersions {
@@ -261,13 +249,13 @@ func TestPostAttestationRecord(t *testing.T) {
 		}
 	`, constants.CollectionAttestationRecord)
 
-	results, err := defra.QueryArray[AttestationRecord](t.Context(), defraNode, query)
+	results, err := defra.QueryArray[Record](t.Context(), defraNode, query)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 
 	record := results[0]
-	require.Equal(t, attestedDocId, record.AttestedDocId)
-	require.Equal(t, []string{testDocResult.DocId}, record.SourceDocIds)
+	require.Equal(t, attestedDocID, record.AttestedDocID)
+	require.Equal(t, []string{testDocResult.DocID}, record.SourceDocIDs)
 	require.NotNil(t, record.CIDs)
 	require.Len(t, record.CIDs, 1)
 }
@@ -277,25 +265,25 @@ func TestPostAttestationRecord(t *testing.T) {
 // ========================================
 
 func TestMergeAttestationRecords_SameDocument(t *testing.T) {
-	record1 := &AttestationRecord{
-		AttestedDocId: "doc-123",
-		SourceDocIds:   []string{"source-1"},
+	record1 := &Record{
+		AttestedDocID: testDocID,
+		SourceDocIDs:  []string{"source-1"},
 		CIDs:          []string{"cid-1", "cid-2"},
 	}
 
-	record2 := &AttestationRecord{
-		AttestedDocId: "doc-123",
-		SourceDocIds:   []string{"source-2"},
+	record2 := &Record{
+		AttestedDocID: testDocID,
+		SourceDocIDs:  []string{"source-2"},
 		CIDs:          []string{"cid-3", "cid-4"},
 	}
 
 	merged, err := MergeAttestationRecords(record1, record2)
 	require.NoError(t, err)
 	require.NotNil(t, merged)
-	require.Equal(t, "doc-123", merged.AttestedDocId)
-	require.Len(t, merged.SourceDocIds, 2)
-	require.Contains(t, merged.SourceDocIds, "source-1")
-	require.Contains(t, merged.SourceDocIds, "source-2")
+	require.Equal(t, testDocID, merged.AttestedDocID)
+	require.Len(t, merged.SourceDocIDs, 2)
+	require.Contains(t, merged.SourceDocIDs, "source-1")
+	require.Contains(t, merged.SourceDocIDs, "source-2")
 	require.Len(t, merged.CIDs, 4)
 	require.Contains(t, merged.CIDs, "cid-1")
 	require.Contains(t, merged.CIDs, "cid-2")
@@ -304,22 +292,22 @@ func TestMergeAttestationRecords_SameDocument(t *testing.T) {
 }
 
 func TestMergeAttestationRecords_WithDuplicateCIDs(t *testing.T) {
-	record1 := &AttestationRecord{
-		AttestedDocId: "doc-123",
-		SourceDocIds:   []string{"source-1"},
+	record1 := &Record{
+		AttestedDocID: testDocID,
+		SourceDocIDs:  []string{"source-1"},
 		CIDs:          []string{"cid-1", "cid-2", "cid-3"},
 	}
 
-	record2 := &AttestationRecord{
-		AttestedDocId: "doc-123",
-		SourceDocIds:   []string{"source-2"},
+	record2 := &Record{
+		AttestedDocID: testDocID,
+		SourceDocIDs:  []string{"source-2"},
 		CIDs:          []string{"cid-2", "cid-3", "cid-4"}, // cid-2 and cid-3 are duplicates
 	}
 
 	merged, err := MergeAttestationRecords(record1, record2)
 	require.NoError(t, err)
 	require.NotNil(t, merged)
-	require.Equal(t, "doc-123", merged.AttestedDocId)
+	require.Equal(t, testDocID, merged.AttestedDocID)
 	require.Len(t, merged.CIDs, 4) // Should deduplicate
 	require.Contains(t, merged.CIDs, "cid-1")
 	require.Contains(t, merged.CIDs, "cid-2")
@@ -337,15 +325,15 @@ func TestMergeAttestationRecords_WithDuplicateCIDs(t *testing.T) {
 }
 
 func TestMergeAttestationRecords_DifferentDocuments(t *testing.T) {
-	record1 := &AttestationRecord{
-		AttestedDocId: "doc-123",
-		SourceDocIds:   []string{"source-1"},
+	record1 := &Record{
+		AttestedDocID: testDocID,
+		SourceDocIDs:  []string{"source-1"},
 		CIDs:          []string{"cid-1", "cid-2"},
 	}
 
-	record2 := &AttestationRecord{
-		AttestedDocId: "doc-456", // Different document
-		SourceDocIds:   []string{"source-2"},
+	record2 := &Record{
+		AttestedDocID: "doc-456", // Different document
+		SourceDocIDs:  []string{"source-2"},
 		CIDs:          []string{"cid-3", "cid-4"},
 	}
 
@@ -356,44 +344,44 @@ func TestMergeAttestationRecords_DifferentDocuments(t *testing.T) {
 }
 
 func TestMergeAttestationRecords_EmptyRecords(t *testing.T) {
-	record1 := &AttestationRecord{
-		AttestedDocId: "doc-123",
-		SourceDocIds:   []string{"source-1"},
+	record1 := &Record{
+		AttestedDocID: testDocID,
+		SourceDocIDs:  []string{"source-1"},
 		CIDs:          []string{},
 	}
 
-	record2 := &AttestationRecord{
-		AttestedDocId: "doc-123",
-		SourceDocIds:   []string{"source-2"},
+	record2 := &Record{
+		AttestedDocID: testDocID,
+		SourceDocIDs:  []string{"source-2"},
 		CIDs:          []string{"cid-1", "cid-2"},
 	}
 
 	merged, err := MergeAttestationRecords(record1, record2)
 	require.NoError(t, err)
 	require.NotNil(t, merged)
-	require.Equal(t, "doc-123", merged.AttestedDocId)
+	require.Equal(t, testDocID, merged.AttestedDocID)
 	require.Len(t, merged.CIDs, 2)
 	require.Contains(t, merged.CIDs, "cid-1")
 	require.Contains(t, merged.CIDs, "cid-2")
 }
 
 func TestMergeAttestationRecords_BothEmpty(t *testing.T) {
-	record1 := &AttestationRecord{
-		AttestedDocId: "doc-123",
-		SourceDocIds:   []string{"source-1"},
+	record1 := &Record{
+		AttestedDocID: testDocID,
+		SourceDocIDs:  []string{"source-1"},
 		CIDs:          []string{},
 	}
 
-	record2 := &AttestationRecord{
-		AttestedDocId: "doc-123",
-		SourceDocIds:   []string{"source-2"},
+	record2 := &Record{
+		AttestedDocID: testDocID,
+		SourceDocIDs:  []string{"source-2"},
 		CIDs:          []string{},
 	}
 
 	merged, err := MergeAttestationRecords(record1, record2)
 	require.NoError(t, err)
 	require.NotNil(t, merged)
-	require.Equal(t, "doc-123", merged.AttestedDocId)
+	require.Equal(t, testDocID, merged.AttestedDocID)
 	require.Len(t, merged.CIDs, 0)
 }
 
@@ -420,18 +408,18 @@ func TestMergeAttestationRecords_IntegrationWithDefraDB(t *testing.T) {
 
 	// Create and start client using new API with test config
 	testConfig := defra.DefaultConfig
-	testConfig.DefraDB.Store.Path = t.TempDir()                          // Use temp directory for test data
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing" // Set test keyring secret
-	testConfig.DefraDB.Url = "localhost:0"                               // Use random available port for API
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"             // Use random available port for P2P
-	testConfig.DefraDB.P2P.Enabled = false                               // Disable P2P networking for testing
-	testConfig.DefraDB.P2P.BootstrapPeers = []string{}                   // No bootstrap peers
+	testConfig.DefraDB.Store.Path = t.TempDir() // Use temp directory for test data
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
+	testConfig.DefraDB.P2P.Enabled = false             // Disable P2P networking for testing
+	testConfig.DefraDB.P2P.BootstrapPeers = []string{} // No bootstrap peers
 
 	client, err := defra.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	// Apply schema using the new Client method
 	err = client.ApplySchema(ctx, testSchema)
@@ -441,7 +429,7 @@ func TestMergeAttestationRecords_IntegrationWithDefraDB(t *testing.T) {
 
 	type TestDoc struct {
 		Name    string    `json:"name"`
-		DocId   string    `json:"_docID"`
+		DocID   string    `json:"_docID"`
 		Version []Version `json:"_version"`
 	}
 
@@ -489,17 +477,17 @@ func TestMergeAttestationRecords_IntegrationWithDefraDB(t *testing.T) {
 	require.NotNil(t, doc2Result)
 
 	// Create attestation records for the same attested document but from different sources
-	attestedDocId := "view-doc-123"
+	attestedDocID := "view-doc-123"
 
-	record1 := &AttestationRecord{
-		AttestedDocId: attestedDocId,
-		SourceDocIds:   []string{doc1Result.DocId},
+	record1 := &Record{
+		AttestedDocID: attestedDocID,
+		SourceDocIDs:  []string{doc1Result.DocID},
 		CIDs:          []string{doc1Result.Version[0].CID},
 	}
 
-	record2 := &AttestationRecord{
-		AttestedDocId: attestedDocId,
-		SourceDocIds:   []string{doc2Result.DocId},
+	record2 := &Record{
+		AttestedDocID: attestedDocID,
+		SourceDocIDs:  []string{doc2Result.DocID},
 		CIDs:          []string{doc2Result.Version[0].CID},
 	}
 
@@ -507,7 +495,7 @@ func TestMergeAttestationRecords_IntegrationWithDefraDB(t *testing.T) {
 	merged, err := MergeAttestationRecords(record1, record2)
 	require.NoError(t, err)
 	require.NotNil(t, merged)
-	require.Equal(t, attestedDocId, merged.AttestedDocId)
+	require.Equal(t, attestedDocID, merged.AttestedDocID)
 	require.Len(t, merged.CIDs, 2)
 	require.Contains(t, merged.CIDs, doc1Result.Version[0].CID)
 	require.Contains(t, merged.CIDs, doc2Result.Version[0].CID)
@@ -525,15 +513,15 @@ func TestMergeAttestationRecords_IntegrationWithDefraDB(t *testing.T) {
 		}
 	`, constants.CollectionAttestationRecord)
 
-	results, err := defra.QueryArray[AttestationRecord](t.Context(), defraNode, query)
+	results, err := defra.QueryArray[Record](t.Context(), defraNode, query)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 
 	storedRecord := results[0]
-	require.Equal(t, attestedDocId, storedRecord.AttestedDocId)
-	require.Len(t, storedRecord.SourceDocIds, 2)
-	require.Contains(t, storedRecord.SourceDocIds, doc1Result.DocId)
-	require.Contains(t, storedRecord.SourceDocIds, doc2Result.DocId)
+	require.Equal(t, attestedDocID, storedRecord.AttestedDocID)
+	require.Len(t, storedRecord.SourceDocIDs, 2)
+	require.Contains(t, storedRecord.SourceDocIDs, doc1Result.DocID)
+	require.Contains(t, storedRecord.SourceDocIDs, doc2Result.DocID)
 	require.Len(t, storedRecord.CIDs, 2)
 	require.Contains(t, storedRecord.CIDs, doc1Result.Version[0].CID)
 	require.Contains(t, storedRecord.CIDs, doc2Result.Version[0].CID)
@@ -549,19 +537,19 @@ func TestMergeAttestationRecords_Performance(t *testing.T) {
 
 	// Create first record with many CIDs
 	cids1 := make([]string, numCIDs)
-	for i := 0; i < numCIDs; i++ {
+	for i := range numCIDs {
 		cids1[i] = fmt.Sprintf("cid-1-%d", i)
 	}
 
-	record1 := &AttestationRecord{
-		AttestedDocId: "doc-123",
-		SourceDocIds:   []string{"source-1"},
+	record1 := &Record{
+		AttestedDocID: testDocID,
+		SourceDocIDs:  []string{"source-1"},
 		CIDs:          cids1,
 	}
 
 	// Create second record with overlapping CIDs
 	cids2 := make([]string, numCIDs)
-	for i := 0; i < numCIDs; i++ {
+	for i := range numCIDs {
 		if i < numCIDs/2 {
 			// First half overlaps with record1
 			cids2[i] = fmt.Sprintf("cid-1-%d", i)
@@ -571,9 +559,9 @@ func TestMergeAttestationRecords_Performance(t *testing.T) {
 		}
 	}
 
-	record2 := &AttestationRecord{
-		AttestedDocId: "doc-123",
-		SourceDocIds:   []string{"source-2"},
+	record2 := &Record{
+		AttestedDocID: testDocID,
+		SourceDocIDs:  []string{"source-2"},
 		CIDs:          cids2,
 	}
 
@@ -581,7 +569,7 @@ func TestMergeAttestationRecords_Performance(t *testing.T) {
 	merged, err := MergeAttestationRecords(record1, record2)
 	require.NoError(t, err)
 	require.NotNil(t, merged)
-	require.Equal(t, "doc-123", merged.AttestedDocId)
+	require.Equal(t, testDocID, merged.AttestedDocID)
 
 	// Should have numCIDs + numCIDs/2 unique CIDs (no duplicates)
 	expectedCIDs := numCIDs + numCIDs/2
@@ -599,34 +587,22 @@ func TestPostAttestationRecord_NewDocument_CreatesSingleRecord(t *testing.T) {
 	ctx := context.Background()
 
 	// Define schema inline for this test
-	testSchema := `
-		type TestDoc {
-			name: String
-		}
-
-		type Ethereum__Mainnet__AttestationRecord {
-			attested_doc: String @index
-			source_doc: [String]
-			CIDs: [String]
-			doc_type: String @index
-			vote_count: Int @crdt(type: pcounter)
-		}
-	`
+	testSchema := testDocAndAttestationSchema
 
 	// Create and start client using new API with test config
 	testConfig := defra.DefaultConfig
-	testConfig.DefraDB.Store.Path = t.TempDir()                          // Use temp directory for test data
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing" // Set test keyring secret
-	testConfig.DefraDB.Url = "localhost:0"                               // Use random available port for API
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"             // Use random available port for P2P
-	testConfig.DefraDB.P2P.Enabled = false                               // Disable P2P networking for testing
-	testConfig.DefraDB.P2P.BootstrapPeers = []string{}                   // No bootstrap peers
+	testConfig.DefraDB.Store.Path = t.TempDir() // Use temp directory for test data
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
+	testConfig.DefraDB.P2P.Enabled = false             // Disable P2P networking for testing
+	testConfig.DefraDB.P2P.BootstrapPeers = []string{} // No bootstrap peers
 
 	client, err := defra.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	// Apply schema using the new Client method
 	err = client.ApplySchema(ctx, testSchema)
@@ -634,9 +610,9 @@ func TestPostAttestationRecord_NewDocument_CreatesSingleRecord(t *testing.T) {
 
 	defraNode := client.GetNode()
 
-	record := &AttestationRecord{
-		AttestedDocId: "doc-123",
-		SourceDocIds:   []string{"doc-123"},
+	record := &Record{
+		AttestedDocID: testDocID,
+		SourceDocIDs:  []string{testDocID},
 		CIDs:          []string{"cid-1"},
 	}
 
@@ -645,7 +621,7 @@ func TestPostAttestationRecord_NewDocument_CreatesSingleRecord(t *testing.T) {
 
 	query := fmt.Sprintf(`
 		query {
-			%s(filter: {attested_doc: {_eq: "doc-123"}}) {
+			%s(filter: {attested_doc: {_eq: testDocID}}) {
 				_docID
 				attested_doc
 				source_doc
@@ -654,44 +630,32 @@ func TestPostAttestationRecord_NewDocument_CreatesSingleRecord(t *testing.T) {
 		}
 	`, constants.CollectionAttestationRecord)
 
-	results, err := defra.QueryArray[AttestationRecord](t.Context(), defraNode, query)
+	results, err := defra.QueryArray[Record](t.Context(), defraNode, query)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
-	require.Equal(t, "doc-123", results[0].AttestedDocId)
+	require.Equal(t, testDocID, results[0].AttestedDocID)
 }
 
 func TestPostAttestationRecord_OldDocument_DuplicateCreateIsHandled(t *testing.T) {
 	ctx := context.Background()
 
 	// Define schema inline for this test
-	testSchema := `
-		type TestDoc {
-			name: String
-		}
-
-		type Ethereum__Mainnet__AttestationRecord {
-			attested_doc: String @index
-			source_doc: [String]
-			CIDs: [String]
-			doc_type: String @index
-			vote_count: Int @crdt(type: pcounter)
-		}
-	`
+	testSchema := testDocAndAttestationSchema
 
 	// Create and start client using new API with test config
 	testConfig := defra.DefaultConfig
-	testConfig.DefraDB.Store.Path = t.TempDir()                          // Use temp directory for test data
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing" // Set test keyring secret
-	testConfig.DefraDB.Url = "localhost:0"                               // Use random available port for API
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"             // Use random available port for P2P
-	testConfig.DefraDB.P2P.Enabled = false                               // Disable P2P networking for testing
-	testConfig.DefraDB.P2P.BootstrapPeers = []string{}                   // No bootstrap peers
+	testConfig.DefraDB.Store.Path = t.TempDir() // Use temp directory for test data
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
+	testConfig.DefraDB.P2P.Enabled = false             // Disable P2P networking for testing
+	testConfig.DefraDB.P2P.BootstrapPeers = []string{} // No bootstrap peers
 
 	client, err := defra.NewClient(testConfig)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	// Apply schema using the new Client method
 	err = client.ApplySchema(ctx, testSchema)
@@ -699,9 +663,9 @@ func TestPostAttestationRecord_OldDocument_DuplicateCreateIsHandled(t *testing.T
 
 	defraNode := client.GetNode()
 
-	record := &AttestationRecord{
-		AttestedDocId: "doc-123",
-		SourceDocIds:   []string{"doc-123"},
+	record := &Record{
+		AttestedDocID: testDocID,
+		SourceDocIDs:  []string{testDocID},
 		CIDs:          []string{"cid-1"},
 	}
 
@@ -712,7 +676,7 @@ func TestPostAttestationRecord_OldDocument_DuplicateCreateIsHandled(t *testing.T
 
 	query := fmt.Sprintf(`
 		query {
-			%s(filter: {attested_doc: {_eq: "doc-123"}}) {
+			%s(filter: {attested_doc: {_eq: testDocID}}) {
 				_docID
 				attested_doc
 				source_doc
@@ -721,16 +685,16 @@ func TestPostAttestationRecord_OldDocument_DuplicateCreateIsHandled(t *testing.T
 		}
 	`, constants.CollectionAttestationRecord)
 
-	results, err := defra.QueryArray[AttestationRecord](t.Context(), defraNode, query)
+	results, err := defra.QueryArray[Record](t.Context(), defraNode, query)
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, len(results), 1)
 }
 
 func TestMergeAttestationRecords_MultipleOldRecords(t *testing.T) {
-	records := []*AttestationRecord{
-		{AttestedDocId: "doc-123", SourceDocIds: []string{"source-1"}, CIDs: []string{"cid-1"}},
-		{AttestedDocId: "doc-123", SourceDocIds: []string{"source-2"}, CIDs: []string{"cid-2", "cid-3"}},
-		{AttestedDocId: "doc-123", SourceDocIds: []string{"source-3"}, CIDs: []string{"cid-3", "cid-4"}},
+	records := []*Record{
+		{AttestedDocID: testDocID, SourceDocIDs: []string{"source-1"}, CIDs: []string{"cid-1"}},
+		{AttestedDocID: testDocID, SourceDocIDs: []string{"source-2"}, CIDs: []string{"cid-2", "cid-3"}},
+		{AttestedDocID: testDocID, SourceDocIDs: []string{"source-3"}, CIDs: []string{"cid-3", "cid-4"}},
 	}
 
 	merged := records[0]
@@ -741,34 +705,26 @@ func TestMergeAttestationRecords_MultipleOldRecords(t *testing.T) {
 	}
 
 	require.NotNil(t, merged)
-	require.Equal(t, "doc-123", merged.AttestedDocId)
-	require.Len(t, merged.SourceDocIds, 3)
-	require.Contains(t, merged.SourceDocIds, "source-1")
-	require.Contains(t, merged.SourceDocIds, "source-2")
-	require.Contains(t, merged.SourceDocIds, "source-3")
+	require.Equal(t, testDocID, merged.AttestedDocID)
+	require.Len(t, merged.SourceDocIDs, 3)
+	require.Contains(t, merged.SourceDocIDs, "source-1")
+	require.Contains(t, merged.SourceDocIDs, "source-2")
+	require.Contains(t, merged.SourceDocIDs, "source-3")
 	require.ElementsMatch(t, []string{"cid-1", "cid-2", "cid-3", "cid-4"}, merged.CIDs)
 }
 
 func TestPostAttestationRecord_MultipleIndexers_AppendsSourceDoc(t *testing.T) {
 	ctx := context.Background()
 
-	schema := `
-		type Ethereum__Mainnet__AttestationRecord {
-			attested_doc: String @index
-			source_doc: [String]
-			CIDs: [String]
-			doc_type: String @index
-			vote_count: Int @crdt(type: pcounter)
-		}
-	`
+	schema := testAttestationRecordSchema
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(schema))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	// First indexer posts attestation
-	record1 := &AttestationRecord{
-		AttestedDocId: "block:500:deadbeef",
-		SourceDocIds:  []string{"indexer-A"},
+	record1 := &Record{
+		AttestedDocID: "block:500:deadbeef",
+		SourceDocIDs:  []string{"indexer-A"},
 		CIDs:          []string{"cid-1", "cid-2"},
 		DocType:       "Block",
 		VoteCount:     1,
@@ -777,9 +733,9 @@ func TestPostAttestationRecord_MultipleIndexers_AppendsSourceDoc(t *testing.T) {
 	require.NoError(t, err)
 
 	// Second indexer posts attestation for the same block
-	record2 := &AttestationRecord{
-		AttestedDocId: "block:500:deadbeef",
-		SourceDocIds:  []string{"indexer-B"},
+	record2 := &Record{
+		AttestedDocID: "block:500:deadbeef",
+		SourceDocIDs:  []string{"indexer-B"},
 		CIDs:          []string{"cid-1", "cid-2"},
 		DocType:       "Block",
 		VoteCount:     1,
@@ -793,29 +749,21 @@ func TestPostAttestationRecord_MultipleIndexers_AppendsSourceDoc(t *testing.T) {
 	require.Len(t, records, 1, "Should have exactly one attestation record")
 
 	record := records[0]
-	require.Contains(t, record.SourceDocIds, "indexer-A", "Should contain first indexer")
-	require.Contains(t, record.SourceDocIds, "indexer-B", "Should contain second indexer")
-	require.Len(t, record.SourceDocIds, 2, "Should have exactly 2 indexer identities")
+	require.Contains(t, record.SourceDocIDs, "indexer-A", "Should contain first indexer")
+	require.Contains(t, record.SourceDocIDs, "indexer-B", "Should contain second indexer")
+	require.Len(t, record.SourceDocIDs, 2, "Should have exactly 2 indexer identities")
 }
 
 func TestPostAttestationRecordsBatch_UpdatesExistingRecord_AppendsCIDs(t *testing.T) {
 	ctx := context.Background()
 
-	testSchema := `
-		type Ethereum__Mainnet__AttestationRecord {
-			attested_doc: String @index
-			source_doc: [String]
-			CIDs: [String]
-			doc_type: String @index
-			vote_count: Int @crdt(type: pcounter)
-		}
-	`
+	testSchema := testAttestationRecordSchema
 
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -823,7 +771,7 @@ func TestPostAttestationRecordsBatch_UpdatesExistingRecord_AppendsCIDs(t *testin
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	err = client.ApplySchema(ctx, testSchema)
 	require.NoError(t, err)
@@ -831,15 +779,15 @@ func TestPostAttestationRecordsBatch_UpdatesExistingRecord_AppendsCIDs(t *testin
 	defraNode := client.GetNode()
 
 	// Step 1: Create initial attestation record with cid-1 and cid-2
-	initialRecord := &AttestationRecord{
-		AttestedDocId: "attested-doc-123",
-		SourceDocIds:   []string{"source-doc-456"},
+	initialRecord := &Record{
+		AttestedDocID: "attested-doc-123",
+		SourceDocIDs:  []string{testSourceDocID},
 		CIDs:          []string{"cid-1", "cid-2"},
 		DocType:       "TestDoc",
 		VoteCount:     1,
 	}
 
-	err = PostAttestationRecordsBatch(ctx, defraNode, []*AttestationRecord{initialRecord})
+	err = PostAttestationRecordsBatch(ctx, defraNode, []*Record{initialRecord})
 	require.NoError(t, err)
 
 	// Verify initial record was created
@@ -854,26 +802,26 @@ func TestPostAttestationRecordsBatch_UpdatesExistingRecord_AppendsCIDs(t *testin
 		}
 	`, constants.CollectionAttestationRecord)
 
-	results, err := defra.QueryArray[AttestationRecord](ctx, defraNode, query)
+	results, err := defra.QueryArray[Record](ctx, defraNode, query)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	require.ElementsMatch(t, []string{"cid-1", "cid-2"}, results[0].CIDs)
 
 	// Step 2: Post update with new CIDs (cid-2 overlaps, cid-3 is new)
-	updateRecord := &AttestationRecord{
-		AttestedDocId: "attested-doc-123",
-		SourceDocIds:   []string{"source-doc-456"},
+	updateRecord := &Record{
+		AttestedDocID: "attested-doc-123",
+		SourceDocIDs:  []string{testSourceDocID},
 		CIDs:          []string{"cid-2", "cid-3"},
 		DocType:       "TestDoc",
 		VoteCount:     1,
 	}
 
-	err = PostAttestationRecordsBatch(ctx, defraNode, []*AttestationRecord{updateRecord})
+	err = PostAttestationRecordsBatch(ctx, defraNode, []*Record{updateRecord})
 	require.NoError(t, err)
 
 	// Step 3: Verify that the batch was posted (SaveMany creates a new record;
 	// CID merging only happens via the upsert_ mutation in PostAttestationRecord)
-	results, err = defra.QueryArray[AttestationRecord](ctx, defraNode, query)
+	results, err = defra.QueryArray[Record](ctx, defraNode, query)
 	require.NoError(t, err)
 	require.NotEmpty(t, results)
 }
@@ -881,21 +829,13 @@ func TestPostAttestationRecordsBatch_UpdatesExistingRecord_AppendsCIDs(t *testin
 func TestPostAttestationRecordsBatch_CreatesNewRecord_WhenNotExists(t *testing.T) {
 	ctx := context.Background()
 
-	testSchema := `
-		type Ethereum__Mainnet__AttestationRecord {
-			attested_doc: String @index
-			source_doc: [String]
-			CIDs: [String]
-			doc_type: String @index
-			vote_count: Int @crdt(type: pcounter)
-		}
-	`
+	testSchema := testAttestationRecordSchema
 
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -903,7 +843,7 @@ func TestPostAttestationRecordsBatch_CreatesNewRecord_WhenNotExists(t *testing.T
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	err = client.ApplySchema(ctx, testSchema)
 	require.NoError(t, err)
@@ -911,15 +851,15 @@ func TestPostAttestationRecordsBatch_CreatesNewRecord_WhenNotExists(t *testing.T
 	defraNode := client.GetNode()
 
 	// Create a new record
-	record := &AttestationRecord{
-		AttestedDocId: "new-attested-doc",
-		SourceDocIds:   []string{"new-source-doc"},
+	record := &Record{
+		AttestedDocID: "new-attested-doc",
+		SourceDocIDs:  []string{"new-source-doc"},
 		CIDs:          []string{"cid-a", "cid-b"},
 		DocType:       "TestDoc",
 		VoteCount:     1,
 	}
 
-	err = PostAttestationRecordsBatch(ctx, defraNode, []*AttestationRecord{record})
+	err = PostAttestationRecordsBatch(ctx, defraNode, []*Record{record})
 	require.NoError(t, err)
 
 	// Verify record was created
@@ -932,32 +872,24 @@ func TestPostAttestationRecordsBatch_CreatesNewRecord_WhenNotExists(t *testing.T
 		}
 	`, constants.CollectionAttestationRecord)
 
-	results, err := defra.QueryArray[AttestationRecord](ctx, defraNode, query)
+	results, err := defra.QueryArray[Record](ctx, defraNode, query)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
-	require.Equal(t, "new-attested-doc", results[0].AttestedDocId)
-	require.Equal(t, []string{"new-source-doc"}, results[0].SourceDocIds)
+	require.Equal(t, "new-attested-doc", results[0].AttestedDocID)
+	require.Equal(t, []string{"new-source-doc"}, results[0].SourceDocIDs)
 	require.ElementsMatch(t, []string{"cid-a", "cid-b"}, results[0].CIDs)
 }
 
 func TestPostAttestationRecordsBatch_MultipleBatchRecords(t *testing.T) {
 	ctx := context.Background()
 
-	testSchema := `
-		type Ethereum__Mainnet__AttestationRecord {
-			attested_doc: String @index
-			source_doc: [String]
-			CIDs: [String]
-			doc_type: String @index
-			vote_count: Int @crdt(type: pcounter)
-		}
-	`
+	testSchema := testAttestationRecordSchema
 
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -965,7 +897,7 @@ func TestPostAttestationRecordsBatch_MultipleBatchRecords(t *testing.T) {
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	err = client.ApplySchema(ctx, testSchema)
 	require.NoError(t, err)
@@ -973,17 +905,17 @@ func TestPostAttestationRecordsBatch_MultipleBatchRecords(t *testing.T) {
 	defraNode := client.GetNode()
 
 	// Create multiple records in a single batch
-	records := []*AttestationRecord{
+	records := []*Record{
 		{
-			AttestedDocId: "doc-1",
-			SourceDocIds:   []string{"source-1"},
+			AttestedDocID: "doc-1",
+			SourceDocIDs:  []string{"source-1"},
 			CIDs:          []string{"cid-1"},
 			DocType:       "TypeA",
 			VoteCount:     1,
 		},
 		{
-			AttestedDocId: "doc-2",
-			SourceDocIds:   []string{"source-2"},
+			AttestedDocID: "doc-2",
+			SourceDocIDs:  []string{"source-2"},
 			CIDs:          []string{"cid-2", "cid-3"},
 			DocType:       "TypeB",
 			VoteCount:     1,
@@ -1003,14 +935,14 @@ func TestPostAttestationRecordsBatch_MultipleBatchRecords(t *testing.T) {
 		}
 	`, constants.CollectionAttestationRecord)
 
-	results, err := defra.QueryArray[AttestationRecord](ctx, defraNode, query)
+	results, err := defra.QueryArray[Record](ctx, defraNode, query)
 	require.NoError(t, err)
 	require.Len(t, results, 2)
 
 	// Find each record by attested_doc
-	resultMap := make(map[string]AttestationRecord)
+	resultMap := make(map[string]Record)
 	for _, r := range results {
-		resultMap[r.AttestedDocId] = r
+		resultMap[r.AttestedDocID] = r
 	}
 
 	require.Contains(t, resultMap, "doc-1")
@@ -1022,21 +954,13 @@ func TestPostAttestationRecordsBatch_MultipleBatchRecords(t *testing.T) {
 func TestPostAttestationRecordsBatch_EmptyRecords_ReturnsNil(t *testing.T) {
 	ctx := context.Background()
 
-	testSchema := `
-		type Ethereum__Mainnet__AttestationRecord {
-			attested_doc: String @index
-			source_doc: [String]
-			CIDs: [String]
-			doc_type: String @index
-			vote_count: Int @crdt(type: pcounter)
-		}
-	`
+	testSchema := testAttestationRecordSchema
 
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -1044,7 +968,7 @@ func TestPostAttestationRecordsBatch_EmptyRecords_ReturnsNil(t *testing.T) {
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	err = client.ApplySchema(ctx, testSchema)
 	require.NoError(t, err)
@@ -1052,16 +976,16 @@ func TestPostAttestationRecordsBatch_EmptyRecords_ReturnsNil(t *testing.T) {
 	defraNode := client.GetNode()
 
 	// Test with empty slice
-	err = PostAttestationRecordsBatch(ctx, defraNode, []*AttestationRecord{})
+	err = PostAttestationRecordsBatch(ctx, defraNode, []*Record{})
 	require.NoError(t, err)
 
 	// Test with nil records in slice
-	err = PostAttestationRecordsBatch(ctx, defraNode, []*AttestationRecord{nil, nil})
+	err = PostAttestationRecordsBatch(ctx, defraNode, []*Record{nil, nil})
 	require.NoError(t, err)
 
 	// Test with records that have empty CIDs
-	err = PostAttestationRecordsBatch(ctx, defraNode, []*AttestationRecord{
-		{AttestedDocId: "doc-1", SourceDocIds: []string{"source-1"}, CIDs: []string{}},
+	err = PostAttestationRecordsBatch(ctx, defraNode, []*Record{
+		{AttestedDocID: "doc-1", SourceDocIDs: []string{"source-1"}, CIDs: []string{}},
 	})
 	require.NoError(t, err)
 }
@@ -1069,21 +993,13 @@ func TestPostAttestationRecordsBatch_EmptyRecords_ReturnsNil(t *testing.T) {
 func TestPostAttestationRecordsBatch_DoesNotMutateInputRecords(t *testing.T) {
 	ctx := context.Background()
 
-	testSchema := `
-		type Ethereum__Mainnet__AttestationRecord {
-			attested_doc: String @index
-			source_doc: [String]
-			CIDs: [String]
-			doc_type: String @index
-			vote_count: Int @crdt(type: pcounter)
-		}
-	`
+	testSchema := testAttestationRecordSchema
 
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -1091,7 +1007,7 @@ func TestPostAttestationRecordsBatch_DoesNotMutateInputRecords(t *testing.T) {
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	err = client.ApplySchema(ctx, testSchema)
 	require.NoError(t, err)
@@ -1099,20 +1015,20 @@ func TestPostAttestationRecordsBatch_DoesNotMutateInputRecords(t *testing.T) {
 	defraNode := client.GetNode()
 
 	// Create initial record
-	initialRecord := &AttestationRecord{
-		AttestedDocId: "attested-doc-mutation-test",
-		SourceDocIds:   []string{"source-doc"},
+	initialRecord := &Record{
+		AttestedDocID: "attested-doc-mutation-test",
+		SourceDocIDs:  []string{"source-doc"},
 		CIDs:          []string{"cid-1"},
 		DocType:       "TestDoc",
 		VoteCount:     1,
 	}
-	err = PostAttestationRecordsBatch(ctx, defraNode, []*AttestationRecord{initialRecord})
+	err = PostAttestationRecordsBatch(ctx, defraNode, []*Record{initialRecord})
 	require.NoError(t, err)
 
 	// Create update record and save original CIDs
-	updateRecord := &AttestationRecord{
-		AttestedDocId: "attested-doc-mutation-test",
-		SourceDocIds:   []string{"source-doc"},
+	updateRecord := &Record{
+		AttestedDocID: "attested-doc-mutation-test",
+		SourceDocIDs:  []string{"source-doc"},
 		CIDs:          []string{"cid-2"},
 		DocType:       "TestDoc",
 		VoteCount:     1,
@@ -1120,7 +1036,7 @@ func TestPostAttestationRecordsBatch_DoesNotMutateInputRecords(t *testing.T) {
 	originalCIDs := make([]string, len(updateRecord.CIDs))
 	copy(originalCIDs, updateRecord.CIDs)
 
-	err = PostAttestationRecordsBatch(ctx, defraNode, []*AttestationRecord{updateRecord})
+	err = PostAttestationRecordsBatch(ctx, defraNode, []*Record{updateRecord})
 	require.NoError(t, err)
 
 	// Verify input record was not mutated
@@ -1162,9 +1078,9 @@ func TestExtractVersionsFromDocument_WithVersionField(t *testing.T) {
 	require.Equal(t, "es256k", versions[0].Signature.Type)
 	require.Equal(t, "identity-abc", versions[0].Signature.Identity)
 	require.Equal(t, "sig-abc", versions[0].Signature.Value)
-	require.Equal(t, "colv-1", versions[0].CollectionVersionId)
+	require.Equal(t, "colv-1", versions[0].CollectionVersionID)
 	require.Equal(t, "cid-def", versions[1].CID)
-	require.Equal(t, "colv-2", versions[1].CollectionVersionId)
+	require.Equal(t, "colv-2", versions[1].CollectionVersionID)
 }
 
 func TestExtractVersionsFromDocument_WithoutVersionField(t *testing.T) {
@@ -1310,7 +1226,7 @@ func TestExtractVersionsFromDocument_NonStringCollectionVersionId(t *testing.T) 
 	require.NoError(t, err)
 	require.Len(t, versions, 1)
 	require.Equal(t, "cid-1", versions[0].CID)
-	require.Equal(t, "", versions[0].CollectionVersionId)
+	require.Equal(t, "", versions[0].CollectionVersionID)
 }
 
 // ========================================
@@ -1320,7 +1236,7 @@ func TestExtractVersionsFromDocument_NonStringCollectionVersionId(t *testing.T) 
 func TestCreateAttestationRecord_DefaultMaxConcurrentVerifications(t *testing.T) {
 	ctx := context.Background()
 	verifier := &MockSignatureVerifier{
-		verifyFunc: func(ctx context.Context, cid string, signature Signature) error {
+		verifyFunc: func(_ context.Context, _ string, _ Signature) error {
 			return nil
 		},
 	}
@@ -1350,8 +1266,8 @@ func TestCreateAttestationRecord_NilVersions(t *testing.T) {
 	record, err := CreateAttestationRecord(ctx, verifier, "doc-1", []string{"source-1"}, "TestDoc", nil, 50)
 	require.NoError(t, err)
 	require.NotNil(t, record)
-	require.Equal(t, "doc-1", record.AttestedDocId)
-	require.Equal(t, []string{"source-1"}, record.SourceDocIds)
+	require.Equal(t, "doc-1", record.AttestedDocID)
+	require.Equal(t, []string{"source-1"}, record.SourceDocIDs)
 	require.Len(t, record.CIDs, 0)
 	require.Equal(t, 1, record.VoteCount)
 }
@@ -1372,26 +1288,18 @@ func TestHandleDocumentAttestation_EmptyVersions(t *testing.T) {
 func TestHandleDocumentAttestation_AllSignaturesInvalid_NoCIDsPosted(t *testing.T) {
 	ctx := context.Background()
 	verifier := &MockSignatureVerifier{
-		verifyFunc: func(ctx context.Context, cid string, signature Signature) error {
-			return fmt.Errorf("invalid signature")
+		verifyFunc: func(_ context.Context, _ string, _ Signature) error {
+			return errInvalidSignature
 		},
 	}
 
-	testSchema := `
-		type Ethereum__Mainnet__AttestationRecord {
-			attested_doc: String @index
-			source_doc: [String]
-			CIDs: [String]
-			doc_type: String @index
-			vote_count: Int @crdt(type: pcounter)
-		}
-	`
+	testSchema := testAttestationRecordSchema
 
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -1399,7 +1307,7 @@ func TestHandleDocumentAttestation_AllSignaturesInvalid_NoCIDsPosted(t *testing.
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	err = client.ApplySchema(ctx, testSchema)
 	require.NoError(t, err)
@@ -1422,7 +1330,7 @@ func TestHandleDocumentAttestation_AllSignaturesInvalid_NoCIDsPosted(t *testing.
 		}
 	`, constants.CollectionAttestationRecord)
 
-	results, err := defra.QueryArray[AttestationRecord](ctx, defraNode, query)
+	results, err := defra.QueryArray[Record](ctx, defraNode, query)
 	require.NoError(t, err)
 	require.Empty(t, results)
 }
@@ -1430,26 +1338,18 @@ func TestHandleDocumentAttestation_AllSignaturesInvalid_NoCIDsPosted(t *testing.
 func TestHandleDocumentAttestation_ValidSignatures_PostsRecord(t *testing.T) {
 	ctx := context.Background()
 	verifier := &MockSignatureVerifier{
-		verifyFunc: func(ctx context.Context, cid string, signature Signature) error {
+		verifyFunc: func(_ context.Context, _ string, _ Signature) error {
 			return nil
 		},
 	}
 
-	testSchema := `
-		type Ethereum__Mainnet__AttestationRecord {
-			attested_doc: String @index
-			source_doc: [String]
-			CIDs: [String]
-			doc_type: String @index
-			vote_count: Int @crdt(type: pcounter)
-		}
-	`
+	testSchema := testAttestationRecordSchema
 
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -1457,7 +1357,7 @@ func TestHandleDocumentAttestation_ValidSignatures_PostsRecord(t *testing.T) {
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	err = client.ApplySchema(ctx, testSchema)
 	require.NoError(t, err)
@@ -1484,10 +1384,10 @@ func TestHandleDocumentAttestation_ValidSignatures_PostsRecord(t *testing.T) {
 		}
 	`, constants.CollectionAttestationRecord)
 
-	results, err := defra.QueryArray[AttestationRecord](ctx, defraNode, query)
+	results, err := defra.QueryArray[Record](ctx, defraNode, query)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
-	require.Equal(t, "doc-handle-1", results[0].AttestedDocId)
+	require.Equal(t, "doc-handle-1", results[0].AttestedDocID)
 	require.ElementsMatch(t, []string{"cid-1", "cid-2"}, results[0].CIDs)
 }
 
@@ -1528,8 +1428,8 @@ func TestHandleDocumentAttestationBatch_AllVersionsEmpty(t *testing.T) {
 func TestHandleDocumentAttestationBatch_AllSignaturesInvalid(t *testing.T) {
 	ctx := context.Background()
 	verifier := &MockSignatureVerifier{
-		verifyFunc: func(ctx context.Context, cid string, signature Signature) error {
-			return fmt.Errorf("invalid signature")
+		verifyFunc: func(_ context.Context, _ string, _ Signature) error {
+			return errInvalidSignature
 		},
 	}
 
@@ -1551,26 +1451,18 @@ func TestHandleDocumentAttestationBatch_AllSignaturesInvalid(t *testing.T) {
 func TestHandleDocumentAttestationBatch_ValidInputs_PostsRecords(t *testing.T) {
 	ctx := context.Background()
 	verifier := &MockSignatureVerifier{
-		verifyFunc: func(ctx context.Context, cid string, signature Signature) error {
+		verifyFunc: func(_ context.Context, _ string, _ Signature) error {
 			return nil
 		},
 	}
 
-	testSchema := `
-		type Ethereum__Mainnet__AttestationRecord {
-			attested_doc: String @index
-			source_doc: [String]
-			CIDs: [String]
-			doc_type: String @index
-			vote_count: Int @crdt(type: pcounter)
-		}
-	`
+	testSchema := testAttestationRecordSchema
 
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -1578,7 +1470,7 @@ func TestHandleDocumentAttestationBatch_ValidInputs_PostsRecords(t *testing.T) {
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	err = client.ApplySchema(ctx, testSchema)
 	require.NoError(t, err)
@@ -1615,13 +1507,13 @@ func TestHandleDocumentAttestationBatch_ValidInputs_PostsRecords(t *testing.T) {
 		}
 	`, constants.CollectionAttestationRecord)
 
-	results, err := defra.QueryArray[AttestationRecord](ctx, defraNode, query)
+	results, err := defra.QueryArray[Record](ctx, defraNode, query)
 	require.NoError(t, err)
 	require.Len(t, results, 2)
 
-	resultMap := make(map[string]AttestationRecord)
+	resultMap := make(map[string]Record)
 	for _, r := range results {
-		resultMap[r.AttestedDocId] = r
+		resultMap[r.AttestedDocID] = r
 	}
 
 	require.Contains(t, resultMap, "batch-doc-1")
@@ -1633,26 +1525,18 @@ func TestHandleDocumentAttestationBatch_ValidInputs_PostsRecords(t *testing.T) {
 func TestHandleDocumentAttestationBatch_MixedValidAndInvalidVersions(t *testing.T) {
 	ctx := context.Background()
 	verifier := &MockSignatureVerifier{
-		verifyFunc: func(ctx context.Context, cid string, signature Signature) error {
+		verifyFunc: func(_ context.Context, _ string, _ Signature) error {
 			return nil
 		},
 	}
 
-	testSchema := `
-		type Ethereum__Mainnet__AttestationRecord {
-			attested_doc: String @index
-			source_doc: [String]
-			CIDs: [String]
-			doc_type: String @index
-			vote_count: Int @crdt(type: pcounter)
-		}
-	`
+	testSchema := testAttestationRecordSchema
 
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -1660,7 +1544,7 @@ func TestHandleDocumentAttestationBatch_MixedValidAndInvalidVersions(t *testing.
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	err = client.ApplySchema(ctx, testSchema)
 	require.NoError(t, err)
@@ -1694,10 +1578,10 @@ func TestHandleDocumentAttestationBatch_MixedValidAndInvalidVersions(t *testing.
 		}
 	`, constants.CollectionAttestationRecord)
 
-	results, err := defra.QueryArray[AttestationRecord](ctx, defraNode, query)
+	results, err := defra.QueryArray[Record](ctx, defraNode, query)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
-	require.Equal(t, "batch-mixed-1", results[0].AttestedDocId)
+	require.Equal(t, "batch-mixed-1", results[0].AttestedDocID)
 }
 
 // ========================================
@@ -1707,21 +1591,13 @@ func TestHandleDocumentAttestationBatch_MixedValidAndInvalidVersions(t *testing.
 func TestCheckExistingAttestation_NoExistingRecords(t *testing.T) {
 	ctx := context.Background()
 
-	testSchema := `
-		type Ethereum__Mainnet__AttestationRecord {
-			attested_doc: String @index
-			source_doc: [String]
-			CIDs: [String]
-			doc_type: String @index
-			vote_count: Int @crdt(type: pcounter)
-		}
-	`
+	testSchema := testAttestationRecordSchema
 
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -1729,7 +1605,7 @@ func TestCheckExistingAttestation_NoExistingRecords(t *testing.T) {
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	err = client.ApplySchema(ctx, testSchema)
 	require.NoError(t, err)
@@ -1745,21 +1621,13 @@ func TestCheckExistingAttestation_NoExistingRecords(t *testing.T) {
 func TestCheckExistingAttestation_WithExistingRecord(t *testing.T) {
 	ctx := context.Background()
 
-	testSchema := `
-		type Ethereum__Mainnet__AttestationRecord {
-			attested_doc: String @index
-			source_doc: [String]
-			CIDs: [String]
-			doc_type: String @index
-			vote_count: Int @crdt(type: pcounter)
-		}
-	`
+	testSchema := testAttestationRecordSchema
 
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -1767,7 +1635,7 @@ func TestCheckExistingAttestation_WithExistingRecord(t *testing.T) {
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	err = client.ApplySchema(ctx, testSchema)
 	require.NoError(t, err)
@@ -1775,9 +1643,9 @@ func TestCheckExistingAttestation_WithExistingRecord(t *testing.T) {
 	defraNode := client.GetNode()
 
 	// First, create an attestation record
-	record := &AttestationRecord{
-		AttestedDocId: "check-existing-doc",
-		SourceDocIds:   []string{"source-doc"},
+	record := &Record{
+		AttestedDocID: "check-existing-doc",
+		SourceDocIDs:  []string{"source-doc"},
 		CIDs:          []string{"cid-check-1"},
 		DocType:       "TestDoc",
 		VoteCount:     1,
@@ -1790,29 +1658,21 @@ func TestCheckExistingAttestation_WithExistingRecord(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, records)
 	require.Len(t, records, 1)
-	require.Equal(t, "check-existing-doc", records[0].AttestedDocId)
-	require.Equal(t, []string{"source-doc"}, records[0].SourceDocIds)
+	require.Equal(t, "check-existing-doc", records[0].AttestedDocID)
+	require.Equal(t, []string{"source-doc"}, records[0].SourceDocIDs)
 	require.ElementsMatch(t, []string{"cid-check-1"}, records[0].CIDs)
 }
 
 func TestCheckExistingAttestation_WrongDocType(t *testing.T) {
 	ctx := context.Background()
 
-	testSchema := `
-		type Ethereum__Mainnet__AttestationRecord {
-			attested_doc: String @index
-			source_doc: [String]
-			CIDs: [String]
-			doc_type: String @index
-			vote_count: Int @crdt(type: pcounter)
-		}
-	`
+	testSchema := testAttestationRecordSchema
 
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -1820,7 +1680,7 @@ func TestCheckExistingAttestation_WrongDocType(t *testing.T) {
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	err = client.ApplySchema(ctx, testSchema)
 	require.NoError(t, err)
@@ -1828,9 +1688,9 @@ func TestCheckExistingAttestation_WrongDocType(t *testing.T) {
 	defraNode := client.GetNode()
 
 	// Create an attestation record with doc_type "TypeA"
-	record := &AttestationRecord{
-		AttestedDocId: "check-doctype-doc",
-		SourceDocIds:   []string{"source-doc"},
+	record := &Record{
+		AttestedDocID: "check-doctype-doc",
+		SourceDocIDs:  []string{"source-doc"},
 		CIDs:          []string{"cid-dt-1"},
 		DocType:       "TypeA",
 		VoteCount:     1,
@@ -1851,21 +1711,13 @@ func TestCheckExistingAttestation_WrongDocType(t *testing.T) {
 func TestIsDocumentAttestedViaBlock_NoBlockAttestation(t *testing.T) {
 	ctx := context.Background()
 
-	testSchema := `
-		type Ethereum__Mainnet__AttestationRecord {
-			attested_doc: String @index
-			source_doc: [String]
-			CIDs: [String]
-			doc_type: String @index
-			vote_count: Int @crdt(type: pcounter)
-		}
-	`
+	testSchema := testAttestationRecordSchema
 
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -1873,7 +1725,7 @@ func TestIsDocumentAttestedViaBlock_NoBlockAttestation(t *testing.T) {
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	err = client.ApplySchema(ctx, testSchema)
 	require.NoError(t, err)
@@ -1889,21 +1741,13 @@ func TestIsDocumentAttestedViaBlock_NoBlockAttestation(t *testing.T) {
 func TestIsDocumentAttestedViaBlock_CIDFound(t *testing.T) {
 	ctx := context.Background()
 
-	testSchema := `
-		type Ethereum__Mainnet__AttestationRecord {
-			attested_doc: String @index
-			source_doc: [String]
-			CIDs: [String]
-			doc_type: String @index
-			vote_count: Int @crdt(type: pcounter)
-		}
-	`
+	testSchema := testAttestationRecordSchema
 
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -1911,7 +1755,7 @@ func TestIsDocumentAttestedViaBlock_CIDFound(t *testing.T) {
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	err = client.ApplySchema(ctx, testSchema)
 	require.NoError(t, err)
@@ -1919,9 +1763,9 @@ func TestIsDocumentAttestedViaBlock_CIDFound(t *testing.T) {
 	defraNode := client.GetNode()
 
 	// Create a block attestation record with attested_doc = "block:42"
-	record := &AttestationRecord{
-		AttestedDocId: "block:42",
-		SourceDocIds:   []string{"block-source"},
+	record := &Record{
+		AttestedDocID: "block:42",
+		SourceDocIDs:  []string{"block-source"},
 		CIDs:          []string{"target-cid", "other-cid"},
 		DocType:       "Block",
 		VoteCount:     1,
@@ -1938,21 +1782,13 @@ func TestIsDocumentAttestedViaBlock_CIDFound(t *testing.T) {
 func TestIsDocumentAttestedViaBlock_CIDNotFound(t *testing.T) {
 	ctx := context.Background()
 
-	testSchema := `
-		type Ethereum__Mainnet__AttestationRecord {
-			attested_doc: String @index
-			source_doc: [String]
-			CIDs: [String]
-			doc_type: String @index
-			vote_count: Int @crdt(type: pcounter)
-		}
-	`
+	testSchema := testAttestationRecordSchema
 
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -1960,7 +1796,7 @@ func TestIsDocumentAttestedViaBlock_CIDNotFound(t *testing.T) {
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	err = client.ApplySchema(ctx, testSchema)
 	require.NoError(t, err)
@@ -1968,9 +1804,9 @@ func TestIsDocumentAttestedViaBlock_CIDNotFound(t *testing.T) {
 	defraNode := client.GetNode()
 
 	// Create a block attestation record
-	record := &AttestationRecord{
-		AttestedDocId: "block:50",
-		SourceDocIds:   []string{"block-source"},
+	record := &Record{
+		AttestedDocID: "block:50",
+		SourceDocIDs:  []string{"block-source"},
 		CIDs:          []string{"cid-in-block"},
 		DocType:       "Block",
 		VoteCount:     1,
@@ -1991,21 +1827,13 @@ func TestIsDocumentAttestedViaBlock_CIDNotFound(t *testing.T) {
 func TestGetBlockAttestations_NoRecords(t *testing.T) {
 	ctx := context.Background()
 
-	testSchema := `
-		type Ethereum__Mainnet__AttestationRecord {
-			attested_doc: String @index
-			source_doc: [String]
-			CIDs: [String]
-			doc_type: String @index
-			vote_count: Int @crdt(type: pcounter)
-		}
-	`
+	testSchema := testAttestationRecordSchema
 
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -2013,7 +1841,7 @@ func TestGetBlockAttestations_NoRecords(t *testing.T) {
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	err = client.ApplySchema(ctx, testSchema)
 	require.NoError(t, err)
@@ -2028,21 +1856,13 @@ func TestGetBlockAttestations_NoRecords(t *testing.T) {
 func TestGetBlockAttestations_WithRecords(t *testing.T) {
 	ctx := context.Background()
 
-	testSchema := `
-		type Ethereum__Mainnet__AttestationRecord {
-			attested_doc: String @index
-			source_doc: [String]
-			CIDs: [String]
-			doc_type: String @index
-			vote_count: Int @crdt(type: pcounter)
-		}
-	`
+	testSchema := testAttestationRecordSchema
 
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -2050,7 +1870,7 @@ func TestGetBlockAttestations_WithRecords(t *testing.T) {
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	err = client.ApplySchema(ctx, testSchema)
 	require.NoError(t, err)
@@ -2058,24 +1878,24 @@ func TestGetBlockAttestations_WithRecords(t *testing.T) {
 	defraNode := client.GetNode()
 
 	// Create block attestation records with the prefix "block:100:"
-	record1 := &AttestationRecord{
-		AttestedDocId: "block:100:merkle-root-a",
-		SourceDocIds:   []string{"indexer-1"},
+	record1 := &Record{
+		AttestedDocID: "block:100:merkle-root-a",
+		SourceDocIDs:  []string{"indexer-1"},
 		CIDs:          []string{"cid-100-a"},
 		DocType:       "Block",
 		VoteCount:     1,
 	}
-	record2 := &AttestationRecord{
-		AttestedDocId: "block:100:merkle-root-b",
-		SourceDocIds:   []string{"indexer-2"},
+	record2 := &Record{
+		AttestedDocID: "block:100:merkle-root-b",
+		SourceDocIDs:  []string{"indexer-2"},
 		CIDs:          []string{"cid-100-b"},
 		DocType:       "Block",
 		VoteCount:     1,
 	}
 	// Also create a record for a different block to make sure it's not returned
-	record3 := &AttestationRecord{
-		AttestedDocId: "block:200:merkle-root-c",
-		SourceDocIds:   []string{"indexer-1"},
+	record3 := &Record{
+		AttestedDocID: "block:200:merkle-root-c",
+		SourceDocIDs:  []string{"indexer-1"},
 		CIDs:          []string{"cid-200-c"},
 		DocType:       "Block",
 		VoteCount:     1,
@@ -2095,7 +1915,7 @@ func TestGetBlockAttestations_WithRecords(t *testing.T) {
 
 	attestedDocs := make(map[string]bool)
 	for _, r := range records {
-		attestedDocs[r.AttestedDocId] = true
+		attestedDocs[r.AttestedDocID] = true
 	}
 	require.True(t, attestedDocs["block:100:merkle-root-a"])
 	require.True(t, attestedDocs["block:100:merkle-root-b"])
@@ -2123,9 +1943,9 @@ func TestGetAttestationRecordsByViewName_WithDocIds(t *testing.T) {
 
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -2133,7 +1953,7 @@ func TestGetAttestationRecordsByViewName_WithDocIds(t *testing.T) {
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	err = client.ApplySchema(ctx, testSchema)
 	require.NoError(t, err)
@@ -2178,7 +1998,7 @@ func TestGetAttestationRecordsByViewName_WithDocIds(t *testing.T) {
 
 	attestedDocs := make(map[string]bool)
 	for _, r := range records {
-		attestedDocs[r.AttestedDocId] = true
+		attestedDocs[r.AttestedDocID] = true
 	}
 	require.True(t, attestedDocs["view-doc-1"])
 	require.True(t, attestedDocs["view-doc-3"])
@@ -2200,9 +2020,9 @@ func TestGetAttestationRecordsByViewName_WithoutDocIds(t *testing.T) {
 
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -2210,7 +2030,7 @@ func TestGetAttestationRecordsByViewName_WithoutDocIds(t *testing.T) {
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	err = client.ApplySchema(ctx, testSchema)
 	require.NoError(t, err)
@@ -2260,9 +2080,9 @@ func TestGetAttestationRecordsByViewName_EmptyDocIds(t *testing.T) {
 
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -2270,7 +2090,7 @@ func TestGetAttestationRecordsByViewName_EmptyDocIds(t *testing.T) {
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	err = client.ApplySchema(ctx, testSchema)
 	require.NoError(t, err)
@@ -2310,9 +2130,9 @@ func TestGetAttestationRecordsByViewName_NoRecords(t *testing.T) {
 
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -2320,7 +2140,7 @@ func TestGetAttestationRecordsByViewName_NoRecords(t *testing.T) {
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	err = client.ApplySchema(ctx, testSchema)
 	require.NoError(t, err)
@@ -2340,21 +2160,13 @@ func TestGetAttestationRecordsByViewName_NoRecords(t *testing.T) {
 func TestPostAttestationRecord_EmptyCIDs(t *testing.T) {
 	ctx := context.Background()
 
-	testSchema := `
-		type Ethereum__Mainnet__AttestationRecord {
-			attested_doc: String @index
-			source_doc: [String]
-			CIDs: [String]
-			doc_type: String @index
-			vote_count: Int @crdt(type: pcounter)
-		}
-	`
+	testSchema := testAttestationRecordSchema
 
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -2362,16 +2174,16 @@ func TestPostAttestationRecord_EmptyCIDs(t *testing.T) {
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	err = client.ApplySchema(ctx, testSchema)
 	require.NoError(t, err)
 
 	defraNode := client.GetNode()
 
-	record := &AttestationRecord{
-		AttestedDocId: "empty-cids-doc",
-		SourceDocIds:   []string{"source-doc"},
+	record := &Record{
+		AttestedDocID: "empty-cids-doc",
+		SourceDocIDs:  []string{"source-doc"},
 		CIDs:          []string{},
 		DocType:       "TestDoc",
 		VoteCount:     1,
@@ -2384,21 +2196,13 @@ func TestPostAttestationRecord_EmptyCIDs(t *testing.T) {
 func TestPostAttestationRecord_MultipleCIDs(t *testing.T) {
 	ctx := context.Background()
 
-	testSchema := `
-		type Ethereum__Mainnet__AttestationRecord {
-			attested_doc: String @index
-			source_doc: [String]
-			CIDs: [String]
-			doc_type: String @index
-			vote_count: Int @crdt(type: pcounter)
-		}
-	`
+	testSchema := testAttestationRecordSchema
 
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -2406,16 +2210,16 @@ func TestPostAttestationRecord_MultipleCIDs(t *testing.T) {
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	err = client.ApplySchema(ctx, testSchema)
 	require.NoError(t, err)
 
 	defraNode := client.GetNode()
 
-	record := &AttestationRecord{
-		AttestedDocId: "multi-cid-doc",
-		SourceDocIds:   []string{"source-doc"},
+	record := &Record{
+		AttestedDocID: "multi-cid-doc",
+		SourceDocIDs:  []string{"source-doc"},
 		CIDs:          []string{"cid-1", "cid-2", "cid-3"},
 		DocType:       "TestDoc",
 		VoteCount:     5,
@@ -2434,7 +2238,7 @@ func TestPostAttestationRecord_MultipleCIDs(t *testing.T) {
 		}
 	`, constants.CollectionAttestationRecord)
 
-	results, err := defra.QueryArray[AttestationRecord](ctx, defraNode, query)
+	results, err := defra.QueryArray[Record](ctx, defraNode, query)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	require.ElementsMatch(t, []string{"cid-1", "cid-2", "cid-3"}, results[0].CIDs)
@@ -2513,9 +2317,9 @@ func TestPostAttestationRecord_MissingSchema_ReturnsError(t *testing.T) {
 	// Create a defra node without the attestation schema applied
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -2523,14 +2327,14 @@ func TestPostAttestationRecord_MissingSchema_ReturnsError(t *testing.T) {
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	// Intentionally do NOT apply the schema - this will make the mutation fail
 	defraNode := client.GetNode()
 
-	record := &AttestationRecord{
-		AttestedDocId: "doc-error",
-		SourceDocIds:   []string{"source-error"},
+	record := &Record{
+		AttestedDocID: "doc-error",
+		SourceDocIDs:  []string{"source-error"},
 		CIDs:          []string{"cid-1"},
 		DocType:       "TestDoc",
 		VoteCount:     1,
@@ -2551,9 +2355,9 @@ func TestPostAttestationRecordsBatch_MissingSchema_ReturnsError(t *testing.T) {
 	// Create a defra node without the attestation schema
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -2561,15 +2365,15 @@ func TestPostAttestationRecordsBatch_MissingSchema_ReturnsError(t *testing.T) {
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	// Do NOT apply the attestation schema
 	defraNode := client.GetNode()
 
-	records := []*AttestationRecord{
+	records := []*Record{
 		{
-			AttestedDocId: "doc-1",
-			SourceDocIds:   []string{"source-1"},
+			AttestedDocID: "doc-1",
+			SourceDocIDs:  []string{"source-1"},
 			CIDs:          []string{"cid-1"},
 			DocType:       "TestDoc",
 			VoteCount:     1,
@@ -2587,21 +2391,13 @@ func TestPostAttestationRecordsBatch_AllNilOrEmptyCIDs_ReturnsNil(t *testing.T) 
 
 	// All records are nil or have empty CIDs - should return early with nil
 	// after filtering produces empty attestedDocIDs
-	testSchema := `
-		type Ethereum__Mainnet__AttestationRecord {
-			attested_doc: String @index
-			source_doc: [String]
-			CIDs: [String]
-			doc_type: String @index
-			vote_count: Int @crdt(type: pcounter)
-		}
-	`
+	testSchema := testAttestationRecordSchema
 
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -2609,7 +2405,7 @@ func TestPostAttestationRecordsBatch_AllNilOrEmptyCIDs_ReturnsNil(t *testing.T) 
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	err = client.ApplySchema(ctx, testSchema)
 	require.NoError(t, err)
@@ -2617,11 +2413,11 @@ func TestPostAttestationRecordsBatch_AllNilOrEmptyCIDs_ReturnsNil(t *testing.T) 
 	defraNode := client.GetNode()
 
 	// Mix of nil records and records with empty CIDs
-	records := []*AttestationRecord{
+	records := []*Record{
 		nil,
-		{AttestedDocId: "doc-1", SourceDocIds: []string{"src-1"}, CIDs: []string{}},
+		{AttestedDocID: "doc-1", SourceDocIDs: []string{"src-1"}, CIDs: []string{}},
 		nil,
-		{AttestedDocId: "doc-2", SourceDocIds: []string{"src-2"}, CIDs: []string{}},
+		{AttestedDocID: "doc-2", SourceDocIDs: []string{"src-2"}, CIDs: []string{}},
 	}
 
 	err = PostAttestationRecordsBatch(ctx, defraNode, records)
@@ -2635,7 +2431,7 @@ func TestPostAttestationRecordsBatch_AllNilOrEmptyCIDs_ReturnsNil(t *testing.T) 
 func TestHandleDocumentAttestation_PostAttestationRecordError(t *testing.T) {
 	ctx := context.Background()
 	verifier := &MockSignatureVerifier{
-		verifyFunc: func(ctx context.Context, cid string, signature Signature) error {
+		verifyFunc: func(_ context.Context, _ string, _ Signature) error {
 			return nil
 		},
 	}
@@ -2643,9 +2439,9 @@ func TestHandleDocumentAttestation_PostAttestationRecordError(t *testing.T) {
 	// Create a defra node without the attestation schema so PostAttestationRecord fails
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -2653,7 +2449,7 @@ func TestHandleDocumentAttestation_PostAttestationRecordError(t *testing.T) {
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	// Do NOT apply the attestation schema
 	defraNode := client.GetNode()
@@ -2678,29 +2474,21 @@ func TestHandleDocumentAttestationBatch_MixedEmptyAndValidAndInvalidSigs(t *test
 	// combined with inputs that have valid sigs, plus empty version inputs.
 	ctx := context.Background()
 	verifier := &MockSignatureVerifier{
-		verifyFunc: func(ctx context.Context, cid string, signature Signature) error {
+		verifyFunc: func(_ context.Context, cid string, _ Signature) error {
 			if cid == "fail-cid" {
-				return fmt.Errorf("invalid signature")
+				return errInvalidSignature
 			}
 			return nil
 		},
 	}
 
-	testSchema := `
-		type Ethereum__Mainnet__AttestationRecord {
-			attested_doc: String @index
-			source_doc: [String]
-			CIDs: [String]
-			doc_type: String @index
-			vote_count: Int @crdt(type: pcounter)
-		}
-	`
+	testSchema := testAttestationRecordSchema
 
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -2708,7 +2496,7 @@ func TestHandleDocumentAttestationBatch_MixedEmptyAndValidAndInvalidSigs(t *test
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	err = client.ApplySchema(ctx, testSchema)
 	require.NoError(t, err)
@@ -2748,10 +2536,10 @@ func TestHandleDocumentAttestationBatch_MixedEmptyAndValidAndInvalidSigs(t *test
 		}
 	`, constants.CollectionAttestationRecord)
 
-	results, err := defra.QueryArray[AttestationRecord](ctx, defraNode, query)
+	results, err := defra.QueryArray[Record](ctx, defraNode, query)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
-	require.Equal(t, "doc-valid", results[0].AttestedDocId)
+	require.Equal(t, "doc-valid", results[0].AttestedDocID)
 }
 
 // ========================================
@@ -2761,21 +2549,13 @@ func TestHandleDocumentAttestationBatch_MixedEmptyAndValidAndInvalidSigs(t *test
 func TestCheckExistingAttestation_ReturnsMultipleRecords(t *testing.T) {
 	ctx := context.Background()
 
-	testSchema := `
-		type Ethereum__Mainnet__AttestationRecord {
-			attested_doc: String @index
-			source_doc: [String]
-			CIDs: [String]
-			doc_type: String @index
-			vote_count: Int @crdt(type: pcounter)
-		}
-	`
+	testSchema := testAttestationRecordSchema
 
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -2783,7 +2563,7 @@ func TestCheckExistingAttestation_ReturnsMultipleRecords(t *testing.T) {
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	err = client.ApplySchema(ctx, testSchema)
 	require.NoError(t, err)
@@ -2792,9 +2572,9 @@ func TestCheckExistingAttestation_ReturnsMultipleRecords(t *testing.T) {
 
 	// Create two attestation records for same attested_doc and doc_type
 	// Using upsert, the second one will merge with the first
-	record1 := &AttestationRecord{
-		AttestedDocId: "multi-check-doc",
-		SourceDocIds:   []string{"source-1"},
+	record1 := &Record{
+		AttestedDocID: "multi-check-doc",
+		SourceDocIDs:  []string{"source-1"},
 		CIDs:          []string{"cid-1"},
 		DocType:       "TypeA",
 		VoteCount:     1,
@@ -2805,7 +2585,7 @@ func TestCheckExistingAttestation_ReturnsMultipleRecords(t *testing.T) {
 	records, err := CheckExistingAttestation(ctx, defraNode, "multi-check-doc", "TypeA")
 	require.NoError(t, err)
 	require.NotEmpty(t, records)
-	require.Equal(t, "multi-check-doc", records[0].AttestedDocId)
+	require.Equal(t, "multi-check-doc", records[0].AttestedDocID)
 }
 
 // ========================================
@@ -2816,21 +2596,13 @@ func TestIsDocumentAttestedViaBlock_MultipleRecords_CIDInSecond(t *testing.T) {
 	// Test that the function checks CIDs across all returned records
 	ctx := context.Background()
 
-	testSchema := `
-		type Ethereum__Mainnet__AttestationRecord {
-			attested_doc: String @index
-			source_doc: [String]
-			CIDs: [String]
-			doc_type: String @index
-			vote_count: Int @crdt(type: pcounter)
-		}
-	`
+	testSchema := testAttestationRecordSchema
 
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -2838,7 +2610,7 @@ func TestIsDocumentAttestedViaBlock_MultipleRecords_CIDInSecond(t *testing.T) {
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	err = client.ApplySchema(ctx, testSchema)
 	require.NoError(t, err)
@@ -2846,9 +2618,9 @@ func TestIsDocumentAttestedViaBlock_MultipleRecords_CIDInSecond(t *testing.T) {
 	defraNode := client.GetNode()
 
 	// Create a block attestation with specific CIDs
-	record := &AttestationRecord{
-		AttestedDocId: "block:77",
-		SourceDocIds:   []string{"block-source"},
+	record := &Record{
+		AttestedDocID: "block:77",
+		SourceDocIDs:  []string{"block-source"},
 		CIDs:          []string{"cid-a", "cid-b", "target-cid-77"},
 		DocType:       "Block",
 		VoteCount:     1,
@@ -2875,21 +2647,13 @@ func TestGetBlockAttestations_DifferentBlockNumbers(t *testing.T) {
 	// Make sure filtering by block prefix works correctly
 	ctx := context.Background()
 
-	testSchema := `
-		type Ethereum__Mainnet__AttestationRecord {
-			attested_doc: String @index
-			source_doc: [String]
-			CIDs: [String]
-			doc_type: String @index
-			vote_count: Int @crdt(type: pcounter)
-		}
-	`
+	testSchema := testAttestationRecordSchema
 
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -2897,7 +2661,7 @@ func TestGetBlockAttestations_DifferentBlockNumbers(t *testing.T) {
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	err = client.ApplySchema(ctx, testSchema)
 	require.NoError(t, err)
@@ -2906,9 +2670,9 @@ func TestGetBlockAttestations_DifferentBlockNumbers(t *testing.T) {
 
 	// Create block attestations for multiple blocks
 	for _, bn := range []int{300, 300, 301} {
-		record := &AttestationRecord{
-			AttestedDocId: fmt.Sprintf("block:%d:merkle-%d", bn, bn),
-			SourceDocIds:   []string{fmt.Sprintf("indexer-%d", bn)},
+		record := &Record{
+			AttestedDocID: fmt.Sprintf("block:%d:merkle-%d", bn, bn),
+			SourceDocIDs:  []string{fmt.Sprintf("indexer-%d", bn)},
 			CIDs:          []string{fmt.Sprintf("cid-%d", bn)},
 			DocType:       "Block",
 			VoteCount:     1,
@@ -2948,9 +2712,9 @@ func TestCheckExistingAttestation_MissingSchema_ReturnsNilNil(t *testing.T) {
 	// Create a defra node WITHOUT applying the attestation schema
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -2958,7 +2722,7 @@ func TestCheckExistingAttestation_MissingSchema_ReturnsNilNil(t *testing.T) {
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	// Do NOT apply the attestation schema - collection won't exist
 	defraNode := client.GetNode()
@@ -2985,9 +2749,9 @@ func TestIsDocumentAttestedViaBlock_MissingSchema_ReturnsFalseNil(t *testing.T) 
 	// Create a defra node WITHOUT applying the attestation schema
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -2995,7 +2759,7 @@ func TestIsDocumentAttestedViaBlock_MissingSchema_ReturnsFalseNil(t *testing.T) 
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	// Do NOT apply the attestation schema
 	defraNode := client.GetNode()
@@ -3015,9 +2779,9 @@ func TestGetBlockAttestations_MissingSchema_ReturnsNilNil(t *testing.T) {
 	// Create a defra node WITHOUT applying the attestation schema
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -3025,7 +2789,7 @@ func TestGetBlockAttestations_MissingSchema_ReturnsNilNil(t *testing.T) {
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	// Do NOT apply the attestation schema
 	defraNode := client.GetNode()
@@ -3066,7 +2830,7 @@ func TestExtractVersionsFromDocument_NonStringSignatureType(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, versions, 1)
 	require.Equal(t, "cid-nst", versions[0].CID)
-	require.Equal(t, "", versions[0].Signature.Type)       // Should be zero value
+	require.Equal(t, "", versions[0].Signature.Type) // Should be zero value
 	require.Equal(t, "identity-ok", versions[0].Signature.Identity)
 	require.Equal(t, "sig-ok", versions[0].Signature.Value)
 }
@@ -3178,7 +2942,7 @@ func TestExtractVersionsFromDocument_NoSignatureField(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, versions, 1)
 	require.Equal(t, "cid-no-sig", versions[0].CID)
-	require.Equal(t, "colv-1", versions[0].CollectionVersionId)
+	require.Equal(t, "colv-1", versions[0].CollectionVersionID)
 	require.Equal(t, "", versions[0].Signature.Type)
 	require.Equal(t, "", versions[0].Signature.Identity)
 	require.Equal(t, "", versions[0].Signature.Value)
@@ -3198,7 +2962,7 @@ func TestExtractVersionsFromDocument_NoCIDNoSignatureNoCollectionVersionId(t *te
 	require.NoError(t, err)
 	require.Len(t, versions, 1)
 	require.Equal(t, "", versions[0].CID)
-	require.Equal(t, "", versions[0].CollectionVersionId)
+	require.Equal(t, "", versions[0].CollectionVersionID)
 	require.Equal(t, "", versions[0].Signature.Type)
 }
 
@@ -3212,21 +2976,13 @@ func TestPostAttestationRecordsBatch_NilRecordsInSlice_SkipNilOnly(t *testing.T)
 	// loop (line 129) and the docs assembly loop (line 202).
 	ctx := context.Background()
 
-	testSchema := `
-		type Ethereum__Mainnet__AttestationRecord {
-			attested_doc: String @index
-			source_doc: [String]
-			CIDs: [String]
-			doc_type: String @index
-			vote_count: Int @crdt(type: pcounter)
-		}
-	`
+	testSchema := testAttestationRecordSchema
 
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -3234,18 +2990,18 @@ func TestPostAttestationRecordsBatch_NilRecordsInSlice_SkipNilOnly(t *testing.T)
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	err = client.ApplySchema(ctx, testSchema)
 	require.NoError(t, err)
 
 	defraNode := client.GetNode()
 
-	records := []*AttestationRecord{
+	records := []*Record{
 		nil,
-		{AttestedDocId: "nil-test-doc", SourceDocIds: []string{"src-nil"}, CIDs: []string{"cid-nil-1"}, DocType: "TestDoc", VoteCount: 1},
+		{AttestedDocID: "nil-test-doc", SourceDocIDs: []string{"src-nil"}, CIDs: []string{"cid-nil-1"}, DocType: "TestDoc", VoteCount: 1},
 		nil,
-		{AttestedDocId: "nil-test-doc-2", SourceDocIds: []string{"src-nil-2"}, CIDs: []string{}, DocType: "TestDoc", VoteCount: 1},
+		{AttestedDocID: "nil-test-doc-2", SourceDocIDs: []string{"src-nil-2"}, CIDs: []string{}, DocType: "TestDoc", VoteCount: 1},
 	}
 
 	err = PostAttestationRecordsBatch(ctx, defraNode, records)
@@ -3259,10 +3015,10 @@ func TestPostAttestationRecordsBatch_NilRecordsInSlice_SkipNilOnly(t *testing.T)
 		}
 	`, constants.CollectionAttestationRecord)
 
-	results, err := defra.QueryArray[AttestationRecord](ctx, defraNode, query)
+	results, err := defra.QueryArray[Record](ctx, defraNode, query)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
-	require.Equal(t, "nil-test-doc", results[0].AttestedDocId)
+	require.Equal(t, "nil-test-doc", results[0].AttestedDocID)
 }
 
 // ========================================
@@ -3368,21 +3124,13 @@ func TestExtractDocIDFromResult_MultipleDocsReturnsFirst(t *testing.T) {
 func TestLookupExistingAttestation_NotFound(t *testing.T) {
 	ctx := context.Background()
 
-	testSchema := `
-		type Ethereum__Mainnet__AttestationRecord {
-			attested_doc: String @index
-			source_doc: [String]
-			CIDs: [String]
-			doc_type: String @index
-			vote_count: Int @crdt(type: pcounter)
-		}
-	`
+	testSchema := testAttestationRecordSchema
 
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -3390,7 +3138,7 @@ func TestLookupExistingAttestation_NotFound(t *testing.T) {
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	err = client.ApplySchema(ctx, testSchema)
 	require.NoError(t, err)
@@ -3408,21 +3156,13 @@ func TestLookupExistingAttestation_NotFound(t *testing.T) {
 func TestLookupExistingAttestation_Found(t *testing.T) {
 	ctx := context.Background()
 
-	testSchema := `
-		type Ethereum__Mainnet__AttestationRecord {
-			attested_doc: String @index
-			source_doc: [String]
-			CIDs: [String]
-			doc_type: String @index
-			vote_count: Int @crdt(type: pcounter)
-		}
-	`
+	testSchema := testAttestationRecordSchema
 
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -3430,7 +3170,7 @@ func TestLookupExistingAttestation_Found(t *testing.T) {
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	err = client.ApplySchema(ctx, testSchema)
 	require.NoError(t, err)
@@ -3438,9 +3178,9 @@ func TestLookupExistingAttestation_Found(t *testing.T) {
 	defraNode := client.GetNode()
 
 	// Create a record first
-	record := &AttestationRecord{
-		AttestedDocId: "lookup-existing-doc",
-		SourceDocIds:   []string{"source-doc"},
+	record := &Record{
+		AttestedDocID: "lookup-existing-doc",
+		SourceDocIDs:  []string{"source-doc"},
 		CIDs:          []string{"cid-lookup"},
 		DocType:       "TestDoc",
 		VoteCount:     1,
@@ -3522,9 +3262,9 @@ func TestGetAttestationRecordsByViewName_MissingViewSchema(t *testing.T) {
 	// Create a defra node without any view-specific attestation schema
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -3532,7 +3272,7 @@ func TestGetAttestationRecordsByViewName_MissingViewSchema(t *testing.T) {
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	defer client.Stop(t.Context())
+	defer func() { _ = client.Stop(t.Context()) }()
 
 	defraNode := client.GetNode()
 

--- a/pkg/attestation/attestationRecordService_test.go
+++ b/pkg/attestation/attestationRecordService_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/shinzonetwork/shinzo-host-client/pkg/defradb"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/constants"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/defradb"
 	"github.com/stretchr/testify/require"
 )
 

--- a/pkg/attestation/blockSignatureVerifier.go
+++ b/pkg/attestation/blockSignatureVerifier.go
@@ -118,7 +118,7 @@ func (v *BlockSignatureVerifier) VerifyBlockSignature(sig *BlockSignature) error
 	case "Ed25519", "ed25519":
 		keyType = crypto.KeyTypeEd25519
 	default:
-		return fmt.Errorf("signature type %s: %w", sig.SignatureType, ErrUnsupportedSignatureType)
+		return fmt.Errorf("unsupported signature type: %s", sig.SignatureType)
 	}
 
 	pubKey, err := crypto.PublicKeyFromString(keyType, sig.SignatureIdentity)

--- a/pkg/attestation/blockSignatureVerifier.go
+++ b/pkg/attestation/blockSignatureVerifier.go
@@ -2,7 +2,6 @@ package attestation
 
 import (
 	"bytes"
-	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -14,7 +13,7 @@ import (
 	"github.com/sourcenetwork/defradb/crypto"
 )
 
-// BlockSignature represents a block signature from an indexer
+// BlockSignature represents a block signature from an indexer.
 type BlockSignature struct {
 	BlockNumber       int64    `json:"blockNumber"`
 	BlockHash         string   `json:"blockHash"`
@@ -27,14 +26,14 @@ type BlockSignature struct {
 	CreatedAt         string   `json:"createdAt"`
 }
 
-// BlockSignatureCache stores block signatures indexed by block number
+// BlockSignatureCache stores block signatures indexed by block number.
 type BlockSignatureCache struct {
 	mu         sync.RWMutex
 	signatures map[int64]*BlockSignature
 	maxSize    int
 }
 
-// NewBlockSignatureCache creates a new block signature cache
+// NewBlockSignatureCache creates a new block signature cache.
 func NewBlockSignatureCache(maxSize int) *BlockSignatureCache {
 	if maxSize <= 0 {
 		maxSize = 10000
@@ -45,7 +44,7 @@ func NewBlockSignatureCache(maxSize int) *BlockSignatureCache {
 	}
 }
 
-// Add adds a block signature to the cache
+// Add adds a block signature to the cache.
 func (c *BlockSignatureCache) Add(sig *BlockSignature) {
 	if sig == nil {
 		return
@@ -66,7 +65,7 @@ func (c *BlockSignatureCache) Add(sig *BlockSignature) {
 	}
 }
 
-// Get retrieves a block signature by block number
+// Get retrieves a block signature by block number.
 func (c *BlockSignatureCache) Get(blockNumber int64) (*BlockSignature, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -74,32 +73,32 @@ func (c *BlockSignatureCache) Get(blockNumber int64) (*BlockSignature, bool) {
 	return sig, ok
 }
 
-// BlockSignatureVerifier verifies block signatures and their CIDs
+// BlockSignatureVerifier verifies block signatures and their CIDs.
 type BlockSignatureVerifier struct {
 	cache *BlockSignatureCache
 }
 
-// NewBlockSignatureVerifier creates a new block signature verifier
+// NewBlockSignatureVerifier creates a new block signature verifier.
 func NewBlockSignatureVerifier(cacheSize int) *BlockSignatureVerifier {
 	return &BlockSignatureVerifier{
 		cache: NewBlockSignatureCache(cacheSize),
 	}
 }
 
-// AddBlockSignature adds a block signature to the verifier's cache
+// AddBlockSignature adds a block signature to the verifier's cache.
 func (v *BlockSignatureVerifier) AddBlockSignature(sig *BlockSignature) {
 	v.cache.Add(sig)
 }
 
-// GetBlockSignature retrieves a block signature by block number
+// GetBlockSignature retrieves a block signature by block number.
 func (v *BlockSignatureVerifier) GetBlockSignature(blockNumber int64) (*BlockSignature, bool) {
 	return v.cache.Get(blockNumber)
 }
 
-// VerifyBlockSignature verifies that a block signature is valid
-func (v *BlockSignatureVerifier) VerifyBlockSignature(ctx context.Context, sig *BlockSignature) error {
+// VerifyBlockSignature verifies that a block signature is valid.
+func (v *BlockSignatureVerifier) VerifyBlockSignature(sig *BlockSignature) error {
 	if sig == nil {
-		return fmt.Errorf("block signature is nil")
+		return ErrBlockSignatureNil
 	}
 
 	merkleRoot, err := hex.DecodeString(sig.MerkleRoot)
@@ -119,7 +118,7 @@ func (v *BlockSignatureVerifier) VerifyBlockSignature(ctx context.Context, sig *
 	case "Ed25519", "ed25519":
 		keyType = crypto.KeyTypeEd25519
 	default:
-		return fmt.Errorf("unsupported signature type: %s", sig.SignatureType)
+		return fmt.Errorf("signature type %s: %w", sig.SignatureType, ErrUnsupportedSignatureType)
 	}
 
 	pubKey, err := crypto.PublicKeyFromString(keyType, sig.SignatureIdentity)
@@ -132,21 +131,21 @@ func (v *BlockSignatureVerifier) VerifyBlockSignature(ctx context.Context, sig *
 		return fmt.Errorf("signature verification error: %w", err)
 	}
 	if !valid {
-		return fmt.Errorf("block signature verification failed for block %d", sig.BlockNumber)
+		return fmt.Errorf("block %d: %w", sig.BlockNumber, ErrBlockSigVerifyFailed)
 	}
 
 	return nil
 }
 
-// VerifyCIDsAgainstBlockSignature verifies that a list of CIDs matches a block signature's merkle root
+// VerifyCIDsAgainstBlockSignature verifies that a list of CIDs matches a block signature's merkle root.
 func (v *BlockSignatureVerifier) VerifyCIDsAgainstBlockSignature(cids []string, sig *BlockSignature) (bool, error) {
 	if sig == nil {
-		return false, fmt.Errorf("block signature is nil")
+		return false, ErrBlockSignatureNil
 	}
 
 	computedRoot := ComputeMerkleRootFromStrings(cids)
 	if computedRoot == nil {
-		return false, fmt.Errorf("failed to compute merkle root from CIDs")
+		return false, ErrComputeMerkleRoot
 	}
 
 	expectedRoot, err := hex.DecodeString(sig.MerkleRoot)
@@ -176,7 +175,7 @@ func (v *BlockSignatureVerifier) VerifyCIDListAgainstMerkleRoot(sig *BlockSignat
 }
 
 // ComputeMerkleRootFromStrings computes a merkle root from CID strings
-// This must match defradb/internal/core/block/block_signing.go
+// This must match defradb/internal/core/block/block_signing.go.
 func ComputeMerkleRootFromStrings(cidStrings []string) []byte {
 	if len(cidStrings) == 0 {
 		return nil
@@ -210,12 +209,14 @@ func ComputeMerkleRootFromStrings(cidStrings []string) []byte {
 		var newHashes [][]byte
 		for i := 0; i < len(hashes); i += 2 {
 			if i+1 < len(hashes) {
-				combined := append(hashes[i], hashes[i+1]...)
+				combined := make([]byte, 0, len(hashes[i])+len(hashes[i+1]))
+				combined = append(combined, hashes[i]...)
+				combined = append(combined, hashes[i+1]...)
 				hash := sha256.Sum256(combined)
 				newHashes = append(newHashes, hash[:])
-			} else {
-				newHashes = append(newHashes, hashes[i])
+				continue
 			}
+			newHashes = append(newHashes, hashes[i])
 		}
 		hashes = newHashes
 	}
@@ -223,7 +224,7 @@ func ComputeMerkleRootFromStrings(cidStrings []string) []byte {
 	return hashes[0]
 }
 
-// BlockCIDCollector collects CIDs for documents in a block for block signature verification
+// BlockCIDCollector collects CIDs for documents in a block for block signature verification.
 type BlockCIDCollector struct {
 	mu        sync.Mutex
 	blockCIDs map[int64][]string
@@ -231,7 +232,7 @@ type BlockCIDCollector struct {
 	docTypes  map[string]string
 }
 
-// NewBlockCIDCollector creates a new block CID collector
+// NewBlockCIDCollector creates a new block CID collector.
 func NewBlockCIDCollector() *BlockCIDCollector {
 	return &BlockCIDCollector{
 		blockCIDs: make(map[int64][]string),
@@ -240,7 +241,7 @@ func NewBlockCIDCollector() *BlockCIDCollector {
 	}
 }
 
-// AddDocumentCID adds a document's CID to the collector
+// AddDocumentCID adds a document's CID to the collector.
 func (c *BlockCIDCollector) AddDocumentCID(blockNumber int64, docID string, docType string, cid string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -249,7 +250,7 @@ func (c *BlockCIDCollector) AddDocumentCID(blockNumber int64, docID string, docT
 	c.docTypes[docID] = docType
 }
 
-// GetBlockCIDs returns all CIDs collected for a block
+// GetBlockCIDs returns all CIDs collected for a block.
 func (c *BlockCIDCollector) GetBlockCIDs(blockNumber int64) []string {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -262,7 +263,7 @@ func (c *BlockCIDCollector) GetBlockCIDs(blockNumber int64) []string {
 	return result
 }
 
-// ClearBlock removes all collected data for a block (call after processing)
+// ClearBlock removes all collected data for a block (call after processing).
 func (c *BlockCIDCollector) ClearBlock(blockNumber int64) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/pkg/attestation/blockSignatureVerifier.go
+++ b/pkg/attestation/blockSignatureVerifier.go
@@ -118,7 +118,7 @@ func (v *BlockSignatureVerifier) VerifyBlockSignature(sig *BlockSignature) error
 	case "Ed25519", "ed25519":
 		keyType = crypto.KeyTypeEd25519
 	default:
-		return fmt.Errorf("unsupported signature type: %s", sig.SignatureType)
+		return fmt.Errorf("%w: %v", ErrUnsupportedSignatureType, sig.SignatureType)
 	}
 
 	pubKey, err := crypto.PublicKeyFromString(keyType, sig.SignatureIdentity)

--- a/pkg/attestation/blockSignatureVerifier_test.go
+++ b/pkg/attestation/blockSignatureVerifier_test.go
@@ -1,7 +1,6 @@
 package attestation
 
 import (
-	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -72,13 +71,13 @@ func TestBlockSignatureCache_Add(t *testing.T) {
 	}{
 		{
 			name:      "nil signature is ignored",
-			setup:     func(c *BlockSignatureCache) {},
+			setup:     func(_ *BlockSignatureCache) {},
 			sig:       nil,
 			expectLen: 0,
 		},
 		{
 			name:  "add normal signature",
-			setup: func(c *BlockSignatureCache) {},
+			setup: func(_ *BlockSignatureCache) {},
 			sig: &BlockSignature{
 				BlockNumber: 10,
 				BlockHash:   "abc",
@@ -140,7 +139,7 @@ func TestBlockSignatureCache_Get(t *testing.T) {
 		},
 		{
 			name:        "get missing entry",
-			setup:       func(c *BlockSignatureCache) {},
+			setup:       func(_ *BlockSignatureCache) {},
 			blockNumber: 99,
 			expectFound: false,
 		},
@@ -270,11 +269,10 @@ func TestBlockSignatureVerifier_VerifyBlockSignature(t *testing.T) {
 	}
 
 	v := NewBlockSignatureVerifier(10)
-	ctx := context.Background()
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := v.VerifyBlockSignature(ctx, tt.sig)
+			err := v.VerifyBlockSignature(tt.sig)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), tt.wantErr)
 		})
@@ -551,7 +549,7 @@ func TestBlockCIDCollector_GetBlockCIDs(t *testing.T) {
 	}{
 		{
 			name:        "get missing block returns nil",
-			setup:       func(c *BlockCIDCollector) {},
+			setup:       func(_ *BlockCIDCollector) {},
 			blockNumber: 99,
 			expect:      nil,
 		},
@@ -633,7 +631,6 @@ func TestBlockSignatureVerifier_VerifyBlockSignature_Ed25519_Success(t *testing.
 	pubKeyHex, sigHex := signMerkleRoot(t, merkleRoot[:], crypto.KeyTypeEd25519)
 
 	v := NewBlockSignatureVerifier(10)
-	ctx := context.Background()
 
 	sig := &BlockSignature{
 		BlockNumber:       42,
@@ -643,7 +640,7 @@ func TestBlockSignatureVerifier_VerifyBlockSignature_Ed25519_Success(t *testing.
 		SignatureIdentity: pubKeyHex,
 	}
 
-	err := v.VerifyBlockSignature(ctx, sig)
+	err := v.VerifyBlockSignature(sig)
 	require.NoError(t, err)
 }
 
@@ -652,7 +649,6 @@ func TestBlockSignatureVerifier_VerifyBlockSignature_Ed25519Lowercase_Success(t 
 	pubKeyHex, sigHex := signMerkleRoot(t, merkleRoot[:], crypto.KeyTypeEd25519)
 
 	v := NewBlockSignatureVerifier(10)
-	ctx := context.Background()
 
 	sig := &BlockSignature{
 		BlockNumber:       43,
@@ -662,7 +658,7 @@ func TestBlockSignatureVerifier_VerifyBlockSignature_Ed25519Lowercase_Success(t 
 		SignatureIdentity: pubKeyHex,
 	}
 
-	err := v.VerifyBlockSignature(ctx, sig)
+	err := v.VerifyBlockSignature(sig)
 	require.NoError(t, err)
 }
 
@@ -672,7 +668,6 @@ func TestBlockSignatureVerifier_VerifyBlockSignature_Secp256k1_Success(t *testin
 	pubKeyHex, sigHex := signMerkleRoot(t, merkleRoot[:], crypto.KeyTypeSecp256k1)
 
 	v := NewBlockSignatureVerifier(10)
-	ctx := context.Background()
 
 	sig := &BlockSignature{
 		BlockNumber:       44,
@@ -682,7 +677,7 @@ func TestBlockSignatureVerifier_VerifyBlockSignature_Secp256k1_Success(t *testin
 		SignatureIdentity: pubKeyHex,
 	}
 
-	err := v.VerifyBlockSignature(ctx, sig)
+	err := v.VerifyBlockSignature(sig)
 	require.NoError(t, err)
 }
 
@@ -691,7 +686,6 @@ func TestBlockSignatureVerifier_VerifyBlockSignature_EcdsaAlias_Success(t *testi
 	pubKeyHex, sigHex := signMerkleRoot(t, merkleRoot[:], crypto.KeyTypeSecp256k1)
 
 	v := NewBlockSignatureVerifier(10)
-	ctx := context.Background()
 
 	sig := &BlockSignature{
 		BlockNumber:       45,
@@ -701,7 +695,7 @@ func TestBlockSignatureVerifier_VerifyBlockSignature_EcdsaAlias_Success(t *testi
 		SignatureIdentity: pubKeyHex,
 	}
 
-	err := v.VerifyBlockSignature(ctx, sig)
+	err := v.VerifyBlockSignature(sig)
 	require.NoError(t, err)
 }
 
@@ -715,7 +709,6 @@ func TestBlockSignatureVerifier_VerifyBlockSignature_InvalidSignature(t *testing
 	pubKeyHex, sigHex := signMerkleRoot(t, differentData[:], crypto.KeyTypeEd25519)
 
 	v := NewBlockSignatureVerifier(10)
-	ctx := context.Background()
 
 	sig := &BlockSignature{
 		BlockNumber:       46,
@@ -725,7 +718,7 @@ func TestBlockSignatureVerifier_VerifyBlockSignature_InvalidSignature(t *testing
 		SignatureIdentity: pubKeyHex,
 	}
 
-	err := v.VerifyBlockSignature(ctx, sig)
+	err := v.VerifyBlockSignature(sig)
 	require.Error(t, err)
 	// Should be either "signature verification error" or "block signature verification failed"
 	errMsg := err.Error()
@@ -744,7 +737,6 @@ func TestBlockSignatureVerifier_VerifyBlockSignature_Secp256k1_InvalidSignature(
 	pubKeyHex, sigHex := signMerkleRoot(t, differentData[:], crypto.KeyTypeSecp256k1)
 
 	v := NewBlockSignatureVerifier(10)
-	ctx := context.Background()
 
 	sig := &BlockSignature{
 		BlockNumber:       47,
@@ -754,7 +746,7 @@ func TestBlockSignatureVerifier_VerifyBlockSignature_Secp256k1_InvalidSignature(
 		SignatureIdentity: pubKeyHex,
 	}
 
-	err := v.VerifyBlockSignature(ctx, sig)
+	err := v.VerifyBlockSignature(sig)
 	require.Error(t, err)
 }
 
@@ -769,7 +761,6 @@ func TestBlockSignatureVerifier_VerifyBlockSignature_MalformedSignatureBytes(t *
 	pubKeyHex := privKey.GetPublic().String()
 
 	v := NewBlockSignatureVerifier(10)
-	ctx := context.Background()
 
 	sig := &BlockSignature{
 		BlockNumber:       48,
@@ -779,7 +770,7 @@ func TestBlockSignatureVerifier_VerifyBlockSignature_MalformedSignatureBytes(t *
 		SignatureIdentity: pubKeyHex,
 	}
 
-	err = v.VerifyBlockSignature(ctx, sig)
+	err = v.VerifyBlockSignature(sig)
 	require.Error(t, err)
 }
 
@@ -793,7 +784,6 @@ func TestBlockSignatureVerifier_VerifyBlockSignature_Ed25519_MalformedSignatureB
 	pubKeyHex := privKey.GetPublic().String()
 
 	v := NewBlockSignatureVerifier(10)
-	ctx := context.Background()
 
 	sig := &BlockSignature{
 		BlockNumber:       49,
@@ -803,7 +793,7 @@ func TestBlockSignatureVerifier_VerifyBlockSignature_Ed25519_MalformedSignatureB
 		SignatureIdentity: pubKeyHex,
 	}
 
-	err = v.VerifyBlockSignature(ctx, sig)
+	err = v.VerifyBlockSignature(sig)
 	require.Error(t, err)
 	errMsg := err.Error()
 	require.True(t,
@@ -854,10 +844,10 @@ func TestBlockCIDCollector_ConcurrentAccess(t *testing.T) {
 			c.AddDocumentCID(1, fmt.Sprintf("doc-%d", idx), "type", fmt.Sprintf("cid-%d", idx))
 			done <- true
 		}(i)
-		go func(idx int) {
+		go func() {
 			_ = c.GetBlockCIDs(1)
 			done <- true
-		}(i)
+		}()
 		go func() {
 			c.ClearBlock(2) // clear a different block concurrently
 			done <- true

--- a/pkg/attestation/constants_test.go
+++ b/pkg/attestation/constants_test.go
@@ -1,0 +1,34 @@
+package attestation
+
+const (
+	testDocID       = "doc-123"
+	testSourceDocID = "source-doc-456"
+
+	testKeyringSecret   = "test-keyring-secret-for-testing"
+	testListenAddrLocal = "localhost:0"
+	testListenAddrP2P   = "/ip4/0.0.0.0/tcp/0"
+
+	testDocAndAttestationSchema = `
+		type TestDoc {
+			name: String
+		}
+
+		type Ethereum__Mainnet__AttestationRecord {
+			attested_doc: String @index
+			source_doc: [String]
+			CIDs: [String]
+			doc_type: String @index
+			vote_count: Int @crdt(type: pcounter)
+		}
+	`
+
+	testAttestationRecordSchema = `
+		type Ethereum__Mainnet__AttestationRecord {
+			attested_doc: String @index
+			source_doc: [String]
+			CIDs: [String]
+			doc_type: String @index
+			vote_count: Int @crdt(type: pcounter)
+		}
+	`
+)

--- a/pkg/attestation/errors.go
+++ b/pkg/attestation/errors.go
@@ -1,0 +1,14 @@
+package attestation
+
+import "errors"
+
+var ( //nolint:revive
+	ErrBlockSignatureNil        = errors.New("block signature is nil")                                         //nolint:revive
+	ErrUnsupportedSignatureType = errors.New("unsupported signature type")                                     //nolint:revive
+	ErrBlockSigVerifyFailed     = errors.New("block signature verification failed")                            //nolint:revive
+	ErrComputeMerkleRoot        = errors.New("failed to compute merkle root from CIDs")                        //nolint:revive
+	ErrEmptyIdentityOrCID       = errors.New("empty identity or CID")                                          //nolint:revive
+	ErrInvalidSignatureType     = errors.New("invalid signature type")                                         //nolint:revive
+	ErrDefraDBUnavailable       = errors.New("defradb node or DB is not available for signature verification") //nolint:revive
+	ErrDifferentAttestedDocIDs  = errors.New("cannot merge records with different attested document IDs")      //nolint:revive
+)

--- a/pkg/attestation/errors.go
+++ b/pkg/attestation/errors.go
@@ -11,4 +11,5 @@ var ( //nolint:revive
 	ErrInvalidSignatureType     = errors.New("invalid signature type")                                         //nolint:revive
 	ErrDefraDBUnavailable       = errors.New("defradb node or DB is not available for signature verification") //nolint:revive
 	ErrDifferentAttestedDocIDs  = errors.New("cannot merge records with different attested document IDs")      //nolint:revive
+	ErrDocumentNotFound         = errors.New("document not found")                                             //nolint:revive
 )

--- a/pkg/attestation/errors_test.go
+++ b/pkg/attestation/errors_test.go
@@ -1,0 +1,5 @@
+package attestation
+
+import "errors"
+
+var errInvalidSignature = errors.New("invalid signature")

--- a/pkg/attestation/signatureVerifier.go
+++ b/pkg/attestation/signatureVerifier.go
@@ -10,21 +10,24 @@ import (
 	"github.com/sourcenetwork/defradb/node"
 )
 
+// SignatureVerifier defines the interface for verifying signatures. It abstracts the verification logic, allowing for different implementations (e.g., using DefraDB directly or a mock verifier for testing). The Verify method checks if the provided signature is valid for the given CID.
 type SignatureVerifier interface {
 	Verify(ctx context.Context, cid string, signature constants.Signature) error
 }
 
-// SignatureMetrics defines the metrics interface for signature verification
+// SignatureMetrics defines the metrics interface for signature verification.
 type SignatureMetrics interface {
 	IncrementSignatureVerifications()
 	IncrementSignatureFailures()
 }
 
+// DefraSignatureVerifier is an implementation of the SignatureVerifier interface that uses a DefraDB node to verify signatures directly against the database. It also reports metrics for successful verifications and failures.
 type DefraSignatureVerifier struct { // Implements SignatureVerifier interface
 	defraNode *node.Node
 	metrics   SignatureMetrics
 }
 
+// NewDefraSignatureVerifier creates a new instance of DefraSignatureVerifier with the provided DefraDB node and metrics. This verifier will use the DefraDB node to verify signatures directly against the database, and will report metrics for successful verifications and failures.
 func NewDefraSignatureVerifier(defraNode *node.Node, metrics SignatureMetrics) *DefraSignatureVerifier {
 	return &DefraSignatureVerifier{
 		defraNode: defraNode,
@@ -32,16 +35,16 @@ func NewDefraSignatureVerifier(defraNode *node.Node, metrics SignatureMetrics) *
 	}
 }
 
-// Verify verifies that the signature is valid for the given CID using DefraDB directly (no HTTP)
+// Verify verifies that the signature is valid for the given CID using DefraDB directly (no HTTP).
 func (v *DefraSignatureVerifier) Verify(ctx context.Context, cid string, signature constants.Signature) error {
 	if signature.Identity == "" || cid == "" {
-		return fmt.Errorf("empty identity or CID")
+		return ErrEmptyIdentityOrCID
 	}
-	if strings.ToUpper(signature.Type) != "ES256K" {
-		return fmt.Errorf("invalid signature type %s", signature.Type)
+	if !strings.EqualFold(signature.Type, "ES256K") {
+		return fmt.Errorf("signature type %s: %w", signature.Type, ErrInvalidSignatureType)
 	}
 	if v.defraNode == nil || v.defraNode.DB == nil {
-		return fmt.Errorf("defradb node or DB is not available for signature verification")
+		return ErrDefraDBUnavailable
 	}
 
 	// Parse the public key from the hex identity string
@@ -65,10 +68,12 @@ func (v *DefraSignatureVerifier) Verify(ctx context.Context, cid string, signatu
 	return nil
 }
 
+// MockSignatureVerifier is a mock implementation of the SignatureVerifier interface for testing purposes. It allows tests to define custom verification behavior by providing a function that will be called when Verify is invoked.
 type MockSignatureVerifier struct {
 	verifyFunc func(ctx context.Context, cid string, signature constants.Signature) error
 }
 
+// Verify calls the custom verify function if set, otherwise it returns nil (indicating success). This allows tests to define specific verification behavior by providing a custom function.
 func (m *MockSignatureVerifier) Verify(ctx context.Context, cid string, signature constants.Signature) error {
 	if m.verifyFunc != nil {
 		return m.verifyFunc(ctx, cid, signature)

--- a/pkg/attestation/signatureVerifier_test.go
+++ b/pkg/attestation/signatureVerifier_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// testMetrics implements SignatureMetrics for testing
+// testMetrics implements SignatureMetrics for testing.
 type testMetrics struct {
 	verifications atomic.Int64
 	failures      atomic.Int64
@@ -88,11 +88,11 @@ func TestSignatureVerifier_Validation(t *testing.T) {
 	}
 }
 
-// TestCachedSignatureVerifier_MockVerifier tests the MockSignatureVerifier behavior
+// TestCachedSignatureVerifier_MockVerifier tests the MockSignatureVerifier behavior.
 func TestCachedSignatureVerifier_MockVerifier(t *testing.T) {
 	// Test MockSignatureVerifier
 	mockVerifier := &MockSignatureVerifier{
-		verifyFunc: func(ctx context.Context, cid string, signature constants.Signature) error {
+		verifyFunc: func(_ context.Context, cid string, _ constants.Signature) error {
 			if cid == "error-cid" {
 				return assert.AnError
 			}
@@ -125,7 +125,7 @@ func TestDefraSignatureVerifier_Verify_InvalidIdentityFormat(t *testing.T) {
 	require.Contains(t, err.Error(), "empty identity")
 }
 
-// TestDefraSignatureVerifier_NilDB tests that verification fails gracefully when DB is nil
+// TestDefraSignatureVerifier_NilDB tests that verification fails gracefully when DB is nil.
 func TestDefraSignatureVerifier_NilDB(t *testing.T) {
 	ctx := context.Background()
 	verifier := NewDefraSignatureVerifier(nil, nil)
@@ -140,11 +140,11 @@ func TestDefraSignatureVerifier_NilDB(t *testing.T) {
 	require.Contains(t, err.Error(), "defradb node or DB is not available")
 }
 
-// TestMockSignatureVerifier_ConcurrentAccess tests thread safety of MockSignatureVerifier
+// TestMockSignatureVerifier_ConcurrentAccess tests thread safety of MockSignatureVerifier.
 func TestMockSignatureVerifier_ConcurrentAccess(t *testing.T) {
 	var callCount atomic.Int64
 	mockVerifier := &MockSignatureVerifier{
-		verifyFunc: func(ctx context.Context, cid string, signature constants.Signature) error {
+		verifyFunc: func(_ context.Context, _ string, _ constants.Signature) error {
 			callCount.Add(1)
 			return nil
 		},
@@ -163,7 +163,7 @@ func TestMockSignatureVerifier_ConcurrentAccess(t *testing.T) {
 
 	for range numGoroutines {
 		go func() {
-			mockVerifier.Verify(ctx, "concurrent-test", signature)
+			_ = mockVerifier.Verify(ctx, "concurrent-test", signature)
 			done <- true
 		}()
 	}
@@ -175,11 +175,11 @@ func TestMockSignatureVerifier_ConcurrentAccess(t *testing.T) {
 	assert.Equal(t, int64(numGoroutines), callCount.Load())
 }
 
-// TestMockSignatureVerifier_DifferentCIDs tests that MockSignatureVerifier handles different CIDs
+// TestMockSignatureVerifier_DifferentCIDs tests that MockSignatureVerifier handles different CIDs.
 func TestMockSignatureVerifier_DifferentCIDs(t *testing.T) {
 	callCount := 0
 	mockVerifier := &MockSignatureVerifier{
-		verifyFunc: func(ctx context.Context, cid string, signature constants.Signature) error {
+		verifyFunc: func(_ context.Context, _ string, _ constants.Signature) error {
 			callCount++
 			return nil
 		},
@@ -222,9 +222,9 @@ func setupDefraForVerifier(t *testing.T) *defra.Client {
 	`
 	testConfig := defra.DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.KeyringSecret = "test-keyring-secret-for-testing"
-	testConfig.DefraDB.Url = "localhost:0"
-	testConfig.DefraDB.P2P.ListenAddr = "/ip4/0.0.0.0/tcp/0"
+	testConfig.DefraDB.KeyringSecret = testKeyringSecret
+	testConfig.DefraDB.URL = testListenAddrLocal
+	testConfig.DefraDB.P2P.ListenAddr = testListenAddrP2P
 	testConfig.DefraDB.P2P.Enabled = false
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{}
 
@@ -232,7 +232,7 @@ func setupDefraForVerifier(t *testing.T) *defra.Client {
 	require.NoError(t, err)
 	err = client.Start(t.Context())
 	require.NoError(t, err)
-	t.Cleanup(func() { client.Stop(t.Context()) })
+	t.Cleanup(func() { _ = client.Stop(t.Context()) })
 
 	err = client.ApplySchema(t.Context(), testSchema)
 	require.NoError(t, err)
@@ -333,7 +333,7 @@ func TestDefraSignatureVerifier_Verify_Success_WithMetrics(t *testing.T) {
 
 	type TestDoc struct {
 		Name    string    `json:"name"`
-		DocId   string    `json:"_docID"`
+		DocID   string    `json:"_docID"`
 		Version []Version `json:"_version"`
 	}
 
@@ -377,7 +377,7 @@ func TestDefraSignatureVerifier_Verify_Success_NilMetrics(t *testing.T) {
 
 	type TestDoc struct {
 		Name    string    `json:"name"`
-		DocId   string    `json:"_docID"`
+		DocID   string    `json:"_docID"`
 		Version []Version `json:"_version"`
 	}
 

--- a/pkg/attestation/signatureVerifier_test.go
+++ b/pkg/attestation/signatureVerifier_test.go
@@ -5,8 +5,8 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/shinzonetwork/shinzo-host-client/pkg/defradb"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/constants"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/defradb"
 	"github.com/sourcenetwork/defradb/crypto"
 	"github.com/sourcenetwork/defradb/node"
 	"github.com/stretchr/testify/assert"

--- a/pkg/constants/accessListEntry.go
+++ b/pkg/constants/accessListEntry.go
@@ -1,11 +1,11 @@
 package constants
 
-// AccessListEntry represents an access list entry from Ethereum
+// AccessListEntry represents an access list entry from Ethereum.
 type AccessListEntry struct {
 	Address     string      `json:"address"`
 	StorageKeys []string    `json:"storageKeys"`
 	Transaction Transaction `json:"transaction"`
 
 	Version []Version `json:"_version"`
-	DocId   string    `json:"_docID"`
+	DocID   string    `json:"_docID"`
 }

--- a/pkg/constants/attestationRecord.go
+++ b/pkg/constants/attestationRecord.go
@@ -1,9 +1,9 @@
 package constants
 
-// AttestationRecord represents an attestation record in DefraDB
+// AttestationRecord represents an attestation record in DefraDB.
 type AttestationRecord struct {
-	AttestedDocId string   `json:"attested_doc"`
-	SourceDocIds  []string `json:"source_doc"`
+	AttestedDocID string   `json:"attested_doc"`
+	SourceDocIDs  []string `json:"source_doc"`
 	CIDs          []string `json:"CIDs"`
 	DocType       string   `json:"doc_type"`
 	VoteCount     int      `json:"vote_count"`

--- a/pkg/constants/block.go
+++ b/pkg/constants/block.go
@@ -1,6 +1,6 @@
 package constants
 
-// Block represents a block from EVM or similar chain
+// Block represents a block from EVM or similar chain.
 type Block struct {
 	Hash             string        `json:"hash"`
 	Number           uint64        `json:"number"`
@@ -25,5 +25,5 @@ type Block struct {
 	Transactions     []Transaction `json:"transactions"`
 
 	Version []Version `json:"_version"`
-	DocId   string    `json:"_docID"`
+	DocID   string    `json:"_docID"`
 }

--- a/pkg/constants/collections.go
+++ b/pkg/constants/collections.go
@@ -1,6 +1,6 @@
 package constants
 
-// DefraDB Collection Names - matches schema.graphql types
+// DefraDB Collection Names - matches schema.graphql types.
 const (
 	CollectionBlock             = "Ethereum__Mainnet__Block"
 	CollectionTransaction       = "Ethereum__Mainnet__Transaction"
@@ -14,7 +14,9 @@ const (
 
 // Collection name slice for bulk operations (used for P2P replication subscriptions).
 // AttestationRecord is excluded — each host builds its own attestation state independently.
-var AllCollections = []string{
+
+// AllCollections is a list of DefraDB collection names.
+var AllCollections = []string{ //nolint:gochecknoglobals
 	CollectionBlock,
 	CollectionTransaction,
 	CollectionAccessListEntry,

--- a/pkg/constants/lastProcessedPage.go
+++ b/pkg/constants/lastProcessedPage.go
@@ -1,5 +1,6 @@
 package constants
 
+// LastProcessedPage represents the last page number that was processed in a paginated query. This is used to track progress and resume processing from the correct point in case of interruptions.
 type LastProcessedPage struct {
 	Page int `json:"page"`
 }

--- a/pkg/constants/log.go
+++ b/pkg/constants/log.go
@@ -1,6 +1,6 @@
 package constants
 
-// Log represents a log from Ethereum
+// Log represents a log from Ethereum.
 type Log struct {
 	Address          string      `json:"address"`
 	Topics           []string    `json:"topics"`
@@ -15,5 +15,5 @@ type Log struct {
 	Transaction      Transaction `json:"transaction"`
 
 	Version []Version `json:"_version"`
-	DocId   string    `json:"_docID"`
+	DocID   string    `json:"_docID"`
 }

--- a/pkg/constants/signature.go
+++ b/pkg/constants/signature.go
@@ -1,6 +1,6 @@
 package constants
 
-// Signature represents a cryptographic signature
+// Signature represents a cryptographic signature.
 type Signature struct {
 	Type     string `json:"type"`
 	Identity string `json:"identity"`

--- a/pkg/constants/transaction.go
+++ b/pkg/constants/transaction.go
@@ -1,6 +1,6 @@
 package constants
 
-// Transaction represents a transaction from Ethereum
+// Transaction represents a transaction from Ethereum.
 type Transaction struct {
 	Hash                 string            `json:"hash"`
 	BlockHash            string            `json:"blockHash"`
@@ -16,7 +16,7 @@ type Transaction struct {
 	Nonce                string            `json:"nonce"`
 	TransactionIndex     int               `json:"transactionIndex"`
 	Type                 string            `json:"type"`
-	ChainId              string            `json:"chainId"`
+	ChainID              string            `json:"chainId"`
 	V                    string            `json:"v"`
 	R                    string            `json:"r"`
 	S                    string            `json:"s"`
@@ -28,5 +28,5 @@ type Transaction struct {
 	AccessList           []AccessListEntry `json:"accessList"`
 
 	Version []Version `json:"_version"`
-	DocId   string    `json:"_docID"`
+	DocID   string    `json:"_docID"`
 }

--- a/pkg/constants/version.go
+++ b/pkg/constants/version.go
@@ -1,8 +1,8 @@
 package constants
 
-// Version represents a version with signature information
+// Version represents a version with signature information.
 type Version struct {
 	CID                 string    `json:"cid"`
 	Signature           Signature `json:"signature"`
-	CollectionVersionId string    `json:"collectionVersionId"`
+	CollectionVersionID string    `json:"collectionVersionId"`
 }

--- a/pkg/defradb/config.go
+++ b/pkg/defradb/config.go
@@ -9,13 +9,15 @@ type Config struct {
 	Logger  LoggerConfig  `yaml:"logger"`
 }
 
-type DefraDBConfig struct {
-	Url           string           `yaml:"url"`
+// DefraDBConfig is a structure for passing the client config to app.
+type DefraDBConfig struct { //nolint:revive // TODO: remove the double reference to defra
+	URL           string           `yaml:"url"`
 	KeyringSecret string           `yaml:"keyring_secret"`
 	P2P           DefraP2PConfig   `yaml:"p2p"`
 	Store         DefraStoreConfig `yaml:"store"`
 }
 
+// DefraP2PConfig is a structure for the default behaviour.
 type DefraP2PConfig struct {
 	Enabled             bool     `yaml:"enabled"`
 	BootstrapPeers      []string `yaml:"bootstrap_peers"`
@@ -26,6 +28,7 @@ type DefraP2PConfig struct {
 	EnableAutoReconnect bool     `yaml:"enable_auto_reconnect"`
 }
 
+// DefraStoreConfig holds configuration for the DefraDB storage engine.
 type DefraStoreConfig struct {
 	Path string `yaml:"path"`
 	// Badger memory configuration.
@@ -40,6 +43,7 @@ type DefraStoreConfig struct {
 	ValueLogFileSizeMB int64 `yaml:"value_log_file_size_mb"`
 }
 
+// LoggerConfig holds configuration for the application logger.
 type LoggerConfig struct {
 	Development bool   `yaml:"development"`
 	LogsDir     string `yaml:"logs_dir"`

--- a/pkg/defradb/constants.go
+++ b/pkg/defradb/constants.go
@@ -1,0 +1,22 @@
+package defradb
+
+import "time"
+
+const (
+	// MaxRetries is the maximum number of retry attempts before giving up.
+	MaxRetries = 5
+	// RetryBaseDelayMs is the base delay in milliseconds between retry attempts.
+	RetryBaseDelayMs = 1000
+	// ReconnectIntervalsMs is the interval in milliseconds between reconnection attempts.
+	ReconnectIntervalsMs = 60000
+	// BlockCacheMB is the default block cache size in megabytes for the Badger store.
+	BlockCacheMB = 20
+	// MemTableMB is the default memtable size in megabytes for the Badger store.
+	MemTableMB = 20
+	// IndexCacheMB is the default index cache size in megabytes for the Badger store.
+	IndexCacheMB = 20
+	// BadgerFileSize is the default value-log file size in megabytes for the Badger store.
+	BadgerFileSize = 20
+	// BaseDelay is the base duration used for exponential backoff calculations.
+	BaseDelay = 30 * time.Second
+)

--- a/pkg/defradb/defra.go
+++ b/pkg/defradb/defra.go
@@ -23,17 +23,18 @@ import (
 	"github.com/sourcenetwork/immutable/enumerable"
 )
 
-var DefaultConfig *Config = &Config{
+// DefaultConfig provides the default configuration used when no config is supplied.
+var DefaultConfig = &Config{ //nolint:gochecknoglobals
 	DefraDB: DefraDBConfig{
-		Url:           "http://localhost:9181",
+		URL:           "http://localhost:9181",
 		KeyringSecret: os.Getenv("DEFRA_KEYRING_SECRET"),
 		P2P: DefraP2PConfig{
 			Enabled:             true,
 			BootstrapPeers:      requiredPeers,
 			ListenAddr:          defaultListenAddress,
-			MaxRetries:          5,
-			RetryBaseDelayMs:    1000,
-			ReconnectIntervalMs: 60000,
+			MaxRetries:          MaxRetries,
+			RetryBaseDelayMs:    RetryBaseDelayMs,
+			ReconnectIntervalMs: ReconnectIntervalsMs,
 			EnableAutoReconnect: true,
 		},
 		Store: DefraStoreConfig{
@@ -46,9 +47,14 @@ var DefaultConfig *Config = &Config{
 	},
 }
 
-var requiredPeers []string = []string{} // Here, we can add some "big peers" to give nodes a starting place when building their peer network
-const defaultListenAddress string = "/ip4/127.0.0.1/tcp/9171"
-const NodeIdentityKeyName string = "node-identity-key"
+//nolint:gochecknoglobals
+var requiredPeers = []string{} // default bootstrap peers used to initialize the P2P network configuration
+const (
+	// defaultListenAddress is the default multiaddr on which the P2P node listens for incoming connections.
+	defaultListenAddress string = "/ip4/127.0.0.1/tcp/9171"
+	// NodeIdentityKeyName is the key name used to store and retrieve the node identity key from the keyring.
+	NodeIdentityKeyName string = "node-identity-key"
+)
 
 // Key Management Implementation Notes:
 //
@@ -77,10 +83,10 @@ const NodeIdentityKeyName string = "node-identity-key"
 // silent nil return.
 func OpenKeyring(cfg *Config) (keyring.Keyring, error) {
 	if cfg == nil {
-		return nil, fmt.Errorf("config cannot be nil")
+		return nil, ErrEmptyConfig
 	}
 	if cfg.DefraDB.KeyringSecret == "" {
-		return nil, fmt.Errorf("KeyringSecret is required for keyring-based key management")
+		return nil, ErrNilKeyringSecret
 	}
 
 	// Use file-based keyring (default for DefraDB)
@@ -91,15 +97,15 @@ func OpenKeyring(cfg *Config) (keyring.Keyring, error) {
 	}
 
 	// Ensure directory exists
-	if err := os.MkdirAll(keyringPath, 0755); err != nil {
-		return nil, fmt.Errorf("failed to create keyring directory: %w", err)
+	if err := os.MkdirAll(keyringPath, 0o750); err != nil { //nolint:mnd
+		return nil, err
 	}
 
 	secret := []byte(cfg.DefraDB.KeyringSecret)
 	return keyring.OpenFileKeyring(keyringPath, secret)
 }
 
-// getOrCreateNodeIdentity retrieves an existing node identity from keyring or creates a new one
+// getOrCreateNodeIdentity retrieves an existing node identity from keyring or creates a new one.
 func getOrCreateNodeIdentity(cfg *Config) (identity.Identity, error) {
 	// Open keyring (required, no fallback)
 	kr, err := OpenKeyring(cfg)
@@ -134,24 +140,24 @@ func getOrCreateNodeIdentity(cfg *Config) (identity.Identity, error) {
 	return LoadIdentityFromBytes(identityBytes)
 }
 
-// saveNodeIdentityToKeyring saves the private key bytes of a node identity to the keyring
+// saveNodeIdentityToKeyring saves the private key bytes of a node identity to the keyring.
 func saveNodeIdentityToKeyring(kr keyring.Keyring, nodeIdentity identity.Identity) error {
 	// Cast to FullIdentity to access private key
 	fullIdentity, ok := nodeIdentity.(identity.FullIdentity)
 	if !ok {
-		return fmt.Errorf("identity is not a FullIdentity, cannot extract private key")
+		return ErrIdentityNotFull
 	}
 
 	// Get the private key from the identity
 	privateKey := fullIdentity.PrivateKey()
 	if privateKey == nil {
-		return fmt.Errorf("failed to get private key from identity")
+		return ErrPrivateKeyFailure
 	}
 
 	// Get raw key bytes
 	keyBytes := privateKey.Raw()
 	if len(keyBytes) == 0 {
-		return fmt.Errorf("private key has no raw bytes")
+		return ErrPrivateKeyNoBytes
 	}
 
 	// Format: "keyType:rawKeyBytes" (same format as DefraDB CLI)
@@ -160,7 +166,7 @@ func saveNodeIdentityToKeyring(kr keyring.Keyring, nodeIdentity identity.Identit
 
 	// Save to keyring
 	if err := kr.Set(NodeIdentityKeyName, identityBytes); err != nil {
-		return fmt.Errorf("failed to save identity to keyring: %w", err)
+		return err
 	}
 
 	logger.Sugar.Info("DefraDB identity private key saved to keyring")
@@ -184,13 +190,13 @@ func LoadIdentityFromBytes(identityBytes []byte) (identity.Identity, error) {
 	privateKey, err := crypto.PrivateKeyFromBytes(crypto.KeyType(keyType), keyBytes)
 	if err != nil {
 		var emptyIdentity identity.Identity
-		return emptyIdentity, fmt.Errorf("failed to reconstruct private key: %w", err)
+		return emptyIdentity, err
 	}
 
 	fullIdentity, err := identity.FromPrivateKey(privateKey)
 	if err != nil {
 		var emptyIdentity identity.Identity
-		return emptyIdentity, fmt.Errorf("failed to reconstruct identity from private key: %w", err)
+		return emptyIdentity, err
 	}
 
 	return fullIdentity, nil
@@ -202,7 +208,7 @@ func LoadIdentityFromBytes(identityBytes []byte) (identity.Identity, error) {
 func LoadIdentityFromKeyring(kr keyring.Keyring) (identity.Identity, error) {
 	identityBytes, err := kr.Get(NodeIdentityKeyName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get identity from keyring: %w", err)
+		return nil, err
 	}
 	return LoadIdentityFromBytes(identityBytes)
 }
@@ -217,7 +223,7 @@ func GetOrCreateNodeIdentity(cfg *Config) (identity.Identity, error) {
 func GetIdentityContext(ctx context.Context, cfg *Config) (context.Context, error) {
 	nodeIdentity, err := getOrCreateNodeIdentity(cfg)
 	if err != nil {
-		return ctx, fmt.Errorf("failed to get node identity: %w", err)
+		return ctx, err
 	}
 	return identity.WithContext(ctx, immutable.Some[identity.Identity](nodeIdentity)), nil
 }
@@ -230,42 +236,43 @@ func CreateLibP2PKeyFromIdentity(nodeIdentity identity.Identity) (libp2pcrypto.P
 	// Cast to FullIdentity to access private key
 	fullIdentity, ok := nodeIdentity.(identity.FullIdentity)
 	if !ok {
-		return nil, fmt.Errorf("identity is not a FullIdentity, cannot extract private key")
+		return nil, ErrIdentityNotFull
 	}
 
 	// Get the private key from the identity
 	privateKey := fullIdentity.PrivateKey()
 	if privateKey == nil {
-		return nil, fmt.Errorf("failed to get private key from identity")
+		return nil, ErrPrivateKeyFailure
 	}
 
 	// Get raw key bytes
 	keyBytes := privateKey.Raw()
 	if len(keyBytes) == 0 {
-		return nil, fmt.Errorf("private key has no raw bytes")
+		return nil, ErrPrivateKeyNoBytes
 	}
 
 	// DefraDB expects Ed25519 keys, but DefraDB identities use secp256k1
 	// We need to derive an Ed25519 key deterministically from the secp256k1 key
 	// Use the secp256k1 key bytes as seed for Ed25519 key generation
-	if len(keyBytes) != 32 {
-		return nil, fmt.Errorf("expected 32-byte secp256k1 key, got %d bytes", len(keyBytes))
+	if len(keyBytes) != 32 { // nolint:mnd
+		return nil, ErrKeyLengthError
 	}
 
 	// Generate Ed25519 key from secp256k1 seed
 	libp2pPrivKey, _, err := libp2pcrypto.GenerateEd25519Key(strings.NewReader(string(keyBytes)))
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate Ed25519 key from identity seed: %w", err)
+		return nil, err
 	}
 
 	return libp2pPrivKey, nil
 }
 
-func StartDefraInstance(cfg *Config, schemaApplier SchemaApplier, nodeOpts []options.Enumerable[options.NodeOptions], replicationFilter client.ReplicationFilter, collectionsOfInterest ...string) (*node.Node, *NetworkHandler, error) {
+// StartDefraInstance initializes and starts a DefraDB node instance with the provided configuration.
+func StartDefraInstance(cfg *Config, schemaApplier SchemaApplier, nodeOpts []options.Enumerable[options.NodeOptions], replicationFilter client.ReplicationFilter, collectionsOfInterest ...string) (*node.Node, *NetworkHandler, error) { //nolint:funlen //TODO fix length
 	ctx := context.Background()
 
 	if cfg == nil {
-		return nil, nil, fmt.Errorf("config cannot be nil")
+		return nil, nil, ErrEmptyConfig
 	}
 	cfg.DefraDB.P2P.BootstrapPeers = append(cfg.DefraDB.P2P.BootstrapPeers, requiredPeers...)
 	if len(cfg.DefraDB.P2P.ListenAddr) == 0 {
@@ -277,33 +284,33 @@ func StartDefraInstance(cfg *Config, schemaApplier SchemaApplier, nodeOpts []opt
 	// Use persistent identity from keyring (required, no fallback)
 	nodeIdentity, err := getOrCreateNodeIdentity(cfg)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error getting or creating identity: %w", err)
+		return nil, nil, err
 	}
 
 	// Create LibP2P private key from the same identity to ensure consistent peer ID
 	libp2pPrivKey, err := CreateLibP2PKeyFromIdentity(nodeIdentity)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error creating LibP2P private key from identity: %v", err)
+		return nil, nil, err
 	}
 
 	// Get raw bytes for P2P private key configuration (DefraDB 0.20 API TBD)
 	libp2pKeyBytes, err := libp2pPrivKey.Raw()
 	if err != nil {
-		return nil, nil, fmt.Errorf("error getting LibP2P private key bytes: %v", err)
+		return nil, nil, err
 	}
 
 	// Get real IP address to replace loopback addresses
 	ipAddress, err := getLANIP()
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get LAN IP address: %v", err)
+		return nil, nil, err
 	}
 
 	// Replace loopback addresses in URL with real IP
-	defraUrl := cfg.DefraDB.Url
-	defraUrl = strings.Replace(defraUrl, "http://localhost", ipAddress, 1)
-	defraUrl = strings.Replace(defraUrl, "http://127.0.0.1", ipAddress, 1)
-	defraUrl = strings.Replace(defraUrl, "localhost", ipAddress, 1)
-	defraUrl = strings.Replace(defraUrl, "127.0.0.1", ipAddress, 1)
+	defraURL := cfg.DefraDB.URL
+	defraURL = strings.Replace(defraURL, "http://localhost", ipAddress, 1)
+	defraURL = strings.Replace(defraURL, "http://127.0.0.1", ipAddress, 1)
+	defraURL = strings.Replace(defraURL, "localhost", ipAddress, 1)
+	defraURL = strings.Replace(defraURL, "127.0.0.1", ipAddress, 1)
 
 	// Replace loopback addresses in listen address with real IP
 	listenAddress := cfg.DefraDB.P2P.ListenAddr
@@ -318,23 +325,23 @@ func StartDefraInstance(cfg *Config, schemaApplier SchemaApplier, nodeOpts []opt
 		SetDisableP2P(false) // Enable P2P networking
 	nb.P2P().SetEnablePubSub(true)
 	nb.Store().SetPath(cfg.DefraDB.Store.Path)
-	nb.HTTP().SetAddress(defraUrl)
+	nb.HTTP().SetAddress(defraURL)
 	nb.DB().SetNodeIdentity(nodeIdentity)
 
 	// Apply badger memory configuration if specified
 	var storeOpts []func(*options.NodeOptions)
 	if cfg.DefraDB.Store.BlockCacheMB > 0 {
-		size := cfg.DefraDB.Store.BlockCacheMB << 20
+		size := cfg.DefraDB.Store.BlockCacheMB << BlockCacheMB
 		storeOpts = append(storeOpts, func(o *options.NodeOptions) { o.Store.BadgerBlockCacheSize = size })
 		logger.Sugar.Infof("Badger block cache size: %dMB", cfg.DefraDB.Store.BlockCacheMB)
 	}
 	if cfg.DefraDB.Store.MemTableMB > 0 {
-		size := cfg.DefraDB.Store.MemTableMB << 20
+		size := cfg.DefraDB.Store.MemTableMB << MemTableMB
 		storeOpts = append(storeOpts, func(o *options.NodeOptions) { o.Store.BadgerMemTableSize = size })
 		logger.Sugar.Infof("Badger memtable size: %dMB", cfg.DefraDB.Store.MemTableMB)
 	}
 	if cfg.DefraDB.Store.IndexCacheMB > 0 {
-		size := cfg.DefraDB.Store.IndexCacheMB << 20
+		size := cfg.DefraDB.Store.IndexCacheMB << IndexCacheMB
 		storeOpts = append(storeOpts, func(o *options.NodeOptions) { o.Store.BadgerIndexCacheSize = size })
 		logger.Sugar.Infof("Badger index cache size: %dMB", cfg.DefraDB.Store.IndexCacheMB)
 	}
@@ -357,7 +364,7 @@ func StartDefraInstance(cfg *Config, schemaApplier SchemaApplier, nodeOpts []opt
 	if vlogSizeMB <= 0 {
 		vlogSizeMB = 64
 	}
-	nb.Store().SetBadgerFileSize(vlogSizeMB << 20)
+	nb.Store().SetBadgerFileSize(vlogSizeMB << BadgerFileSize)
 	logger.Sugar.Infof("Badger value log file size: %dMB", vlogSizeMB)
 
 	// Add P2P configuration options
@@ -380,7 +387,7 @@ func StartDefraInstance(cfg *Config, schemaApplier SchemaApplier, nodeOpts []opt
 
 	defraNode, err := node.New(ctx, allOpts...)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create defra node: %v ", err)
+		return nil, nil, fmt.Errorf("failed to create defra node: %w ", err)
 	}
 
 	if replicationFilter != nil {
@@ -389,7 +396,7 @@ func StartDefraInstance(cfg *Config, schemaApplier SchemaApplier, nodeOpts []opt
 
 	err = defraNode.Start(ctx)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to start defra node: %v ", err)
+		return nil, nil, fmt.Errorf("failed to start defra node: %w ", err)
 	}
 
 	err = schemaApplier.ApplySchema(ctx, defraNode)
@@ -397,8 +404,8 @@ func StartDefraInstance(cfg *Config, schemaApplier SchemaApplier, nodeOpts []opt
 		if strings.Contains(err.Error(), "collection already exists") {
 			logger.Sugar.Warnf("Failed to apply schema: %v\nProceeding...", err)
 		} else {
-			defer defraNode.Close(ctx)
-			return nil, nil, fmt.Errorf("failed to apply schema: %v", err)
+			defer func() { _ = defraNode.Close(ctx) }()
+			return nil, nil, fmt.Errorf("failed to apply schema: %w", err)
 		}
 	}
 
@@ -424,19 +431,19 @@ func StartDefraInstance(cfg *Config, schemaApplier SchemaApplier, nodeOpts []opt
 	return defraNode, networkHandler, nil
 }
 
-// A simple wrapper on StartDefraInstance that changes the configured defra store path to a temp directory for the test
+// StartDefraInstanceWithTestConfig is a simple wrapper on StartDefraInstance that changes the configured defra store path to a temp directory for the test.
 func StartDefraInstanceWithTestConfig(t *testing.T, cfg *Config, schemaApplier SchemaApplier, collectionsOfInterest ...string) (*node.Node, error) {
 	ipAddress, err := getLANIP()
 	if err != nil {
 		return nil, err
 	}
 	listenAddress := fmt.Sprintf("/ip4/%s/tcp/0", ipAddress)
-	defraUrl := fmt.Sprintf("%s:0", ipAddress)
+	defraURL := fmt.Sprintf("%s:0", ipAddress)
 	if cfg == nil {
 		cfg = DefaultConfig
 	}
 	cfg.DefraDB.Store.Path = t.TempDir()
-	cfg.DefraDB.Url = defraUrl
+	cfg.DefraDB.URL = defraURL
 	cfg.DefraDB.P2P.ListenAddr = listenAddress
 	cfg.DefraDB.KeyringSecret = "testSecret"
 	node, _, err := StartDefraInstance(cfg, schemaApplier, nil, nil, collectionsOfInterest...)
@@ -452,12 +459,12 @@ func Subscribe[T any](ctx context.Context, defraNode *node.Node, subscription st
 	if result.Subscription == nil {
 		// Check if there are GraphQL errors that explain why subscription is nil
 		if result.GQL.Errors != nil {
-			return nil, fmt.Errorf("subscription failed with GraphQL errors: %v", result.GQL.Errors)
+			return nil, fmt.Errorf("subscription failed with GraphQL errors: %v", result.GQL.Errors) // nolint:err113
 		}
-		return nil, fmt.Errorf("subscription channel is nil - DefraDB may not support subscriptions for this query: %s", subscription)
+		return nil, ErrNilSubscriptionChannel
 	}
 
-	resultChan := make(chan T, 100000)
+	resultChan := make(chan T, 100000) // nolint:mnd
 
 	go func() {
 		defer close(resultChan)
@@ -499,7 +506,7 @@ func Subscribe[T any](ctx context.Context, defraNode *node.Node, subscription st
 
 // marshalUnmarshal converts a generic interface{} to a specific typed struct
 // using JSON marshal/unmarshal. This is the same pattern used throughout the query client.
-func marshalUnmarshal(data interface{}, target interface{}) error {
+func marshalUnmarshal(data any, target any) error {
 	dataBytes, err := json.Marshal(data)
 	if err != nil {
 		return fmt.Errorf("failed to marshal data: %w", err)
@@ -511,17 +518,17 @@ func marshalUnmarshal(data interface{}, target interface{}) error {
 // NEW CLIENT API - Clean alternative to StartDefraInstance
 // ====================================================================
 
-// Client provides a clean interface for DefraDB operations
+// Client provides a clean interface for DefraDB operations.
 type Client struct {
 	node    *node.Node
 	network *NetworkHandler
 	config  *Config
 }
 
-// NewClient creates a new client instance (doesn't start anything)
+// NewClient creates a new client instance (doesn't start anything).
 func NewClient(cfg *Config) (*Client, error) {
 	if cfg == nil {
-		return nil, fmt.Errorf("config cannot be nil")
+		return nil, ErrEmptyConfig
 	}
 
 	return &Client{
@@ -529,10 +536,10 @@ func NewClient(cfg *Config) (*Client, error) {
 	}, nil
 }
 
-// Start initializes key generation, node startup, and network handler
-func (c *Client) Start(ctx context.Context) error {
+// Start initializes key generation, node startup, and network handler.
+func (c *Client) Start(ctx context.Context) error { // nolint:funlen
 	if c.node != nil {
-		return fmt.Errorf("client already started")
+		return ErrClientStarted
 	}
 
 	// Use the same core logic as StartDefraInstance but without schema
@@ -552,27 +559,27 @@ func (c *Client) Start(ctx context.Context) error {
 	// Create LibP2P private key from the same identity to ensure consistent peer ID
 	libp2pPrivKey, err := CreateLibP2PKeyFromIdentity(nodeIdentity)
 	if err != nil {
-		return fmt.Errorf("error creating LibP2P private key from identity: %v", err)
+		return fmt.Errorf("error creating LibP2P private key from identity: %w", err)
 	}
 
 	// Get raw bytes for P2P private key configuration
 	libp2pKeyBytes, err := libp2pPrivKey.Raw()
 	if err != nil {
-		return fmt.Errorf("error getting LibP2P private key bytes: %v", err)
+		return fmt.Errorf("error getting LibP2P private key bytes: %w", err)
 	}
 
 	// Get real IP address to replace loopback addresses
 	ipAddress, err := getLANIP()
 	if err != nil {
-		return fmt.Errorf("failed to get LAN IP address: %v", err)
+		return fmt.Errorf("failed to get LAN IP address: %w", err)
 	}
 
 	// Replace loopback addresses in URL with real IP
-	defraUrl := c.config.DefraDB.Url
-	defraUrl = strings.Replace(defraUrl, "http://localhost", ipAddress, 1)
-	defraUrl = strings.Replace(defraUrl, "http://127.0.0.1", ipAddress, 1)
-	defraUrl = strings.Replace(defraUrl, "localhost", ipAddress, 1)
-	defraUrl = strings.Replace(defraUrl, "127.0.0.1", ipAddress, 1)
+	defraURL := c.config.DefraDB.URL
+	defraURL = strings.Replace(defraURL, "http://localhost", ipAddress, 1)
+	defraURL = strings.Replace(defraURL, "http://127.0.0.1", ipAddress, 1)
+	defraURL = strings.Replace(defraURL, "localhost", ipAddress, 1)
+	defraURL = strings.Replace(defraURL, "127.0.0.1", ipAddress, 1)
 
 	// Replace loopback addresses in listen address with real IP
 	listenAddress := c.config.DefraDB.P2P.ListenAddr
@@ -587,21 +594,21 @@ func (c *Client) Start(ctx context.Context) error {
 		SetDisableP2P(false)
 	nb.P2P().SetEnablePubSub(true)
 	nb.Store().SetPath(c.config.DefraDB.Store.Path)
-	nb.HTTP().SetAddress(defraUrl)
+	nb.HTTP().SetAddress(defraURL)
 	nb.DB().SetNodeIdentity(nodeIdentity)
 
 	// Apply badger memory configuration if specified
 	var storeOpts []func(*options.NodeOptions)
 	if c.config.DefraDB.Store.BlockCacheMB > 0 {
-		size := c.config.DefraDB.Store.BlockCacheMB << 20
+		size := c.config.DefraDB.Store.BlockCacheMB << BlockCacheMB
 		storeOpts = append(storeOpts, func(o *options.NodeOptions) { o.Store.BadgerBlockCacheSize = size })
 	}
 	if c.config.DefraDB.Store.MemTableMB > 0 {
-		size := c.config.DefraDB.Store.MemTableMB << 20
+		size := c.config.DefraDB.Store.MemTableMB << MemTableMB
 		storeOpts = append(storeOpts, func(o *options.NodeOptions) { o.Store.BadgerMemTableSize = size })
 	}
 	if c.config.DefraDB.Store.IndexCacheMB > 0 {
-		size := c.config.DefraDB.Store.IndexCacheMB << 20
+		size := c.config.DefraDB.Store.IndexCacheMB << IndexCacheMB
 		storeOpts = append(storeOpts, func(o *options.NodeOptions) { o.Store.BadgerIndexCacheSize = size })
 	}
 	if c.config.DefraDB.Store.NumCompactors > 0 {
@@ -621,7 +628,7 @@ func (c *Client) Start(ctx context.Context) error {
 		if vlogSizeMB <= 0 {
 			vlogSizeMB = 64
 		}
-		nb.Store().SetBadgerFileSize(vlogSizeMB << 20)
+		nb.Store().SetBadgerFileSize(vlogSizeMB << BadgerFileSize)
 	}
 
 	if len(listenAddress) > 0 {
@@ -642,12 +649,12 @@ func (c *Client) Start(ctx context.Context) error {
 
 	c.node, err = node.New(ctx, allOpts...)
 	if err != nil {
-		return fmt.Errorf("failed to create defra node: %v", err)
+		return fmt.Errorf("failed to create defra node: %w", err)
 	}
 
 	err = c.node.Start(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to start defra node: %v", err)
+		return fmt.Errorf("failed to start defra node: %w", err)
 	}
 
 	// Create network handler
@@ -665,7 +672,7 @@ func (c *Client) Start(ctx context.Context) error {
 	return nil
 }
 
-// Stop cleanly shuts down the client
+// Stop cleanly shuts down the client.
 func (c *Client) Stop(ctx context.Context) error {
 	if c.node == nil {
 		return nil
@@ -677,14 +684,14 @@ func (c *Client) Stop(ctx context.Context) error {
 	return err
 }
 
-// ApplySchema applies a GraphQL schema string to the started node
+// ApplySchema applies a GraphQL schema string to the started node.
 func (c *Client) ApplySchema(ctx context.Context, schema string) error {
 	if c.node == nil {
-		return fmt.Errorf("client must be started before applying schema")
+		return ErrClientMustBeStarted
 	}
 
 	if len(schema) == 0 {
-		return fmt.Errorf("schema cannot be empty")
+		return ErrEmptySchema
 	}
 
 	_, err := c.node.DB.AddSchema(ctx, schema)
@@ -693,18 +700,18 @@ func (c *Client) ApplySchema(ctx context.Context, schema string) error {
 			logger.Sugar.Warnf("Failed to apply schema: %v\nProceeding...", err)
 			return nil
 		}
-		return fmt.Errorf("failed to apply schema: %v", err)
+		return fmt.Errorf("failed to apply schema: %w", err)
 	}
 
 	return nil
 }
 
-// GetNode returns the underlying DefraDB node
+// GetNode returns the underlying DefraDB node.
 func (c *Client) GetNode() *node.Node {
 	return c.node
 }
 
-// GetNetworkHandler returns the network handler
+// GetNetworkHandler returns the network handler.
 func (c *Client) GetNetworkHandler() *NetworkHandler {
 	return c.network
 }

--- a/pkg/defradb/errors.go
+++ b/pkg/defradb/errors.go
@@ -1,0 +1,66 @@
+package defradb
+
+import "errors"
+
+var (
+	// defra.go.
+
+	// ErrEmptyConfig is returned when a nil config is provided.
+	ErrEmptyConfig = errors.New("config cannot be nil")
+	// ErrNilKeyringSecret is returned when no keyring secret is provided for keyring-based key management.
+	ErrNilKeyringSecret = errors.New("keyringSecret is required for keyring-based key management")
+	// ErrIdentityNotFull is returned when an identity does not implement FullIdentity and a private key is required.
+	ErrIdentityNotFull = errors.New("identity is not a FullIdentity, cannot extract private key")
+	// ErrPrivateKeyFailure is returned when extracting a private key from an identity fails.
+	ErrPrivateKeyFailure = errors.New("failed to get private key from identity")
+	// ErrPrivateKeyNoBytes is returned when a private key yields no raw bytes.
+	ErrPrivateKeyNoBytes = errors.New("private key has no raw bytes")
+	// ErrKeyLengthError is returned when a secp256k1 key is not exactly 32 bytes.
+	ErrKeyLengthError = errors.New("expected 32-byte secp256k1 key")
+	// ErrNilSubscriptionChannel is returned when a subscription channel is nil.
+	ErrNilSubscriptionChannel = errors.New("subscription channel is nil")
+	// ErrClientStarted is returned when attempting to start a client that is already running.
+	ErrClientStarted = errors.New("client already started")
+	// ErrClientMustBeStarted is returned when an operation requires the client to be started first.
+	ErrClientMustBeStarted = errors.New("client must be started before applying schema")
+	// ErrEmptySchema is returned when an empty schema string is provided.
+	ErrEmptySchema = errors.New("schema cannot be empty")
+	// ErrNoPeerFound is returned when a requested peer cannot be located.
+	ErrNoPeerFound = errors.New("peer not found")
+	// ErrNoP2PMesh is returned when all active peers have been lost and the P2P mesh is down.
+	ErrNoP2PMesh = errors.New("P2P mesh lost - no active peers")
+	// ErrPeerDisconnected is returned when a peer unexpectedly disconnects.
+	ErrPeerDisconnected = errors.New("peer disconnected")
+	// ErrPeerAlreadyAdded is returned when attempting to add a peer that already exists.
+	ErrPeerAlreadyAdded = errors.New("peer already exists")
+	// ErrInvalidBootstrapPeer is returned when a bootstrap peer entry is malformed or unusable.
+	ErrInvalidBootstrapPeer = errors.New("bootstrap peer is invalid and will be skipped")
+	// ErrPeerEmptyID is returned when a bootstrap peer has no peer ID.
+	ErrPeerEmptyID = errors.New("peer has empty ID and will be skipped")
+	// ErrPeerNoAddresses is returned when a bootstrap peer has no addresses to dial.
+	ErrPeerNoAddresses = errors.New("peer has no addresses and will be skipped")
+
+	// query.go.
+
+	// ErrDefraNodeNil is returned when a nil defraNode is passed to a query function.
+	ErrDefraNodeNil = errors.New("defraNode parameter cannot be nil")
+	// ErrQueryEmpty is returned when an empty query string is provided.
+	ErrQueryEmpty = errors.New("query parameter is empty")
+	// ErrGraphQLErrors is returned when the GraphQL response contains one or more errors.
+	ErrGraphQLErrors = errors.New("graphql errors")
+	// ErrUnexpectedDataFormat is returned when the response data is not in the expected format.
+	ErrUnexpectedDataFormat = errors.New("unexpected data format")
+	// ErrResultNotPointer is returned when the result parameter is not a pointer.
+	ErrResultNotPointer = errors.New("result must be a pointer")
+
+	// writer.go.
+
+	// ErrNotMutation is returned when a non-mutation query is passed to a mutation writer.
+	ErrNotMutation = errors.New("query must be a mutation")
+	// ErrMutationErrors is returned when the GraphQL mutation response contains errors.
+	ErrMutationErrors = errors.New("encountered errors posting mutation")
+	// ErrPostingMutation is returned when posting a GraphQL mutation fails.
+	ErrPostingMutation = errors.New("error posting mutation")
+	// ErrNoArrayData is returned when a mutation result contains no array data.
+	ErrNoArrayData = errors.New("no array data found in mutation result")
+)

--- a/pkg/defradb/lan_ip.go
+++ b/pkg/defradb/lan_ip.go
@@ -6,7 +6,7 @@ import (
 )
 
 // dialFunc abstracts net.Dial for testability.
-var dialFunc = net.Dial
+var dialFunc = net.Dial // nolint:gochecknoglobals
 
 // getLANIP returns the local LAN IP by opening a UDP "connection" to a public
 // address. The dial does not actually transmit; the kernel selects the egress
@@ -15,9 +15,9 @@ var dialFunc = net.Dial
 func getLANIP() (string, error) {
 	conn, err := dialFunc("udp", "8.8.8.8:80")
 	if err != nil {
-		return "", fmt.Errorf("Error retrieving ip address: %v", err)
+		return "", fmt.Errorf("error retrieving ip address: %w", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	localAddr := conn.LocalAddr().(*net.UDPAddr)
 

--- a/pkg/defradb/network_handler.go
+++ b/pkg/defradb/network_handler.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sourcenetwork/defradb/node"
 )
 
-// NetworkHandler manages P2P networking for DefraDB
+// NetworkHandler manages P2P networking for DefraDB.
 type NetworkHandler struct {
 	node *node.Node
 	cfg  *Config
@@ -29,13 +29,13 @@ type NetworkHandler struct {
 	reconnectTicker *time.Ticker
 	reconnectStop   chan struct{}
 
-	// Context management
+	// nolint:containedctx // Context management
 	ctx    context.Context
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
 }
 
-// NewNetworkHandler creates a new network handler
+// NewNetworkHandler creates a new network handler.
 func NewNetworkHandler(defraNode *node.Node, cfg *Config) *NetworkHandler {
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -69,7 +69,7 @@ func NewNetworkHandler(defraNode *node.Node, cfg *Config) *NetworkHandler {
 	}
 }
 
-// StartNetwork activates P2P networking and begins connection attempts
+// StartNetwork activates P2P networking and begins connection attempts.
 func (nh *NetworkHandler) StartNetwork() error {
 	nh.peersMu.Lock()
 	defer nh.peersMu.Unlock()
@@ -98,7 +98,7 @@ func (nh *NetworkHandler) StartNetwork() error {
 	return nil
 }
 
-// StopNetwork deactivates P2P networking gracefully
+// StopNetwork deactivates P2P networking gracefully.
 func (nh *NetworkHandler) StopNetwork() error {
 	nh.peersMu.Lock()
 
@@ -135,28 +135,28 @@ func (nh *NetworkHandler) StopNetwork() error {
 	return nil
 }
 
-// IsNetworkActive returns whether P2P networking is currently active
+// IsNetworkActive returns whether P2P networking is currently active.
 func (nh *NetworkHandler) IsNetworkActive() bool {
 	nh.peersMu.RLock()
 	defer nh.peersMu.RUnlock()
 	return nh.networkActive
 }
 
-// IsHostRunning returns whether the host is running
+// IsHostRunning returns whether the host is running.
 func (nh *NetworkHandler) IsHostRunning() bool {
 	nh.peersMu.RLock()
 	defer nh.peersMu.RUnlock()
 	return nh.hostRunning
 }
 
-// SetHostRunning updates the host running state
+// SetHostRunning updates the host running state.
 func (nh *NetworkHandler) SetHostRunning(running bool) {
 	nh.peersMu.Lock()
 	defer nh.peersMu.Unlock()
 	nh.hostRunning = running
 }
 
-// ToggleNetwork switches P2P networking on/off
+// ToggleNetwork switches P2P networking on/off.
 func (nh *NetworkHandler) ToggleNetwork() error {
 	if nh.IsNetworkActive() {
 		return nh.StopNetwork()
@@ -164,11 +164,11 @@ func (nh *NetworkHandler) ToggleNetwork() error {
 	return nh.StartNetwork()
 }
 
-// connectWithRetryLocked attempts to connect to a peer with exponential backoff
+// connectWithRetryLocked attempts to connect to a peer with exponential backoff.
 func (nh *NetworkHandler) connectWithRetryLocked(peerAddr string) error {
 	peer, exists := nh.peers[peerAddr]
 	if !exists {
-		return fmt.Errorf("peer not found: %s", peerAddr)
+		return ErrNoPeerFound
 	}
 
 	maxRetries := nh.cfg.DefraDB.P2P.MaxRetries
@@ -177,7 +177,7 @@ func (nh *NetworkHandler) connectWithRetryLocked(peerAddr string) error {
 	peer.State = StateConnecting
 	peer.RetryCount = 0
 
-	for attempt := 0; attempt < maxRetries; attempt++ {
+	for attempt := range maxRetries {
 		peer.LastAttempt = time.Now()
 		peer.RetryCount = attempt + 1
 
@@ -202,10 +202,7 @@ func (nh *NetworkHandler) connectWithRetryLocked(peerAddr string) error {
 		default:
 		}
 
-		delay := baseDelay * time.Duration(1<<attempt)
-		if delay > 30*time.Second {
-			delay = 30 * time.Second
-		}
+		delay := min(baseDelay*time.Duration(1<<attempt), BaseDelay)
 
 		logger.Sugar.Debugf("Connection attempt %d/%d to %s failed: %v. Retrying in %v",
 			attempt+1, maxRetries, peerAddr, err, delay)
@@ -225,7 +222,7 @@ func (nh *NetworkHandler) connectWithRetryLocked(peerAddr string) error {
 	return fmt.Errorf("failed to connect to peer %s after %d retries: %w", peerAddr, maxRetries, peer.LastError)
 }
 
-// startReconnectionLoop starts the background reconnection goroutine
+// startReconnectionLoop starts the background reconnection goroutine.
 func (nh *NetworkHandler) startReconnectionLoop() {
 	if !nh.cfg.DefraDB.P2P.EnableAutoReconnect {
 		return
@@ -233,9 +230,7 @@ func (nh *NetworkHandler) startReconnectionLoop() {
 	interval := time.Duration(nh.cfg.DefraDB.P2P.ReconnectIntervalMs) * time.Millisecond
 	nh.reconnectStop = make(chan struct{})
 	nh.reconnectTicker = time.NewTicker(interval)
-	nh.wg.Add(1)
-	go func() {
-		defer nh.wg.Done()
+	nh.wg.Go(func() {
 		defer nh.reconnectTicker.Stop()
 		for {
 			select {
@@ -248,11 +243,11 @@ func (nh *NetworkHandler) startReconnectionLoop() {
 				nh.reconnectDisconnectedPeers()
 			}
 		}
-	}()
+	})
 	nh.startNoPeersEventListener()
 }
 
-// startNoPeersEventListener subscribes to P2PNoPeers events and triggers immediate reconnection
+// startNoPeersEventListener subscribes to P2PNoPeers events and triggers immediate reconnection.
 func (nh *NetworkHandler) startNoPeersEventListener() {
 	if nh.node == nil || nh.node.DB == nil {
 		return
@@ -262,9 +257,7 @@ func (nh *NetworkHandler) startNoPeersEventListener() {
 		logger.Sugar.Warnf("Failed to subscribe to P2PNoPeers events: %v", err)
 		return
 	}
-	nh.wg.Add(1)
-	go func() {
-		defer nh.wg.Done()
+	nh.wg.Go(func() {
 		for {
 			select {
 			case <-nh.reconnectStop:
@@ -280,25 +273,25 @@ func (nh *NetworkHandler) startNoPeersEventListener() {
 				}
 			}
 		}
-	}()
+	})
 	logger.Sugar.Info("P2PNoPeers event listener started")
 }
 
-// forceReconnectAll marks all peers as disconnected and triggers immediate reconnection
+// forceReconnectAll marks all peers as disconnected and triggers immediate reconnection.
 func (nh *NetworkHandler) forceReconnectAll() {
 	nh.peersMu.Lock()
 	for _, peer := range nh.peers {
 		if peer.State == StateConnected {
 			peer.State = StateDisconnected
 			peer.ConnectedAt = time.Time{}
-			peer.LastError = fmt.Errorf("P2P mesh lost - no active peers")
+			peer.LastError = ErrNoP2PMesh
 		}
 	}
 	nh.peersMu.Unlock()
 	nh.reconnectDisconnectedPeers()
 }
 
-// checkPeerHealth verifies that peers we think are connected are still connected
+// checkPeerHealth verifies that peers we think are connected are still connected.
 func (nh *NetworkHandler) checkPeerHealth() {
 	if nh.node == nil || nh.node.DB == nil {
 		return
@@ -339,12 +332,12 @@ func (nh *NetworkHandler) checkPeerHealth() {
 		if !stillConnected {
 			peer.State = StateDisconnected
 			peer.ConnectedAt = time.Time{}
-			peer.LastError = fmt.Errorf("peer disconnected: no longer in active peer list")
+			peer.LastError = ErrPeerDisconnected
 		}
 	}
 }
 
-// extractPeerID extracts the peer ID from a multiaddr string
+// extractPeerID extracts the peer ID from a multiaddr string.
 func extractPeerID(multiaddr string) string {
 	const p2pPrefix = "/p2p/"
 	for i := len(multiaddr) - len(p2pPrefix); i >= 0; i-- {
@@ -355,7 +348,7 @@ func extractPeerID(multiaddr string) string {
 	return ""
 }
 
-// reconnectDisconnectedPeers attempts to reconnect to all disconnected or failed peers
+// reconnectDisconnectedPeers attempts to reconnect to all disconnected or failed peers.
 func (nh *NetworkHandler) reconnectDisconnectedPeers() {
 	nh.peersMu.RLock()
 	disconnectedPeers := []string{}
@@ -378,7 +371,7 @@ func (nh *NetworkHandler) reconnectDisconnectedPeers() {
 	}
 }
 
-// attemptReconnect attempts to reconnect to a single peer
+// attemptReconnect attempts to reconnect to a single peer.
 func (nh *NetworkHandler) attemptReconnect(peerAddr string) {
 	nh.peersMu.Lock()
 	defer nh.peersMu.Unlock()
@@ -395,12 +388,12 @@ func (nh *NetworkHandler) attemptReconnect(peerAddr string) {
 	}
 }
 
-// AddPeer adds a new peer at runtime
+// AddPeer adds a new peer at runtime.
 func (nh *NetworkHandler) AddPeer(peerAddr string) error {
 	nh.peersMu.Lock()
 	defer nh.peersMu.Unlock()
 	if _, exists := nh.peers[peerAddr]; exists {
-		return fmt.Errorf("peer already exists: %s", peerAddr)
+		return ErrPeerAlreadyAdded
 	}
 	nh.peers[peerAddr] = &PeerState{
 		Address: peerAddr,
@@ -408,28 +401,26 @@ func (nh *NetworkHandler) AddPeer(peerAddr string) error {
 	}
 	logger.Sugar.Infof("Added new peer: %s", peerAddr)
 	if nh.networkActive {
-		nh.wg.Add(1)
-		go func() {
-			defer nh.wg.Done()
+		nh.wg.Go(func() {
 			nh.attemptReconnect(peerAddr)
-		}()
+		})
 	}
 	return nil
 }
 
-// RemovePeer removes a peer from the handler
+// RemovePeer removes a peer from the handler.
 func (nh *NetworkHandler) RemovePeer(peerAddr string) error {
 	nh.peersMu.Lock()
 	defer nh.peersMu.Unlock()
 	if _, exists := nh.peers[peerAddr]; !exists {
-		return fmt.Errorf("peer not found: %s", peerAddr)
+		return ErrNoPeerFound
 	}
 	delete(nh.peers, peerAddr)
 	logger.Sugar.Infof("Removed peer: %s", peerAddr)
 	return nil
 }
 
-// GetPeers returns a copy of all peer states
+// GetPeers returns a copy of all peer states.
 func (nh *NetworkHandler) GetPeers() map[string]PeerState {
 	nh.peersMu.RLock()
 	defer nh.peersMu.RUnlock()
@@ -440,7 +431,7 @@ func (nh *NetworkHandler) GetPeers() map[string]PeerState {
 	return result
 }
 
-// GetConnectedPeers returns a list of connected peer addresses
+// GetConnectedPeers returns a list of connected peer addresses.
 func (nh *NetworkHandler) GetConnectedPeers() []string {
 	nh.peersMu.RLock()
 	defer nh.peersMu.RUnlock()
@@ -453,7 +444,7 @@ func (nh *NetworkHandler) GetConnectedPeers() []string {
 	return connected
 }
 
-// GetPeerState returns the state of a specific peer
+// GetPeerState returns the state of a specific peer.
 func (nh *NetworkHandler) GetPeerState(peerAddr string) (PeerState, bool) {
 	nh.peersMu.RLock()
 	defer nh.peersMu.RUnlock()
@@ -463,7 +454,7 @@ func (nh *NetworkHandler) GetPeerState(peerAddr string) (PeerState, bool) {
 	return PeerState{}, false
 }
 
-// GetConnectionStats returns connection statistics
+// GetConnectionStats returns connection statistics.
 func (nh *NetworkHandler) GetConnectionStats() ConnectionStats {
 	nh.peersMu.RLock()
 	defer nh.peersMu.RUnlock()
@@ -487,7 +478,7 @@ func (nh *NetworkHandler) GetConnectionStats() ConnectionStats {
 	return stats
 }
 
-// ConnectionStats provides summary statistics about peer connections
+// ConnectionStats provides summary statistics about peer connections.
 type ConnectionStats struct {
 	TotalPeers        int  `json:"total_peers"`
 	ConnectedPeers    int  `json:"connected_peers"`

--- a/pkg/defradb/network_state.go
+++ b/pkg/defradb/network_state.go
@@ -4,23 +4,23 @@ import (
 	"time"
 )
 
-// ConnectionState represents the current state of a peer connection
+// ConnectionState represents the current state of a peer connection.
 type ConnectionState int
 
 const (
-	// StateDisconnected: Not connected to the peer
+	// StateDisconnected Not connected to the peer.
 	StateDisconnected ConnectionState = iota
-	// StateConnecting: Attempting to establish connection
+	// StateConnecting Attempting to establish connection.
 	StateConnecting
-	// StateConnected: Successfully connected to the peer
+	// StateConnected Successfully connected to the peer.
 	StateConnected
-	// StateReconnecting: Lost connection, attempting to reconnect
+	// StateReconnecting Lost connection, attempting to reconnect.
 	StateReconnecting
-	// StateFailed: Connection failed after max retries
+	// StateFailed Connection failed after max retries.
 	StateFailed
 )
 
-// String returns a human-readable representation of the connection state
+// String returns a human-readable representation of the connection state.
 func (s ConnectionState) String() string {
 	switch s {
 	case StateDisconnected:
@@ -38,7 +38,7 @@ func (s ConnectionState) String() string {
 	}
 }
 
-// PeerState tracks the connection state of an individual peer
+// PeerState tracks the connection state of an individual peer.
 type PeerState struct {
 	Address     string          // Peer address in multiaddr format
 	State       ConnectionState // Current connection state
@@ -48,17 +48,17 @@ type PeerState struct {
 	ConnectedAt time.Time       // Time when connection was established (zero if not connected)
 }
 
-// IsConnected returns true if the peer is currently connected
+// IsConnected returns true if the peer is currently connected.
 func (p *PeerState) IsConnected() bool {
 	return p.State == StateConnected
 }
 
-// IsReachable returns true if the peer can potentially be reached
+// IsReachable returns true if the peer can potentially be reached.
 func (p *PeerState) IsReachable() bool {
 	return p.State != StateFailed
 }
 
-// Copy returns a copy of the PeerState
+// Copy returns a copy of the PeerState.
 func (p *PeerState) Copy() PeerState {
 	return PeerState{
 		Address:     p.Address,

--- a/pkg/defradb/peers.go
+++ b/pkg/defradb/peers.go
@@ -9,14 +9,17 @@ import (
 	"github.com/sourcenetwork/defradb/node"
 )
 
+// BootstrapIntoPeers parses a list of bootstrap peer multiaddr strings into PeerInfo structs.
+// Each peer string is expected to be in the format "<multiaddr>/p2p/<peerID>".
+// Invalid entries are skipped and their errors are returned alongside the valid peers.
 func BootstrapIntoPeers(configuredBootstrapPeers []string) ([]client.PeerInfo, []error) {
 	peers := []client.PeerInfo{}
 	errors := []error{}
 
-	for i, peer := range configuredBootstrapPeers {
+	for _, peer := range configuredBootstrapPeers {
 		parts := strings.Split(peer, "/p2p/")
-		if len(parts) != 2 {
-			errors = append(errors, fmt.Errorf("peer at index %d is invalid and will be skipped. Given: %v", i, configuredBootstrapPeers))
+		if len(parts) != 2 { //nolint:mnd
+			errors = append(errors, ErrInvalidBootstrapPeer)
 			continue
 		}
 		address := parts[0]
@@ -32,18 +35,21 @@ func BootstrapIntoPeers(configuredBootstrapPeers []string) ([]client.PeerInfo, [
 	return peers, errors
 }
 
+// PeersIntoBootstrap converts a list of PeerInfo structs into bootstrap peer multiaddr strings.
+// Each resulting string is in the format "<multiaddr>/p2p/<peerID>".
+// Peers missing an ID or addresses are skipped and their errors are returned alongside the valid peers.
 func PeersIntoBootstrap(peers []client.PeerInfo) ([]string, []error) {
 	bootstrapPeers := []string{}
 	errors := []error{}
 
-	for i, peer := range peers {
+	for _, peer := range peers {
 		if peer.ID == "" {
-			errors = append(errors, fmt.Errorf("peer at index %d has empty ID and will be skipped", i))
+			errors = append(errors, ErrPeerEmptyID)
 			continue
 		}
 
 		if len(peer.Addresses) == 0 {
-			errors = append(errors, fmt.Errorf("peer at index %d has no addresses and will be skipped", i))
+			errors = append(errors, ErrPeerNoAddresses)
 			continue
 		}
 
@@ -56,6 +62,8 @@ func PeersIntoBootstrap(peers []client.PeerInfo) ([]string, []error) {
 	return bootstrapPeers, errors
 }
 
+// connectToPeers connects the given DefraDB node to the provided list of peer multiaddr strings.
+// Returns nil if the peers list is empty. Returns an error if the connection attempt fails.
 func connectToPeers(ctx context.Context, defraNode *node.Node, peers []string) error {
 	if len(peers) == 0 {
 		return nil
@@ -63,7 +71,7 @@ func connectToPeers(ctx context.Context, defraNode *node.Node, peers []string) e
 
 	err := defraNode.DB.Connect(ctx, peers)
 	if err != nil {
-		return fmt.Errorf("error connecting to peer: %v", err)
+		return fmt.Errorf("error connecting to peer: %w", err)
 	}
 
 	return nil

--- a/pkg/defradb/query.go
+++ b/pkg/defradb/query.go
@@ -10,15 +10,15 @@ import (
 	"github.com/sourcenetwork/defradb/node"
 )
 
-// queryClient provides a clean interface for executing GraphQL queries against DefraDB using the direct client
+// queryClient provides a clean interface for executing GraphQL queries against DefraDB using the direct client.
 type queryClient struct {
 	defraNode *node.Node
 }
 
-// newQueryClient creates a new GraphQL query client using the Defra node directly
+// newQueryClient creates a new GraphQL query client using the Defra node directly.
 func newQueryClient(defraNode *node.Node) (*queryClient, error) {
 	if defraNode == nil {
-		return nil, fmt.Errorf("defraNode parameter cannot be nil")
+		return nil, ErrDefraNodeNil
 	}
 
 	return &queryClient{
@@ -26,24 +26,24 @@ func newQueryClient(defraNode *node.Node) (*queryClient, error) {
 	}, nil
 }
 
-// query executes a GraphQL query using the Defra client directly and returns the raw result
-func (c *queryClient) query(ctx context.Context, query string) (interface{}, error) {
+// query executes a GraphQL query using the Defra client directly and returns the raw result.
+func (c *queryClient) query(ctx context.Context, query string) (any, error) {
 	if query == "" {
-		return nil, fmt.Errorf("query parameter is empty")
+		return nil, ErrQueryEmpty
 	}
 
 	result := c.defraNode.DB.ExecRequest(ctx, query)
 	gqlResult := result.GQL
 
 	if len(gqlResult.Errors) > 0 {
-		return nil, fmt.Errorf("graphql errors: %v", gqlResult.Errors)
+		return nil, ErrGraphQLErrors
 	}
 
 	return gqlResult.Data, nil
 }
 
-// queryAndUnmarshal executes a GraphQL query and unmarshals the result into the provided interface
-func (c *queryClient) queryAndUnmarshal(ctx context.Context, query string, result interface{}) error {
+// queryAndUnmarshal executes a GraphQL query and unmarshals the result into the provided interface.
+func (c *queryClient) queryAndUnmarshal(ctx context.Context, query string, result any) error { //nolint:unused
 	data, err := c.query(ctx, query)
 	if err != nil {
 		return err
@@ -52,30 +52,30 @@ func (c *queryClient) queryAndUnmarshal(ctx context.Context, query string, resul
 	// Convert the data to JSON and then unmarshal into the result
 	dataBytes, err := json.Marshal(data)
 	if err != nil {
-		return fmt.Errorf("failed to marshal data: %w", err)
+		return ErrUnexpectedDataFormat
 	}
 
 	return json.Unmarshal(dataBytes, result)
 }
 
 // getDataField extracts the data from a GraphQL response
-// For the Defra client, the data is returned directly, not wrapped in a "data" field
-func (c *queryClient) getDataField(ctx context.Context, query string) (map[string]interface{}, error) {
+// For the Defra client, the data is returned directly, not wrapped in a "data" field.
+func (c *queryClient) getDataField(ctx context.Context, query string) (map[string]any, error) { //nolint:unused
 	data, err := c.query(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}
 
-	dataMap, ok := data.(map[string]interface{})
+	dataMap, ok := data.(map[string]any)
 	if !ok {
-		return nil, fmt.Errorf("unexpected data format: %T", data)
+		return nil, ErrUnexpectedDataFormat
 	}
 
 	return dataMap, nil
 }
 
-// queryInto executes a GraphQL query and unmarshals the result into a struct of the specified type
-func (c *queryClient) queryInto(ctx context.Context, query string, result interface{}) error {
+// queryInto executes a GraphQL query and unmarshals the result into a struct of the specified type.
+func (c *queryClient) queryInto(ctx context.Context, query string, result any) error { //nolint:unused
 	data, err := c.query(ctx, query)
 	if err != nil {
 		return err
@@ -91,8 +91,8 @@ func (c *queryClient) queryInto(ctx context.Context, query string, result interf
 }
 
 // queryDataInto executes a GraphQL query and unmarshals only the "data" field into a struct
-// This function handles both single objects and arrays in the response
-func (c *queryClient) queryDataInto(ctx context.Context, query string, result interface{}) error {
+// This function handles both single objects and arrays in the response.
+func (c *queryClient) queryDataInto(ctx context.Context, query string, result any) error { //nolint:unused
 	data, err := c.query(ctx, query)
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
@@ -101,17 +101,17 @@ func (c *queryClient) queryDataInto(ctx context.Context, query string, result in
 	// Check if result is expecting a slice (array) or single object
 	resultValue := reflect.ValueOf(result)
 	if resultValue.Kind() != reflect.Ptr {
-		return fmt.Errorf("result must be a pointer")
+		return ErrResultNotPointer
 	}
 
 	resultElem := resultValue.Elem()
 
 	// If result is a slice, find the first array in data and unmarshal it
 	if resultElem.Kind() == reflect.Slice {
-		if dataMap, ok := data.(map[string]interface{}); ok {
+		if dataMap, ok := data.(map[string]any); ok {
 			for _, value := range dataMap {
 				// Try different array types
-				if array, ok := value.([]interface{}); ok {
+				if array, ok := value.([]any); ok {
 					// Convert the array to JSON and unmarshal into result
 					arrayBytes, err := json.Marshal(array)
 					if err != nil {
@@ -121,7 +121,7 @@ func (c *queryClient) queryDataInto(ctx context.Context, query string, result in
 				}
 
 				// Try []map[string]interface{} type
-				if array, ok := value.([]map[string]interface{}); ok {
+				if array, ok := value.([]map[string]any); ok {
 					// Convert the array to JSON and unmarshal into result
 					arrayBytes, err := json.Marshal(array)
 					if err != nil {
@@ -140,10 +140,10 @@ func (c *queryClient) queryDataInto(ctx context.Context, query string, result in
 	}
 
 	// If result is a single struct, find the first array in data and get its first element
-	if dataMap, ok := data.(map[string]interface{}); ok {
+	if dataMap, ok := data.(map[string]any); ok {
 		for _, value := range dataMap {
 			// Try different array types
-			if array, ok := value.([]interface{}); ok && len(array) > 0 {
+			if array, ok := value.([]any); ok && len(array) > 0 {
 				// Convert the first element to JSON and unmarshal into result
 				firstElementBytes, err := json.Marshal(array[0])
 				if err != nil {
@@ -153,7 +153,7 @@ func (c *queryClient) queryDataInto(ctx context.Context, query string, result in
 			}
 
 			// Try []map[string]interface{} type
-			if array, ok := value.([]map[string]interface{}); ok && len(array) > 0 {
+			if array, ok := value.([]map[string]any); ok && len(array) > 0 {
 				// Convert the first element to JSON and unmarshal into result
 				firstElementBytes, err := json.Marshal(array[0])
 				if err != nil {
@@ -172,7 +172,7 @@ func (c *queryClient) queryDataInto(ctx context.Context, query string, result in
 	return json.Unmarshal(dataBytes, result)
 }
 
-// wrapQueryIfNeeded automatically wraps a query with "query { }" if it doesn't already start with "query", "mutation", or "subscription"
+// wrapQueryIfNeeded automatically wraps a query with "query { }" if it doesn't already start with "query", "mutation", or "subscription".
 func wrapQueryIfNeeded(query string) string {
 	// Trim whitespace to check the actual start
 	trimmed := strings.TrimSpace(query)
@@ -206,7 +206,7 @@ func wrapQueryIfNeeded(query string) string {
 }
 
 // QuerySingle executes a GraphQL query and returns a single item of the specified type
-// This is useful when you expect a single object back (not an array)
+// This is useful when you expect a single object back (not an array).
 func QuerySingle[T any](ctx context.Context, defraNode *node.Node, query string) (T, error) {
 	var result T
 	client, err := newQueryClient(defraNode)
@@ -221,7 +221,7 @@ func QuerySingle[T any](ctx context.Context, defraNode *node.Node, query string)
 }
 
 // QueryArray executes a GraphQL query and returns an array of the specified type
-// This is useful when you expect an array of objects back
+// This is useful when you expect an array of objects back.
 func QueryArray[T any](ctx context.Context, defraNode *node.Node, query string) ([]T, error) {
 	var result []T
 	client, err := newQueryClient(defraNode)

--- a/pkg/defradb/schema.go
+++ b/pkg/defradb/schema.go
@@ -17,7 +17,8 @@ type SchemaApplier interface {
 // without touching the database. Use it in tests that don't care about schema.
 type MockSchemaApplierThatSucceeds struct{}
 
-func (schema *MockSchemaApplierThatSucceeds) ApplySchema(ctx context.Context, defraNode *node.Node) error {
+// ApplySchema is a mock implementation that always succeeds without performing any operations.
+func (schema *MockSchemaApplierThatSucceeds) ApplySchema(ctx context.Context, defraNode *node.Node) error { // nolint:revive
 	return nil
 }
 
@@ -26,13 +27,15 @@ type SchemaApplierFromProvidedSchema struct {
 	ProvidedSchema string
 }
 
+// NewSchemaApplierFromProvidedSchema creates a new SchemaApplierFromProvidedSchema with the given schema string.
 func NewSchemaApplierFromProvidedSchema(schema string) *SchemaApplierFromProvidedSchema {
 	return &SchemaApplierFromProvidedSchema{
 		ProvidedSchema: schema,
 	}
 }
 
+// ApplySchema applies the provided schema string to the DefraDB node.
 func (schema *SchemaApplierFromProvidedSchema) ApplySchema(ctx context.Context, defraNode *node.Node) error {
-	_, err := defraNode.DB.AddSchema(ctx, string(schema.ProvidedSchema))
+	_, err := defraNode.DB.AddSchema(ctx, schema.ProvidedSchema)
 	return err
 }

--- a/pkg/defradb/writer.go
+++ b/pkg/defradb/writer.go
@@ -9,19 +9,20 @@ import (
 	"github.com/sourcenetwork/defradb/node"
 )
 
+// PostMutation executes a GraphQL mutation against the DefraDB node and unmarshals the result into type T.
 func PostMutation[T any](ctx context.Context, defraNode *node.Node, query string) (*T, error) {
 	if !strings.Contains(query, "mutation") {
-		return nil, fmt.Errorf("Query must be a mutation, given: %s", query)
+		return nil, ErrNotMutation
 	}
 
 	result := defraNode.DB.ExecRequest(ctx, query)
 	gqlResult := result.GQL
 	if gqlResult.Data == nil {
-		return nil, fmt.Errorf("Encountered errors posting mutation: %v", gqlResult.Errors)
+		return nil, fmt.Errorf("encountered errors posting mutation: %v", gqlResult.Errors) // nolint:err113
 	}
 
 	if len(gqlResult.Errors) > 0 {
-		err := fmt.Errorf("Error posting mutation %s", query)
+		err := ErrPostingMutation
 		for _, gqlError := range gqlResult.Errors {
 			err = fmt.Errorf("%w: %w", err, gqlError)
 		}
@@ -30,16 +31,16 @@ func PostMutation[T any](ctx context.Context, defraNode *node.Node, query string
 
 	// The GraphQL response data is a map[string]interface{} containing the mutation result
 	// We need to find the first array in the data and extract the first element
-	data, ok := gqlResult.Data.(map[string]interface{})
+	data, ok := gqlResult.Data.(map[string]any)
 	if !ok {
-		return nil, fmt.Errorf("unexpected data format: %T", gqlResult.Data)
+		return nil, ErrUnexpectedDataFormat
 	}
 
 	// Find the first array in the data (mutation results are typically arrays)
 	for _, value := range data {
 
 		// Try different array types
-		if array, ok := value.([]interface{}); ok && len(array) > 0 {
+		if array, ok := value.([]any); ok && len(array) > 0 {
 			// Convert the first element to JSON and unmarshal into result
 			firstElementBytes, err := json.Marshal(array[0])
 			if err != nil {
@@ -56,7 +57,7 @@ func PostMutation[T any](ctx context.Context, defraNode *node.Node, query string
 		}
 
 		// Try []map[string]interface{} type
-		if array, ok := value.([]map[string]interface{}); ok && len(array) > 0 {
+		if array, ok := value.([]map[string]any); ok && len(array) > 0 {
 			// Convert the first element to JSON and unmarshal into result
 			firstElementBytes, err := json.Marshal(array[0])
 			if err != nil {
@@ -73,5 +74,5 @@ func PostMutation[T any](ctx context.Context, defraNode *node.Node, query string
 		}
 	}
 
-	return nil, fmt.Errorf("no array data found in mutation result")
+	return nil, ErrNoArrayData
 }

--- a/pkg/graphql/addBlockNumberFilterToQuery.go
+++ b/pkg/graphql/addBlockNumberFilterToQuery.go
@@ -32,6 +32,7 @@ func getCollectionFilterConfig(collectionName string, start, end uint64) collect
 		}
 	}
 }
+
 func spliceIntoExistingFilter(trimmed string, cfg collectionFilterConfig) (string, error) {
 	filterStart := strings.Index(trimmed, "(")
 	parenCount, filterEnd := 0, 0

--- a/pkg/graphql/addBlockNumberFilterToQuery.go
+++ b/pkg/graphql/addBlockNumberFilterToQuery.go
@@ -32,7 +32,6 @@ func getCollectionFilterConfig(collectionName string, start, end uint64) collect
 		}
 	}
 }
-
 func spliceIntoExistingFilter(trimmed string, cfg collectionFilterConfig) (string, error) {
 	filterStart := strings.Index(trimmed, "(")
 	parenCount, filterEnd := 0, 0
@@ -52,7 +51,10 @@ func spliceIntoExistingFilter(trimmed string, cfg collectionFilterConfig) (strin
 	}
 
 	existing := strings.TrimSpace(trimmed[filterStart+1 : filterEnd])
-	newFilter := cfg.rangeFilter + ", " + cfg.orderClause
+	newFilter := cfg.rangeFilter
+	if cfg.orderClause != "" {
+		newFilter += ", " + cfg.orderClause
+	}
 	if existing != "" {
 		newFilter = existing + ", " + newFilter
 	}
@@ -64,7 +66,10 @@ func insertNewFilter(trimmed string, cfg collectionFilterConfig) (string, error)
 	if braceStart == -1 {
 		return "", ErrNoSelectionSet
 	}
-	filterAndOrder := fmt.Sprintf("(filter: { %s }, %s)", cfg.rangeFilter, cfg.orderClause)
+	filterAndOrder := fmt.Sprintf("(filter: { %s })", cfg.rangeFilter)
+	if cfg.orderClause != "" {
+		filterAndOrder = fmt.Sprintf("(filter: { %s }, %s)", cfg.rangeFilter, cfg.orderClause)
+	}
 	return trimmed[:braceStart] + filterAndOrder + trimmed[braceStart:], nil
 }
 

--- a/pkg/graphql/addBlockNumberFilterToQuery.go
+++ b/pkg/graphql/addBlockNumberFilterToQuery.go
@@ -8,111 +8,83 @@ import (
 	"github.com/shinzonetwork/shinzo-host-client/pkg/constants"
 )
 
-// AddBlockNumberFilter adds a block number filter to a GraphQL query
-// It ensures that only results from block numbers greater than startingBlockNumber are returned
+type collectionFilterConfig struct {
+	rangeFilter string
+	orderClause string
+}
+
+func getCollectionFilterConfig(collectionName string, start, end uint64) collectionFilterConfig {
+	switch collectionName {
+	case constants.CollectionBlock:
+		return collectionFilterConfig{
+			rangeFilter: fmt.Sprintf("_and: [ { number: { _ge: %d } }, { number: { _le: %d } } ]", start, end),
+			orderClause: "order: { number: DESC }",
+		}
+	case constants.CollectionAccessListEntry:
+		return collectionFilterConfig{
+			rangeFilter: fmt.Sprintf("_and: [ { transaction: { blockNumber: { _ge: %d } } }, { transaction: { blockNumber: { _le: %d } } } ]", start, end),
+			orderClause: "order: { transaction: { blockNumber: DESC } }",
+		}
+	default:
+		return collectionFilterConfig{
+			rangeFilter: fmt.Sprintf("_and: [ { blockNumber: { _ge: %d } }, { blockNumber: { _le: %d } } ]", start, end),
+			orderClause: "order: { blockNumber: DESC }",
+		}
+	}
+}
+
+func spliceIntoExistingFilter(trimmed string, cfg collectionFilterConfig) (string, error) {
+	filterStart := strings.Index(trimmed, "(")
+	parenCount, filterEnd := 0, 0
+	for i := filterStart; i < len(trimmed); i++ {
+		if trimmed[i] == '(' {
+			parenCount++
+		} else if trimmed[i] == ')' {
+			parenCount--
+			if parenCount == 0 {
+				filterEnd = i
+				break
+			}
+		}
+	}
+	if filterEnd == 0 {
+		return "", ErrNoClosingParen
+	}
+
+	existing := strings.TrimSpace(trimmed[filterStart+1 : filterEnd])
+	newFilter := cfg.rangeFilter + ", " + cfg.orderClause
+	if existing != "" {
+		newFilter = existing + ", " + newFilter
+	}
+	return trimmed[:filterStart+1] + newFilter + trimmed[filterEnd:], nil
+}
+
+func insertNewFilter(trimmed string, cfg collectionFilterConfig) (string, error) {
+	braceStart := strings.Index(trimmed, "{")
+	if braceStart == -1 {
+		return "", ErrNoSelectionSet
+	}
+	filterAndOrder := fmt.Sprintf("(filter: { %s }, %s)", cfg.rangeFilter, cfg.orderClause)
+	return trimmed[:braceStart] + filterAndOrder + trimmed[braceStart:], nil
+}
+
+// AddBlockNumberFilter adds a block number filter to a GraphQL query.
 func AddBlockNumberFilter(query string, startingBlockNumber uint64, endingBlockNumber uint64) (string, error) {
 	if query == "" {
-		return "", fmt.Errorf("query cannot be empty")
+		return "", ErrQueryEmpty
 	}
 
-	// Parse the query to find the main collection type and add the block number filter
 	trimmed := strings.TrimSpace(query)
-
-	// Look for patterns like "Log { ... }" or "Log(filter: {...}) { ... }"
 	re := regexp.MustCompile(`(\w+)\s*(\{|\()`)
 	matches := re.FindStringSubmatch(trimmed)
-	if len(matches) < 3 {
-		return "", fmt.Errorf("unable to parse collection name from query: %s", query)
+	if len(matches) < minRegexMatchGroups {
+		return "", fmt.Errorf("query %q: %w", query, ErrParseCollectionName)
 	}
 
-	collectionName := matches[1]
-	openingBrace := matches[2]
+	cfg := getCollectionFilterConfig(matches[1], startingBlockNumber, endingBlockNumber)
 
-	// Check if there's already a filter
-	if openingBrace == "(" {
-		// Query already has a filter, we need to add to it
-		// Find the end of the existing filter
-		parenCount := 0
-		filterStart := strings.Index(trimmed, "(")
-		filterEnd := 0
-		for i := filterStart; i < len(trimmed); i++ {
-			if trimmed[i] == '(' {
-				parenCount++
-			} else if trimmed[i] == ')' {
-				parenCount--
-				if parenCount == 0 {
-					filterEnd = i
-					break
-				}
-			}
-		}
-
-		if filterEnd == 0 {
-			return "", fmt.Errorf("unable to find matching closing parenthesis in query")
-		}
-
-		// Extract existing filter content
-		existingFilter := trimmed[filterStart+1 : filterEnd]
-		existingFilter = strings.TrimSpace(existingFilter)
-
-		// Add block number filter to existing filter with order parameter
-		var newFilter string
-		var orderParam string
-
-		if collectionName == constants.CollectionBlock {
-			// For Block queries, number is the correct field
-			orderParam = ", order: { number: DESC }"
-			if existingFilter == "" {
-				newFilter = fmt.Sprintf("_and: [ { number: { _ge: %d } }, { number: { _le: %d } } ]%s", startingBlockNumber, endingBlockNumber, orderParam)
-			} else {
-				newFilter = fmt.Sprintf("%s, _and: [ { number: { _ge: %d } }, { number: { _le: %d } } ]%s", existingFilter, startingBlockNumber, endingBlockNumber, orderParam)
-			}
-		} else if collectionName == constants.CollectionAccessListEntry {
-			// For AccessListEntry queries, block number is within transaction
-			orderParam = ", order: { transaction: { blockNumber: DESC } }"
-			if existingFilter == "" {
-				newFilter = fmt.Sprintf("_and: [ { transaction: { blockNumber: { _ge: %d } } }, { transaction: { blockNumber: { _le: %d } } } ]%s", startingBlockNumber, endingBlockNumber, orderParam)
-			} else {
-				newFilter = fmt.Sprintf("%s, _and: [ { transaction: { blockNumber: { _ge: %d } } }, { transaction: { blockNumber: { _le: %d } } } ]%s", existingFilter, startingBlockNumber, endingBlockNumber, orderParam)
-			}
-		} else {
-			// For other collections (Log, Transaction) filter on blockNumber field
-			orderParam = ", order: { blockNumber: DESC }"
-			if existingFilter == "" {
-				newFilter = fmt.Sprintf("_and: [ { blockNumber: { _ge: %d } }, { blockNumber: { _le: %d } } ]%s", startingBlockNumber, endingBlockNumber, orderParam)
-			} else {
-				newFilter = fmt.Sprintf("%s, _and: [ { blockNumber: { _ge: %d } }, { blockNumber: { _le: %d } } ]%s", existingFilter, startingBlockNumber, endingBlockNumber, orderParam)
-			}
-		}
-
-		// Reconstruct the query
-		beforeFilter := trimmed[:filterStart+1]
-		afterFilter := trimmed[filterEnd:]
-		return beforeFilter + newFilter + afterFilter, nil
-	} else {
-		// No existing filter, add one
-		// Find the opening brace of the selection set
-		braceStart := strings.Index(trimmed, "{")
-		if braceStart == -1 {
-			return "", fmt.Errorf("unable to find selection set in query")
-		}
-
-		// Insert filter before the selection set
-		beforeBrace := trimmed[:braceStart]
-		afterBrace := trimmed[braceStart:]
-
-		// Create filter and order based on collection type
-		var filterAndOrder string
-		if collectionName == constants.CollectionBlock {
-			// For Block queries, number is a direct field
-			filterAndOrder = fmt.Sprintf("(filter: { _and: [ { number: { _ge: %d } }, { number: { _le: %d } } ] }, order: { number: DESC })", startingBlockNumber, endingBlockNumber)
-		} else if collectionName == constants.CollectionAccessListEntry {
-			// For AccessListEntry queries, block number is within transaction
-			filterAndOrder = fmt.Sprintf("(filter: { _and: [ { transaction: { blockNumber: { _ge: %d } } }, { transaction: { blockNumber: { _le: %d } } } ] }, order: { transaction: { blockNumber: DESC } })", startingBlockNumber, endingBlockNumber)
-		} else {
-			// For other collections (Log, Transaction), filter directly on blockNumber field
-			filterAndOrder = fmt.Sprintf("(filter: { _and: [ { blockNumber: { _ge: %d } }, { blockNumber: { _le: %d } } ] }, order: { blockNumber: DESC })", startingBlockNumber, endingBlockNumber)
-		}
-		return beforeBrace + filterAndOrder + afterBrace, nil
+	if matches[2] == "(" {
+		return spliceIntoExistingFilter(trimmed, cfg)
 	}
+	return insertNewFilter(trimmed, cfg)
 }

--- a/pkg/graphql/addBlockNumberFilterToQuery_test.go
+++ b/pkg/graphql/addBlockNumberFilterToQuery_test.go
@@ -3,8 +3,8 @@ package graphql
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/constants"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 

--- a/pkg/graphql/constants.go
+++ b/pkg/graphql/constants.go
@@ -1,0 +1,3 @@
+package graphql
+
+const minRegexMatchGroups = 3

--- a/pkg/graphql/constants_test.go
+++ b/pkg/graphql/constants_test.go
@@ -1,0 +1,4 @@
+package graphql
+
+// versionFragment is a const for the versionArray.
+const versionFragment = "_version { cid signature { type identity value } }"

--- a/pkg/graphql/errors.go
+++ b/pkg/graphql/errors.go
@@ -1,0 +1,10 @@
+package graphql
+
+import "errors"
+
+var ( //nolint:revive
+	ErrQueryEmpty          = errors.New("query cannot be empty")                                //nolint:revive
+	ErrParseCollectionName = errors.New("unable to parse collection name from query")           //nolint:revive
+	ErrNoClosingParen      = errors.New("unable to find matching closing parenthesis in query") //nolint:revive
+	ErrNoSelectionSet      = errors.New("unable to find selection set in query")                //nolint:revive
+)

--- a/pkg/graphql/withBlockNumberFilterToQuery.go
+++ b/pkg/graphql/withBlockNumberFilterToQuery.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/shinzonetwork/shinzo-host-client/pkg/constants"
 )
 
 // WithBlockNumberFilter adds a block number filter to a GraphQL query.
@@ -19,10 +21,25 @@ func WithBlockNumberFilter(query string, startingBlockNumber uint64, endingBlock
 		return "", fmt.Errorf("query %q: %w", query, ErrParseCollectionName)
 	}
 
-	cfg := getCollectionFilterConfig(matches[1], startingBlockNumber, endingBlockNumber)
+	cfg := collectionFilterConfig{
+		rangeFilter: withCollectionRangeFilter(matches[1], startingBlockNumber, endingBlockNumber),
+		orderClause: "", // WithBlockNumberFilter does not add ordering
+	}
 
 	if matches[2] == "(" {
 		return spliceIntoExistingFilter(trimmed, cfg)
 	}
 	return insertNewFilter(trimmed, cfg)
+}
+
+// withCollectionRangeFilter returns only the range filter string for WithBlockNumberFilter (no order clause).
+func withCollectionRangeFilter(collectionName string, start, end uint64) string {
+	switch collectionName {
+	case constants.CollectionBlock:
+		return fmt.Sprintf("_and: [ { number: { _ge: %d } }, { number: { _le: %d } } ]", start, end)
+	case constants.CollectionAccessListEntry:
+		return fmt.Sprintf("_and: [ { transaction: { blockNumber: { _ge: %d } } }, { transaction: { blockNumber: { _le: %d } } } ]", start, end)
+	default:
+		return fmt.Sprintf("_and: [ { blockNumber: { _ge: %d } }, { blockNumber: { _le: %d } } ]", start, end)
+	}
 }

--- a/pkg/graphql/withBlockNumberFilterToQuery.go
+++ b/pkg/graphql/withBlockNumberFilterToQuery.go
@@ -4,110 +4,25 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-
-	"github.com/shinzonetwork/shinzo-host-client/pkg/constants"
 )
 
-// WithBlockNumberFilter adds a block number filter to a GraphQL query
-// It ensures that only results from block numbers greater than startingBlockNumber are returned
+// WithBlockNumberFilter adds a block number filter to a GraphQL query.
 func WithBlockNumberFilter(query string, startingBlockNumber uint64, endingBlockNumber uint64) (string, error) {
 	if query == "" {
-		return "", fmt.Errorf("query cannot be empty")
+		return "", ErrQueryEmpty
 	}
 
-	// Parse the query to find the main collection type and add the block number filter
 	trimmed := strings.TrimSpace(query)
-
-	// Look for patterns like "Log { ... }" or "Log(filter: {...}) { ... }"
 	re := regexp.MustCompile(`(\w+)\s*(\{|\()`)
 	matches := re.FindStringSubmatch(trimmed)
-	if len(matches) < 3 {
-		return "", fmt.Errorf("unable to parse collection name from query: %s", query)
+	if len(matches) < minRegexMatchGroups {
+		return "", fmt.Errorf("query %q: %w", query, ErrParseCollectionName)
 	}
 
-	collectionName := matches[1]
-	openingBrace := matches[2]
+	cfg := getCollectionFilterConfig(matches[1], startingBlockNumber, endingBlockNumber)
 
-	// Check if there's already a filter
-	if openingBrace == "(" {
-		// Query already has a filter, we need to add to it
-		// Find the end of the existing filter
-		parenCount := 0
-		filterStart := strings.Index(trimmed, "(")
-		filterEnd := 0
-		for i := filterStart; i < len(trimmed); i++ {
-			if trimmed[i] == '(' {
-				parenCount++
-			} else if trimmed[i] == ')' {
-				parenCount--
-				if parenCount == 0 {
-					filterEnd = i
-					break
-				}
-			}
-		}
-
-		if filterEnd == 0 {
-			return "", fmt.Errorf("unable to find matching closing parenthesis in query")
-		}
-
-		// Extract existing filter content
-		existingFilter := trimmed[filterStart+1 : filterEnd]
-		existingFilter = strings.TrimSpace(existingFilter)
-
-		// Add block number filter to existing filter
-		var newFilter string
-		if collectionName == constants.CollectionBlock {
-			// For Block queries, number is the correct field
-			if existingFilter == "" {
-				newFilter = fmt.Sprintf("_and: [ { number: { _ge: %d } }, { number: { _le: %d } } ]", startingBlockNumber, endingBlockNumber)
-			} else {
-				newFilter = fmt.Sprintf("%s, _and: [ { number: { _ge: %d } }, { number: { _le: %d } } ]", existingFilter, startingBlockNumber, endingBlockNumber)
-			}
-		} else if collectionName == constants.CollectionAccessListEntry {
-			// For AccessListEntry queries, block number is within transaction
-			if existingFilter == "" {
-				newFilter = fmt.Sprintf("_and: [ { transaction: { blockNumber: { _ge: %d } } }, { transaction: { blockNumber: { _le: %d } } } ]", startingBlockNumber, endingBlockNumber)
-			} else {
-				newFilter = fmt.Sprintf("%s, _and: [ { transaction: { blockNumber: { _ge: %d } } }, { transaction: { blockNumber: { _le: %d } } } ]", existingFilter, startingBlockNumber, endingBlockNumber)
-			}
-		} else {
-			// For other collections (Log, Transaction) filter on blockNumber field
-			if existingFilter == "" {
-				newFilter = fmt.Sprintf("_and: [ { blockNumber: { _ge: %d } }, { blockNumber: { _le: %d } } ]", startingBlockNumber, endingBlockNumber)
-			} else {
-				newFilter = fmt.Sprintf("%s, _and: [ { blockNumber: { _ge: %d } }, { blockNumber: { _le: %d } } ]", existingFilter, startingBlockNumber, endingBlockNumber)
-			}
-		}
-
-		// Reconstruct the query
-		beforeFilter := trimmed[:filterStart+1]
-		afterFilter := trimmed[filterEnd:]
-		return beforeFilter + newFilter + afterFilter, nil
-	} else {
-		// No existing filter, add one
-		// Find the opening brace of the selection set
-		braceStart := strings.Index(trimmed, "{")
-		if braceStart == -1 {
-			return "", fmt.Errorf("unable to find selection set in query")
-		}
-
-		// Insert filter before the selection set
-		beforeBrace := trimmed[:braceStart]
-		afterBrace := trimmed[braceStart:]
-
-		// Create filter based on collection type
-		var filter string
-		if collectionName == constants.CollectionBlock {
-			// For Block queries, number is a direct field
-			filter = fmt.Sprintf("(filter: { _and: [ { number: { _ge: %d } }, { number: { _le: %d } } ] })", startingBlockNumber, endingBlockNumber)
-		} else if collectionName == constants.CollectionAccessListEntry {
-			// For AccessListEntry queries, block number is within transaction
-			filter = fmt.Sprintf("(filter: { _and: [ { transaction: { blockNumber: { _ge: %d } } }, { transaction: { blockNumber: { _le: %d } } } ] })", startingBlockNumber, endingBlockNumber)
-		} else {
-			// For other collections (Log, Transaction), filter directly on blockNumber field
-			filter = fmt.Sprintf("(filter: { _and: [ { blockNumber: { _ge: %d } }, { blockNumber: { _le: %d } } ] })", startingBlockNumber, endingBlockNumber)
-		}
-		return beforeBrace + filter + afterBrace, nil
+	if matches[2] == "(" {
+		return spliceIntoExistingFilter(trimmed, cfg)
 	}
+	return insertNewFilter(trimmed, cfg)
 }

--- a/pkg/graphql/withReturnDocIdAndVersion.go
+++ b/pkg/graphql/withReturnDocIdAndVersion.go
@@ -1,245 +1,209 @@
 package graphql
 
 import (
-	"fmt"
 	"strings"
 )
 
-// WithReturnDocIdAndVersion adds _docID and _version fields to a GraphQL query
+// WithReturnDocIDAndVersion adds _docID and _version fields to a GraphQL query
 // It ensures that _docID and _version are returned for all documents and nested collections
-// without duplicating these fields
-func WithReturnDocIdAndVersion(query string) (string, error) {
+// without duplicating these fields.
+func WithReturnDocIDAndVersion(query string) (string, error) {
 	if query == "" {
-		return "", fmt.Errorf("query cannot be empty")
+		return "", ErrQueryEmpty
 	}
 
 	// Parse the query to find all selection sets and add _docID and _version where needed
 	trimmed := strings.TrimSpace(query)
 	if trimmed == "" {
-		return "", fmt.Errorf("query cannot be empty")
+		return "", ErrQueryEmpty
 	}
 
-	return addDocIdAndVersionToSelectionSets(trimmed)
+	return addDocIDAndVersionToSelectionSets(trimmed)
 }
 
-// addDocIdAndVersionToSelectionSets adds _docID and _version to all selection sets that don't already have them
-func addDocIdAndVersionToSelectionSets(query string) (string, error) {
-	result := query
+// addDocIDAndVersionToSelectionSets adds _docID and _version to all selection sets that don't already have them.
+func addDocIDAndVersionToSelectionSets(query string) (string, error) {
+	mainBracePos := findMainBracePos(query)
+	if mainBracePos == -1 {
+		return query, nil
+	}
 
-	// Find opening braces for selection sets (not filter/order arguments)
-	var bracePositions []int
-	for i, char := range result {
-		if char == '{' {
-			bracePositions = append(bracePositions, i)
+	closeBracePos := findMatchingCloseBrace(query, mainBracePos)
+	if closeBracePos == -1 {
+		return query, nil
+	}
+
+	contentStart := mainBracePos + 1
+	contentEnd := closeBracePos
+	content := query[contentStart:contentEnd]
+
+	const completeVersionPattern = "_version { cid signature { type identity value } }"
+	hasDocID := strings.Contains(content, "_docID")
+	hasCompleteVersion := strings.Contains(content, completeVersionPattern)
+
+	if hasDocID && hasCompleteVersion {
+		return query, nil
+	}
+
+	newContent := buildNewSelectionSetContent(content, hasDocID, hasCompleteVersion, completeVersionPattern)
+	return query[:contentStart] + newContent + query[contentEnd:], nil
+}
+
+// findMainBracePos finds the position of the first opening brace not inside parentheses.
+func findMainBracePos(query string) int {
+	for i, char := range query {
+		if char != '{' {
+			continue
 		}
-	}
-
-	if len(bracePositions) == 0 {
-		// No braces found, return as-is
-		return result, nil
-	}
-
-	// Find the main selection set brace (the one not wrapped in parentheses)
-	var mainBracePos int = -1
-
-	for _, bracePos := range bracePositions {
-		// Check if this brace is wrapped in parentheses
-		beforeBrace := result[:bracePos]
-
-		// Count parentheses to see if we're inside an argument list
 		parenCount := 0
-		for _, char := range beforeBrace {
-			if char == '(' {
+		for _, c := range query[:i] {
+			switch c {
+			case '(':
 				parenCount++
-			} else if char == ')' {
+			case ')':
 				parenCount--
 			}
 		}
-
-		// If parenCount is 0, this brace is not inside parentheses (it's the main selection set)
 		if parenCount == 0 {
-			mainBracePos = bracePos
+			return i
+		}
+	}
+	return -1
+}
+
+// buildNewSelectionSetContent constructs the new selection set content with _docID and _version.
+func buildNewSelectionSetContent(content string, hasDocID, hasCompleteVersion bool, completeVersionPattern string) string {
+	needDocID := !hasDocID
+	needVersion := !hasCompleteVersion
+	hasVersion := strings.Contains(content, "_version")
+
+	trimmedContent := strings.TrimSpace(content)
+	var b strings.Builder
+
+	if needDocID || hasDocID {
+		b.WriteString("_docID ")
+	}
+	if needVersion {
+		b.WriteString(completeVersionPattern)
+	}
+
+	remainingContent := trimmedContent
+	if hasDocID && !needDocID {
+		remainingContent = removeDocIDFromContent(remainingContent)
+	}
+	if hasVersion && needVersion {
+		remainingContent = removeVersionFromContent(remainingContent, completeVersionPattern)
+	}
+
+	hasRemaining := remainingContent != ""
+	if (needVersion && hasRemaining) || (hasVersion && needDocID) {
+		b.WriteString(" ")
+	}
+	if hasRemaining {
+		b.WriteString(remainingContent)
+	}
+
+	return b.String()
+}
+
+// removeDocIDFromContent removes _docID from the beginning of content.
+func removeDocIDFromContent(content string) string {
+	content = strings.TrimSpace(content)
+	switch {
+	case strings.HasPrefix(content, "_docID "):
+		return strings.TrimSpace(content[len("_docID "):])
+	case content == "_docID":
+		return ""
+	case strings.HasPrefix(content, "_docID"):
+		return strings.TrimSpace(content[len("_docID"):])
+	}
+	return content
+}
+
+// removeVersionFromContent removes the _version field (complete or incomplete) from content.
+func removeVersionFromContent(content, completePattern string) string {
+	content = strings.TrimSpace(content)
+
+	switch {
+	case strings.HasPrefix(content, completePattern+" "):
+		return strings.TrimSpace(content[len(completePattern+" "):])
+	case content == completePattern:
+		return ""
+	case strings.HasPrefix(content, completePattern):
+		return strings.TrimSpace(content[len(completePattern):])
+	}
+
+	if result, ok := removeIncompleteVersion(content); ok {
+		return result
+	}
+
+	return removeFallbackVersion(content, completePattern)
+}
+
+// removeIncompleteVersion attempts to find and remove an incomplete _version field.
+func removeIncompleteVersion(content string) (string, bool) {
+	versionStart := strings.Index(content, "_version")
+	if versionStart == -1 {
+		return content, false
+	}
+
+	afterVersion := versionStart + len("_version")
+	for afterVersion < len(content) && (content[afterVersion] == ' ' || content[afterVersion] == '\n' || content[afterVersion] == '\t') {
+		afterVersion++
+	}
+
+	if afterVersion < len(content) && content[afterVersion] == '{' {
+		return removeVersionWithBraces(content, versionStart, afterVersion)
+	}
+
+	beforeVersion := content[:versionStart]
+	afterVersionStr := content[afterVersion:]
+	return strings.TrimSpace(beforeVersion + " " + afterVersionStr), true
+}
+
+// removeVersionWithBraces removes a _version field that has a nested brace structure.
+func removeVersionWithBraces(content string, versionStart, openBracePos int) (string, bool) {
+	braceCount := 1
+	closeBrace := -1
+	for i := openBracePos + 1; i < len(content); i++ {
+		switch content[i] {
+		case '{':
+			braceCount++
+		case '}':
+			braceCount--
+			if braceCount == 0 {
+				closeBrace = i
+			}
+		}
+		if closeBrace != -1 {
 			break
 		}
 	}
 
-	if mainBracePos == -1 {
-		// No main selection set found, return as-is
-		return result, nil
+	if closeBrace == -1 {
+		return content, false
 	}
 
-	closeBracePos := findMatchingCloseBrace(result, mainBracePos)
-	if closeBracePos == -1 {
-		// No matching closing brace found, return as-is
-		return result, nil
+	beforeVersion := content[:versionStart]
+	afterVersionField := ""
+	if closeBrace+1 < len(content) {
+		afterVersionField = content[closeBrace+1:]
 	}
-
-	// Extract the selection set content (between the braces)
-	contentStart := mainBracePos + 1
-	contentEnd := closeBracePos
-	content := result[contentStart:contentEnd]
-
-	// Check if _docID and _version are already present
-	hasDocID := strings.Contains(content, "_docID")
-	hasVersion := strings.Contains(content, "_version")
-
-	// Check if _version is complete (has the full nested structure)
-	completeVersionPattern := "_version { cid signature { type identity value } }"
-	hasCompleteVersion := strings.Contains(content, completeVersionPattern)
-
-	// If both are already present and complete, skip
-	if hasDocID && hasCompleteVersion {
-		return result, nil
-	}
-
-	// Determine what needs to be added
-	needDocID := !hasDocID
-	needVersion := !hasCompleteVersion // Need version if it's missing or incomplete
-
-	// Build new content: always put _docID first, then _version, then everything else
-	trimmedContent := strings.TrimSpace(content)
-
-	var newContentBuilder strings.Builder
-
-	// Start with _docID if needed
-	if needDocID {
-		newContentBuilder.WriteString("_docID")
-	} else if hasDocID {
-		// Extract existing _docID from content - just write "_docID" plus space
-		// We'll handle it in the right position
-		newContentBuilder.WriteString("_docID")
-	}
-
-	// Always add a space after _docID if we have it
-	if needDocID || hasDocID {
-		newContentBuilder.WriteString(" ")
-	}
-
-	// Add _version if needed
-	if needVersion {
-		newContentBuilder.WriteString("_version { cid signature { type identity value } }")
-	}
-
-	// Add the rest of the content (excluding _docID and _version from the main selection set if they were already there)
-	remainingContent := ""
-	hasRemainingContent := false
-	if trimmedContent != "" {
-		remainingContent = trimmedContent
-
-		// If _docID already existed in the top-level, remove it from remainingContent
-		// Only remove from the beginning (top-level), not nested selection sets
-		if hasDocID && !needDocID {
-			remainingContent = strings.TrimSpace(remainingContent)
-			// Remove _docID from the start
-			if strings.HasPrefix(remainingContent, "_docID ") {
-				remainingContent = strings.TrimSpace(remainingContent[len("_docID "):])
-			} else if remainingContent == "_docID" {
-				remainingContent = ""
-			} else if strings.HasPrefix(remainingContent, "_docID") {
-				remainingContent = strings.TrimSpace(remainingContent[len("_docID"):])
-			}
-		}
-
-		// If _version already existed in the top-level, remove it (complete or incomplete) if we need to add/complete it
-		// This handles both complete and incomplete _version fields
-		if hasVersion && needVersion {
-			remainingContent = strings.TrimSpace(remainingContent)
-
-			// Try to remove complete version first
-			completePattern := "_version { cid signature { type identity value } }"
-			if strings.HasPrefix(remainingContent, completePattern+" ") {
-				remainingContent = strings.TrimSpace(remainingContent[len(completePattern+" "):])
-			} else if remainingContent == completePattern {
-				remainingContent = ""
-			} else if strings.HasPrefix(remainingContent, completePattern) {
-				remainingContent = strings.TrimSpace(remainingContent[len(completePattern):])
-			} else {
-				// Try to find and remove incomplete _version field
-				// Look for "_version" followed by optional nested structure
-				versionRemoved := false
-				versionStart := strings.Index(remainingContent, "_version")
-				if versionStart != -1 {
-					// Find the end of the _version field (could be just "_version", "_version { ... }", etc.)
-					afterVersion := versionStart + len("_version")
-
-					// Skip whitespace
-					for afterVersion < len(remainingContent) && (remainingContent[afterVersion] == ' ' || remainingContent[afterVersion] == '\n' || remainingContent[afterVersion] == '\t') {
-						afterVersion++
-					}
-
-					if afterVersion < len(remainingContent) && remainingContent[afterVersion] == '{' {
-						// Find the matching closing brace
-						openBrace := afterVersion
-						braceCount := 1
-						closeBrace := -1
-						for i := openBrace + 1; i < len(remainingContent); i++ {
-							if remainingContent[i] == '{' {
-								braceCount++
-							} else if remainingContent[i] == '}' {
-								braceCount--
-								if braceCount == 0 {
-									closeBrace = i
-									break
-								}
-							}
-						}
-						if closeBrace != -1 {
-							// Remove _version and its nested structure
-							beforeVersion := remainingContent[:versionStart]
-							afterVersionField := ""
-							if closeBrace+1 < len(remainingContent) {
-								afterVersionField = remainingContent[closeBrace+1:]
-							}
-							remainingContent = strings.TrimSpace(beforeVersion + " " + afterVersionField)
-							remainingContent = strings.TrimSpace(remainingContent)
-							versionRemoved = true
-						}
-					} else {
-						// Just "_version" with no nested structure
-						beforeVersion := remainingContent[:versionStart]
-						afterVersion := remainingContent[afterVersion:]
-						remainingContent = strings.TrimSpace(beforeVersion + " " + afterVersion)
-						remainingContent = strings.TrimSpace(remainingContent)
-						versionRemoved = true
-					}
-				}
-
-				// Fallback: try simple pattern matching
-				if !versionRemoved {
-					// Try to find complete version with space before it
-					if idx := strings.Index(remainingContent, " "+completePattern+" "); idx != -1 {
-						remainingContent = remainingContent[:idx] + remainingContent[idx+len(" "+completePattern+" "):]
-						remainingContent = strings.TrimSpace(remainingContent)
-					} else if idx := strings.Index(remainingContent, " "+completePattern); idx != -1 {
-						remainingContent = remainingContent[:idx] + remainingContent[idx+len(" "+completePattern):]
-						remainingContent = strings.TrimSpace(remainingContent)
-					}
-				}
-			}
-		}
-
-		hasRemainingContent = (remainingContent != "")
-	}
-
-	// Add space after _version if it was added and there's remaining content, or if _version exists and we're adding _docID
-	if (needVersion && hasRemainingContent) || (hasVersion && needDocID) {
-		newContentBuilder.WriteString(" ")
-	}
-
-	// Add remaining content if any
-	if hasRemainingContent {
-		newContentBuilder.WriteString(remainingContent)
-	}
-
-	newContent := newContentBuilder.String()
-
-	// Replace the selection set content
-	result = result[:contentStart] + newContent + result[contentEnd:]
-
-	return result, nil
+	return strings.TrimSpace(beforeVersion + " " + afterVersionField), true
 }
 
-// findMatchingCloseBrace finds the matching closing brace for an opening brace
+// removeFallbackVersion tries simple index-based pattern removal.
+func removeFallbackVersion(content, completePattern string) string {
+	if idx := strings.Index(content, " "+completePattern+" "); idx != -1 {
+		return strings.TrimSpace(content[:idx] + content[idx+len(" "+completePattern+" "):])
+	}
+	if idx := strings.Index(content, " "+completePattern); idx != -1 {
+		return strings.TrimSpace(content[:idx] + content[idx+len(" "+completePattern):])
+	}
+	return content
+}
+
+// findMatchingCloseBrace finds the matching closing brace for an opening brace.
 func findMatchingCloseBrace(query string, openBracePos int) int {
 	if openBracePos >= len(query) || query[openBracePos] != '{' {
 		return -1

--- a/pkg/graphql/withReturnDocIdAndVersion_test.go
+++ b/pkg/graphql/withReturnDocIdAndVersion_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestWithReturnDocIdAndVersion(t *testing.T) {
+func TestWithReturnDocIDAndVersion(t *testing.T) {
 	tests := []struct {
 		name          string
 		query         string
@@ -187,7 +187,7 @@ func TestWithReturnDocIdAndVersion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := WithReturnDocIdAndVersion(tt.query)
+			result, err := WithReturnDocIDAndVersion(tt.query)
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -200,7 +200,7 @@ func TestWithReturnDocIdAndVersion(t *testing.T) {
 	}
 }
 
-func TestWithReturnDocIdAndVersionEdgeCases(t *testing.T) {
+func TestWithReturnDocIDAndVersionEdgeCases(t *testing.T) {
 	t.Run("query with complex filter structure", func(t *testing.T) {
 		query := `Log(filter: { 
 			_and: [
@@ -216,7 +216,7 @@ func TestWithReturnDocIdAndVersionEdgeCases(t *testing.T) {
 			} 
 		}`
 
-		result, err := WithReturnDocIdAndVersion(query)
+		result, err := WithReturnDocIDAndVersion(query)
 		require.NoError(t, err)
 
 		// Should add _docID and _version to Log
@@ -241,7 +241,7 @@ func TestWithReturnDocIdAndVersionEdgeCases(t *testing.T) {
 			} 
 		}`
 
-		result, err := WithReturnDocIdAndVersion(query)
+		result, err := WithReturnDocIDAndVersion(query)
 		require.NoError(t, err)
 
 		// Should add _docID and _version to Block
@@ -260,7 +260,7 @@ func TestWithReturnDocIdAndVersionEdgeCases(t *testing.T) {
 			data 
 		}`
 
-		result, err := WithReturnDocIdAndVersion(query)
+		result, err := WithReturnDocIDAndVersion(query)
 		require.NoError(t, err)
 
 		assert.Contains(t, result, "_docID")
@@ -269,7 +269,7 @@ func TestWithReturnDocIdAndVersionEdgeCases(t *testing.T) {
 	})
 }
 
-func TestWithReturnDocIdAndVersionPerformance(t *testing.T) {
+func TestWithReturnDocIDAndVersionPerformance(t *testing.T) {
 	t.Run("large query with many nested objects", func(t *testing.T) {
 		// Create a large query with many nested levels
 		query := `Block {
@@ -297,7 +297,7 @@ func TestWithReturnDocIdAndVersionPerformance(t *testing.T) {
 			}
 		}`
 
-		result, err := WithReturnDocIdAndVersion(query)
+		result, err := WithReturnDocIDAndVersion(query)
 		require.NoError(t, err)
 
 		// Verify all expected _docID and _version fields are present
@@ -371,36 +371,36 @@ func TestFindMatchingCloseBrace(t *testing.T) {
 // addDocIdAndVersionToSelectionSets – additional edge cases
 // ---------------------------------------------------------------------------
 
-func TestAddDocIdAndVersionToSelectionSets_NoBraces(t *testing.T) {
+func TestAddDocIDAndVersionToSelectionSets_NoBraces(t *testing.T) {
 	// Query with no braces at all
-	result, err := addDocIdAndVersionToSelectionSets("Log address topics")
+	result, err := addDocIDAndVersionToSelectionSets("Log address topics")
 	require.NoError(t, err)
 	require.Equal(t, "Log address topics", result, "no braces should return as-is")
 }
 
-func TestAddDocIdAndVersionToSelectionSets_AllBracesInsideParens(t *testing.T) {
+func TestAddDocIDAndVersionToSelectionSets_AllBracesInsideParens(t *testing.T) {
 	// All braces are inside parentheses, so no main selection set brace found
 	query := "Log(filter: { address: { _eq: \"0x123\" } })"
-	result, err := addDocIdAndVersionToSelectionSets(query)
+	result, err := addDocIDAndVersionToSelectionSets(query)
 	require.NoError(t, err)
 	require.Equal(t, query, result, "all braces inside parens should return as-is")
 }
 
-func TestAddDocIdAndVersionToSelectionSets_UnmatchedMainBrace(t *testing.T) {
+func TestAddDocIDAndVersionToSelectionSets_UnmatchedMainBrace(t *testing.T) {
 	// Main selection set opening brace with no matching closing brace
 	query := "Log { address topics"
-	result, err := addDocIdAndVersionToSelectionSets(query)
+	result, err := addDocIDAndVersionToSelectionSets(query)
 	require.NoError(t, err)
 	require.Equal(t, query, result, "unmatched main brace should return as-is")
 }
 
-func TestWithReturnDocIdAndVersion_VersionMiddleOfContent(t *testing.T) {
+func TestWithReturnDocIDAndVersion_VersionMiddleOfContent(t *testing.T) {
 	// _version in the middle of content (not at beginning), with incomplete structure
 	query := constants.CollectionLog + " { address _version { cid } topics }"
-	result, err := WithReturnDocIdAndVersion(query)
+	result, err := WithReturnDocIDAndVersion(query)
 	require.NoError(t, err)
 	require.Contains(t, result, "_docID")
-	require.Contains(t, result, "_version { cid signature { type identity value } }")
+	require.Contains(t, result, versionFragment)
 	require.Contains(t, result, "address")
 	require.Contains(t, result, "topics")
 }
@@ -408,131 +408,131 @@ func TestWithReturnDocIdAndVersion_VersionMiddleOfContent(t *testing.T) {
 func TestWithReturnDocIdAndVersion_DocIDMiddleOfContent(t *testing.T) {
 	// _docID not at the start of content
 	query := constants.CollectionLog + " { address _docID topics }"
-	result, err := WithReturnDocIdAndVersion(query)
+	result, err := WithReturnDocIDAndVersion(query)
 	require.NoError(t, err)
 	require.Contains(t, result, "_docID")
-	require.Contains(t, result, "_version { cid signature { type identity value } }")
+	require.Contains(t, result, versionFragment)
 }
 
 // ---------------------------------------------------------------------------
 // addDocIdAndVersionToSelectionSets – additional branch coverage
 // ---------------------------------------------------------------------------
 
-func TestAddDocIdAndVersionToSelectionSets_CompleteVersionAtStart(t *testing.T) {
+func TestAddDocIDAndVersionToSelectionSets_CompleteVersionAtStart(t *testing.T) {
 	// _version with complete pattern at the very beginning of content, followed by a space and more content
-	completeVersion := "_version { cid signature { type identity value } }"
+	completeVersion := versionFragment
 	query := constants.CollectionLog + " { " + completeVersion + " address topics }"
-	result, err := addDocIdAndVersionToSelectionSets(query)
+	result, err := addDocIDAndVersionToSelectionSets(query)
 	require.NoError(t, err)
 	require.Contains(t, result, "_docID")
-	require.Contains(t, result, "_version { cid signature { type identity value } }")
+	require.Contains(t, result, versionFragment)
 	require.Contains(t, result, "address")
 	require.Contains(t, result, "topics")
 }
 
-func TestAddDocIdAndVersionToSelectionSets_CompleteVersionOnly(t *testing.T) {
+func TestAddDocIDAndVersionToSelectionSets_CompleteVersionOnly(t *testing.T) {
 	// Content is exactly the complete version pattern (nothing else)
-	completeVersion := "_version { cid signature { type identity value } }"
+	completeVersion := versionFragment
 	query := constants.CollectionLog + " { " + completeVersion + " }"
-	result, err := addDocIdAndVersionToSelectionSets(query)
+	result, err := addDocIDAndVersionToSelectionSets(query)
 	require.NoError(t, err)
 	require.Contains(t, result, "_docID")
-	require.Contains(t, result, "_version { cid signature { type identity value } }")
+	require.Contains(t, result, versionFragment)
 }
 
-func TestAddDocIdAndVersionToSelectionSets_CompleteVersionNoTrailingSpace(t *testing.T) {
+func TestAddDocIDAndVersionToSelectionSets_CompleteVersionNoTrailingSpace(t *testing.T) {
 	// _version at start of content with no trailing space (followed immediately by closing brace)
-	completeVersion := "_version { cid signature { type identity value } }"
+	completeVersion := versionFragment
 	query := constants.CollectionLog + " {" + completeVersion + "}"
-	result, err := addDocIdAndVersionToSelectionSets(query)
+	result, err := addDocIDAndVersionToSelectionSets(query)
 	require.NoError(t, err)
 	require.Contains(t, result, "_docID")
 }
 
-func TestAddDocIdAndVersionToSelectionSets_VersionFallbackRemoval(t *testing.T) {
+func TestAddDocIDAndVersionToSelectionSets_VersionFallbackRemoval(t *testing.T) {
 	// Test where _version is in the middle of content with the complete pattern preceded by a space
 	// This exercises the fallback path: strings.Index(remainingContent, " "+completePattern+" ")
-	completeVersion := "_version { cid signature { type identity value } }"
+	completeVersion := versionFragment
 	query := constants.CollectionLog + " { address " + completeVersion + " topics }"
-	result, err := addDocIdAndVersionToSelectionSets(query)
+	result, err := addDocIDAndVersionToSelectionSets(query)
 	require.NoError(t, err)
 	require.Contains(t, result, "_docID")
-	require.Contains(t, result, "_version { cid signature { type identity value } }")
+	require.Contains(t, result, versionFragment)
 	require.Contains(t, result, "address")
 	require.Contains(t, result, "topics")
 }
 
-func TestAddDocIdAndVersionToSelectionSets_VersionFallbackEndOfContent(t *testing.T) {
+func TestAddDocIDAndVersionToSelectionSets_VersionFallbackEndOfContent(t *testing.T) {
 	// _version with complete pattern at the end of content preceded by a space
 	// This exercises: strings.Index(remainingContent, " "+completePattern) at the end
-	completeVersion := "_version { cid signature { type identity value } }"
+	completeVersion := versionFragment
 	query := constants.CollectionLog + " { address topics " + completeVersion + " }"
-	result, err := addDocIdAndVersionToSelectionSets(query)
+	result, err := addDocIDAndVersionToSelectionSets(query)
 	require.NoError(t, err)
 	require.Contains(t, result, "_docID")
-	require.Contains(t, result, "_version { cid signature { type identity value } }")
+	require.Contains(t, result, versionFragment)
 	require.Contains(t, result, "address")
 	require.Contains(t, result, "topics")
 }
 
-func TestAddDocIdAndVersionToSelectionSets_IncompleteVersionMiddleNoNested(t *testing.T) {
+func TestAddDocIDAndVersionToSelectionSets_IncompleteVersionMiddleNoNested(t *testing.T) {
 	// _version without braces in the middle of content - triggers the "Just _version with no nested structure" path
 	query := constants.CollectionLog + " { address _version topics }"
-	result, err := addDocIdAndVersionToSelectionSets(query)
+	result, err := addDocIDAndVersionToSelectionSets(query)
 	require.NoError(t, err)
 	require.Contains(t, result, "_docID")
-	require.Contains(t, result, "_version { cid signature { type identity value } }")
+	require.Contains(t, result, versionFragment)
 	require.Contains(t, result, "address")
 	require.Contains(t, result, "topics")
 }
 
-func TestAddDocIdAndVersionToSelectionSets_DocIDOnlyContent(t *testing.T) {
+func TestAddDocIDAndVersionToSelectionSets_DocIDOnlyContent(t *testing.T) {
 	// Content is exactly _docID
 	query := constants.CollectionLog + " {_docID}"
-	result, err := addDocIdAndVersionToSelectionSets(query)
+	result, err := addDocIDAndVersionToSelectionSets(query)
 	require.NoError(t, err)
 	require.Contains(t, result, "_docID")
-	require.Contains(t, result, "_version { cid signature { type identity value } }")
+	require.Contains(t, result, versionFragment)
 }
 
-func TestAddDocIdAndVersionToSelectionSets_DocIDWithSpace(t *testing.T) {
+func TestAddDocIDAndVersionToSelectionSets_DocIDWithSpace(t *testing.T) {
 	// Content starts with "_docID " followed by more content
 	query := constants.CollectionLog + " { _docID address topics }"
-	result, err := addDocIdAndVersionToSelectionSets(query)
+	result, err := addDocIDAndVersionToSelectionSets(query)
 	require.NoError(t, err)
 	require.Contains(t, result, "_docID")
-	require.Contains(t, result, "_version { cid signature { type identity value } }")
+	require.Contains(t, result, versionFragment)
 	require.Contains(t, result, "address")
 }
 
-func TestAddDocIdAndVersionToSelectionSets_DocIDAndCompleteVersion(t *testing.T) {
+func TestAddDocIDAndVersionToSelectionSets_DocIDAndCompleteVersion(t *testing.T) {
 	// Both _docID and complete _version already present - should return as-is
-	completeVersion := "_version { cid signature { type identity value } }"
+	completeVersion := versionFragment
 	query := constants.CollectionLog + " { _docID " + completeVersion + " address }"
-	result, err := addDocIdAndVersionToSelectionSets(query)
+	result, err := addDocIDAndVersionToSelectionSets(query)
 	require.NoError(t, err)
 	require.Contains(t, result, "_docID")
 	require.Contains(t, result, completeVersion)
 	require.Contains(t, result, "address")
 }
 
-func TestAddDocIdAndVersionToSelectionSets_DocIDPrefixNoSpace(t *testing.T) {
+func TestAddDocIDAndVersionToSelectionSets_DocIDPrefixNoSpace(t *testing.T) {
 	// _docID immediately followed by another token (no separating space).
 	// This exercises the HasPrefix("_docID") fallback in lines 141-142.
 	query := constants.CollectionLog + " {_docIDextra field1 field2}"
-	result, err := addDocIdAndVersionToSelectionSets(query)
+	result, err := addDocIDAndVersionToSelectionSets(query)
 	require.NoError(t, err)
 	require.Contains(t, result, "_docID")
-	require.Contains(t, result, "_version { cid signature { type identity value } }")
+	require.Contains(t, result, versionFragment)
 }
 
-func TestWithReturnDocIdAndVersion_NeedVersionHasVersionNeedDocID(t *testing.T) {
+func TestWithReturnDocIDAndVersion_NeedVersionHasVersionNeedDocID(t *testing.T) {
 	// Has _version (complete) but no _docID => needDocID true, needVersion false, hasVersion true.
 	// This exercises the second half of the condition on line 228:
 	//   (hasVersion && needDocID) for the spacing logic.
-	completeVersion := "_version { cid signature { type identity value } }"
+	completeVersion := versionFragment
 	query := constants.CollectionLog + " { " + completeVersion + " address topics }"
-	result, err := WithReturnDocIdAndVersion(query)
+	result, err := WithReturnDocIDAndVersion(query)
 	require.NoError(t, err)
 	require.Contains(t, result, "_docID")
 	require.Contains(t, result, completeVersion)
@@ -540,22 +540,22 @@ func TestWithReturnDocIdAndVersion_NeedVersionHasVersionNeedDocID(t *testing.T) 
 	require.Contains(t, result, "topics")
 }
 
-func TestWithReturnDocIdAndVersion_EmptyContentAfterDocIDRemoval(t *testing.T) {
+func TestWithReturnDocIDAndVersion_EmptyContentAfterDocIDRemoval(t *testing.T) {
 	// Content is just "_docID" with no other fields
 	// After removing _docID, remaining content is empty
 	query := constants.CollectionLog + " { _docID }"
-	result, err := WithReturnDocIdAndVersion(query)
+	result, err := WithReturnDocIDAndVersion(query)
 	require.NoError(t, err)
 	require.Contains(t, result, "_docID")
-	require.Contains(t, result, "_version { cid signature { type identity value } }")
+	require.Contains(t, result, versionFragment)
 }
 
-func TestWithReturnDocIdAndVersion_IncompleteVersionUnmatchedBrace(t *testing.T) {
+func TestWithReturnDocIDAndVersion_IncompleteVersionUnmatchedBrace(t *testing.T) {
 	// _version with an opening brace but no matching close brace within the selection set.
 	// The outer `}` is consumed as the main selection set close, so findMatchingCloseBrace
 	// returns -1 and the query is returned as-is.
 	query := constants.CollectionLog + " { address _version { cid }"
-	result, err := WithReturnDocIdAndVersion(query)
+	result, err := WithReturnDocIDAndVersion(query)
 	require.NoError(t, err)
 	// The function can't properly parse this malformed query, returns as-is
 	require.Contains(t, result, "_version")

--- a/pkg/host/DocumentProvenanceService.go
+++ b/pkg/host/DocumentProvenanceService.go
@@ -2,37 +2,39 @@ package host
 
 import (
 	"fmt"
+	"maps"
 	"strings"
 )
 
-// ProcessingDecision represents whether a document should be processed
+// ProcessingDecision represents whether a document should be processed.
 type ProcessingDecision struct {
 	ShouldProcess bool
 	Reason        string
 	SkipType      string
 }
 
-// DocumentProvenanceService manages document metadata and processing decisions
+// DocumentProvenanceService manages document metadata and processing decisions.
 type DocumentProvenanceService struct {
 	maxProcessingDepth int
 }
 
-// NewDocumentProvenanceService creates a new provenance service
+// NewDocumentProvenanceService creates a new provenance service.
 func NewDocumentProvenanceService() *DocumentProvenanceService {
 	return &DocumentProvenanceService{
-		maxProcessingDepth: 5, // Prevent infinite loops
+		maxProcessingDepth: defaultMaxProcessingDepth,
 	}
 }
 
+// PrimitiveDocument represents a document with provenance metadata for tracking its origin and processing history.
 type PrimitiveDocument struct {
 	ID          string
 	Type        string
 	BlockNumber uint64
-	Data        map[string]interface{}
+	Data        map[string]any
 	Metadata    DocumentMetadata
 }
 
-// DocumentMetadata tracks the origin and processing history of documents
+// DocumentMetadata tracks the origin and processing history of documents.
 type DocumentMetadata struct {
 	// Origin tracking
 	SourceCollection string `json:"sourceCollection"`
@@ -48,7 +50,7 @@ type DocumentMetadata struct {
 	OriginalDocID string `json:"originalDocID,omitempty"`
 }
 
-// InitializeMetadata creates initial metadata for a source document
+// InitializeMetadata creates initial metadata for a source document.
 func (dps *DocumentProvenanceService) InitializeMetadata(doc PrimitiveDocument) DocumentMetadata {
 	if doc.Metadata.ProcessingDepth == 0 {
 		doc.Metadata = DocumentMetadata{
@@ -63,7 +65,7 @@ func (dps *DocumentProvenanceService) InitializeMetadata(doc PrimitiveDocument) 
 	return doc.Metadata
 }
 
-// ConvertToPrimitiveDocument converts a Document to a PrimitiveDocument with initialized metadata
+// ConvertToPrimitiveDocument converts a Document to a PrimitiveDocument with initialized metadata.
 func (dps *DocumentProvenanceService) ConvertToPrimitiveDocument(doc Document) PrimitiveDocument {
 	return PrimitiveDocument{
 		ID:          doc.ID,
@@ -74,7 +76,7 @@ func (dps *DocumentProvenanceService) ConvertToPrimitiveDocument(doc Document) P
 	}
 }
 
-// ShouldProcessDocument determines if a document should be processed by a view
+// ShouldProcessDocument determines if a document should be processed by a view.
 func (dps *DocumentProvenanceService) ShouldProcessDocument(doc PrimitiveDocument, viewID string) ProcessingDecision {
 	// Initialize metadata if needed
 	doc.Metadata = dps.InitializeMetadata(doc)
@@ -123,8 +125,8 @@ func (dps *DocumentProvenanceService) ShouldProcessDocument(doc PrimitiveDocumen
 	}
 }
 
-// CreateViewOutputDocument creates metadata for a document output by a view
-func (dps *DocumentProvenanceService) CreateViewOutputDocument(sourceDoc PrimitiveDocument, viewID string, outputData map[string]interface{}) PrimitiveDocument {
+// CreateViewOutputDocument creates metadata for a document output by a view.
+func (dps *DocumentProvenanceService) CreateViewOutputDocument(sourceDoc PrimitiveDocument, viewID string, outputData map[string]any) PrimitiveDocument {
 	// Build processing chain
 	chain := sourceDoc.Metadata.ProcessingChain
 	if chain == "" {
@@ -150,13 +152,11 @@ func (dps *DocumentProvenanceService) CreateViewOutputDocument(sourceDoc Primiti
 	}
 }
 
-// PreserveFilterFields ensures required fields are preserved in view outputs
-func (dps *DocumentProvenanceService) PreserveFilterFields(sourceData, outputData map[string]interface{}, requiredFields []string) map[string]interface{} {
+// PreserveFilterFields ensures required fields are preserved in view outputs.
+func (dps *DocumentProvenanceService) PreserveFilterFields(sourceData, outputData map[string]any, requiredFields []string) map[string]any {
 	// Copy output data to avoid mutation
-	result := make(map[string]interface{})
-	for k, v := range outputData {
-		result[k] = v
-	}
+	result := make(map[string]any)
+	maps.Copy(result, outputData)
 
 	// Preserve required fields from source if they're missing in output
 	for _, field := range requiredFields {
@@ -170,7 +170,7 @@ func (dps *DocumentProvenanceService) PreserveFilterFields(sourceData, outputDat
 	return result
 }
 
-// GetRequiredFieldsByType returns the required filter fields for each document type
+// GetRequiredFieldsByType returns the required filter fields for each document type.
 func (dps *DocumentProvenanceService) GetRequiredFieldsByType() map[string][]string {
 	return map[string][]string{
 		"Ethereum__Mainnet__Transaction":     {"from", "to", "hash", "blockNumber"},
@@ -184,8 +184,8 @@ func (dps *DocumentProvenanceService) GetRequiredFieldsByType() map[string][]str
 	}
 }
 
-// ValidateDocumentForView validates that a document has required fields for a view
-func (dps *DocumentProvenanceService) ValidateDocumentForView(doc PrimitiveDocument, viewID string) error {
+// ValidateDocumentForView validates that a document has required fields for a view.
+func (dps *DocumentProvenanceService) ValidateDocumentForView(doc PrimitiveDocument, _ string) error {
 	// Get required fields for document type
 	requiredFields := dps.GetRequiredFieldsByType()
 	fields, exists := requiredFields[doc.Type]
@@ -209,18 +209,18 @@ func (dps *DocumentProvenanceService) ValidateDocumentForView(doc PrimitiveDocum
 		}
 	}
 
-	return fmt.Errorf("document %s of type %s missing required filter fields: %v", doc.ID, doc.Type, fields)
+	return fmt.Errorf("document %s of type %s, fields %v: %w", doc.ID, doc.Type, fields, ErrMissingFilterFields)
 }
 
-// generateOutputID creates a unique ID for view output documents
+// generateOutputID creates a unique ID for view output documents.
 func (dps *DocumentProvenanceService) generateOutputID(sourceID, viewID string) string {
 	// Create deterministic but unique ID
 	return fmt.Sprintf("%s-%s", strings.Replace(sourceID, "bae-", "", 1), strings.Replace(viewID, "WASMView_", "", 1))
 }
 
-// GetProcessingStats returns statistics about document processing
-func (dps *DocumentProvenanceService) GetProcessingStats(doc PrimitiveDocument) map[string]interface{} {
-	return map[string]interface{}{
+// GetProcessingStats returns statistics about document processing.
+func (dps *DocumentProvenanceService) GetProcessingStats(doc PrimitiveDocument) map[string]any {
+	return map[string]any{
 		"processing_depth":  doc.Metadata.ProcessingDepth,
 		"is_view_output":    doc.Metadata.IsViewOutput,
 		"source_collection": doc.Metadata.SourceCollection,

--- a/pkg/host/DocumentProvenanceService_test.go
+++ b/pkg/host/DocumentProvenanceService_test.go
@@ -31,7 +31,7 @@ func TestInitializeMetadata(t *testing.T) {
 			doc: PrimitiveDocument{
 				ID:   "bae-123",
 				Type: "Transaction",
-				Data: map[string]interface{}{"from": "0xabc"},
+				Data: map[string]any{"from": "0xabc"},
 				Metadata: DocumentMetadata{
 					ProcessingDepth: 0,
 				},
@@ -50,7 +50,7 @@ func TestInitializeMetadata(t *testing.T) {
 			doc: PrimitiveDocument{
 				ID:   "bae-456",
 				Type: "Block",
-				Data: map[string]interface{}{"hash": "0xdef"},
+				Data: map[string]any{"hash": "0xdef"},
 				Metadata: DocumentMetadata{
 					SourceCollection: "Transaction",
 					IsViewOutput:     true,
@@ -101,7 +101,7 @@ func TestConvertToPrimitiveDocument(t *testing.T) {
 				ID:          "bae-abc",
 				Type:        "Transaction",
 				BlockNumber: 100,
-				Data:        map[string]interface{}{"from": "0x1", "to": "0x2"},
+				Data:        map[string]any{"from": "0x1", "to": "0x2"},
 				Metadata:    DocumentMetadata{},
 			},
 		},
@@ -145,7 +145,7 @@ func TestShouldProcessDocument(t *testing.T) {
 			doc: PrimitiveDocument{
 				ID:   "bae-1",
 				Type: "Transaction",
-				Data: map[string]interface{}{},
+				Data: map[string]any{},
 				Metadata: DocumentMetadata{
 					ProcessingDepth: 0,
 				},
@@ -162,10 +162,10 @@ func TestShouldProcessDocument(t *testing.T) {
 			doc: PrimitiveDocument{
 				ID:   "bae-2",
 				Type: "Transaction",
-				Data: map[string]interface{}{},
+				Data: map[string]any{},
 				Metadata: DocumentMetadata{
-					ProcessingDepth: 5,
-					ProcessingChain: "v1,v2,v3,v4,v5",
+					ProcessingDepth:  5,
+					ProcessingChain:  "v1,v2,v3,v4,v5",
 					SourceCollection: "Transaction",
 					DocumentType:     "Transaction",
 					OriginalDocID:    "bae-2",
@@ -183,7 +183,7 @@ func TestShouldProcessDocument(t *testing.T) {
 			doc: PrimitiveDocument{
 				ID:   "bae-3",
 				Type: "Transaction",
-				Data: map[string]interface{}{},
+				Data: map[string]any{},
 				Metadata: DocumentMetadata{
 					ProcessingDepth:  1,
 					ViewID:           "view-A",
@@ -206,7 +206,7 @@ func TestShouldProcessDocument(t *testing.T) {
 			doc: PrimitiveDocument{
 				ID:   "bae-4",
 				Type: "Transaction",
-				Data: map[string]interface{}{},
+				Data: map[string]any{},
 				Metadata: DocumentMetadata{
 					ProcessingDepth:  2,
 					ViewID:           "view-B",
@@ -229,7 +229,7 @@ func TestShouldProcessDocument(t *testing.T) {
 			doc: PrimitiveDocument{
 				ID:   "bae-5",
 				Type: "Transaction",
-				Data: map[string]interface{}{},
+				Data: map[string]any{},
 				Metadata: DocumentMetadata{
 					ProcessingDepth:  1,
 					ViewID:           "view-A",
@@ -264,7 +264,7 @@ func TestCreateViewOutputDocument(t *testing.T) {
 		name       string
 		sourceDoc  PrimitiveDocument
 		viewID     string
-		outputData map[string]interface{}
+		outputData map[string]any
 		expected   PrimitiveDocument
 	}{
 		{
@@ -273,7 +273,7 @@ func TestCreateViewOutputDocument(t *testing.T) {
 				ID:          "bae-src1",
 				Type:        "Transaction",
 				BlockNumber: 42,
-				Data:        map[string]interface{}{"from": "0x1"},
+				Data:        map[string]any{"from": "0x1"},
 				Metadata: DocumentMetadata{
 					SourceCollection: "Transaction",
 					ProcessingDepth:  0,
@@ -283,12 +283,12 @@ func TestCreateViewOutputDocument(t *testing.T) {
 				},
 			},
 			viewID:     "WASMView_myview",
-			outputData: map[string]interface{}{"result": "processed"},
+			outputData: map[string]any{"result": "processed"},
 			expected: PrimitiveDocument{
 				ID:          "src1-myview",
 				Type:        "Transaction",
 				BlockNumber: 42,
-				Data:        map[string]interface{}{"result": "processed"},
+				Data:        map[string]any{"result": "processed"},
 				Metadata: DocumentMetadata{
 					SourceCollection: "Transaction",
 					IsViewOutput:     true,
@@ -306,7 +306,7 @@ func TestCreateViewOutputDocument(t *testing.T) {
 				ID:          "bae-src2",
 				Type:        "Log",
 				BlockNumber: 99,
-				Data:        map[string]interface{}{"address": "0xabc"},
+				Data:        map[string]any{"address": "0xabc"},
 				Metadata: DocumentMetadata{
 					SourceCollection: "Log",
 					IsViewOutput:     true,
@@ -318,12 +318,12 @@ func TestCreateViewOutputDocument(t *testing.T) {
 				},
 			},
 			viewID:     "view-B",
-			outputData: map[string]interface{}{"enriched": true},
+			outputData: map[string]any{"enriched": true},
 			expected: PrimitiveDocument{
 				ID:          "src2-view-B",
 				Type:        "Log",
 				BlockNumber: 99,
-				Data:        map[string]interface{}{"enriched": true},
+				Data:        map[string]any{"enriched": true},
 				Metadata: DocumentMetadata{
 					SourceCollection: "Log",
 					IsViewOutput:     true,
@@ -350,38 +350,38 @@ func TestPreserveFilterFields(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		sourceData     map[string]interface{}
-		outputData     map[string]interface{}
+		sourceData     map[string]any
+		outputData     map[string]any
 		requiredFields []string
-		expected       map[string]interface{}
+		expected       map[string]any
 	}{
 		{
 			name:           "preserves missing required fields from source",
-			sourceData:     map[string]interface{}{"from": "0x1", "to": "0x2", "hash": "0xabc"},
-			outputData:     map[string]interface{}{"result": "done"},
+			sourceData:     map[string]any{"from": "0x1", "to": "0x2", "hash": "0xabc"},
+			outputData:     map[string]any{"result": "done"},
 			requiredFields: []string{"from", "to"},
-			expected:       map[string]interface{}{"result": "done", "from": "0x1", "to": "0x2"},
+			expected:       map[string]any{"result": "done", "from": "0x1", "to": "0x2"},
 		},
 		{
 			name:           "does not overwrite existing output fields",
-			sourceData:     map[string]interface{}{"from": "0x1", "to": "0x2"},
-			outputData:     map[string]interface{}{"from": "0xoverride", "result": "done"},
+			sourceData:     map[string]any{"from": "0x1", "to": "0x2"},
+			outputData:     map[string]any{"from": "0xoverride", "result": "done"},
 			requiredFields: []string{"from", "to"},
-			expected:       map[string]interface{}{"from": "0xoverride", "result": "done", "to": "0x2"},
+			expected:       map[string]any{"from": "0xoverride", "result": "done", "to": "0x2"},
 		},
 		{
 			name:           "handles field missing from both source and output",
-			sourceData:     map[string]interface{}{"from": "0x1"},
-			outputData:     map[string]interface{}{"result": "done"},
+			sourceData:     map[string]any{"from": "0x1"},
+			outputData:     map[string]any{"result": "done"},
 			requiredFields: []string{"from", "to", "hash"},
-			expected:       map[string]interface{}{"result": "done", "from": "0x1"},
+			expected:       map[string]any{"result": "done", "from": "0x1"},
 		},
 		{
 			name:           "empty required fields returns copy of output",
-			sourceData:     map[string]interface{}{"from": "0x1"},
-			outputData:     map[string]interface{}{"result": "done"},
+			sourceData:     map[string]any{"from": "0x1"},
+			outputData:     map[string]any{"result": "done"},
 			requiredFields: []string{},
-			expected:       map[string]interface{}{"result": "done"},
+			expected:       map[string]any{"result": "done"},
 		},
 	}
 
@@ -469,7 +469,7 @@ func TestValidateDocumentForView(t *testing.T) {
 			doc: PrimitiveDocument{
 				ID:   "bae-1",
 				Type: "Transaction",
-				Data: map[string]interface{}{"from": "0xabc", "to": "0xdef"},
+				Data: map[string]any{"from": "0xabc", "to": "0xdef"},
 			},
 			viewID:      "view-1",
 			expectError: false,
@@ -479,7 +479,7 @@ func TestValidateDocumentForView(t *testing.T) {
 			doc: PrimitiveDocument{
 				ID:   "bae-2",
 				Type: "Block",
-				Data: map[string]interface{}{"number": int(42)},
+				Data: map[string]any{"number": int(42)},
 			},
 			viewID:      "view-2",
 			expectError: false,
@@ -489,7 +489,7 @@ func TestValidateDocumentForView(t *testing.T) {
 			doc: PrimitiveDocument{
 				ID:   "bae-3",
 				Type: "Block",
-				Data: map[string]interface{}{"number": uint64(100)},
+				Data: map[string]any{"number": uint64(100)},
 			},
 			viewID:      "view-3",
 			expectError: false,
@@ -499,7 +499,7 @@ func TestValidateDocumentForView(t *testing.T) {
 			doc: PrimitiveDocument{
 				ID:   "bae-4",
 				Type: "Transaction",
-				Data: map[string]interface{}{"unrelated": "value"},
+				Data: map[string]any{"unrelated": "value"},
 			},
 			viewID:      "view-4",
 			expectError: true,
@@ -509,7 +509,7 @@ func TestValidateDocumentForView(t *testing.T) {
 			doc: PrimitiveDocument{
 				ID:   "bae-5",
 				Type: "Transaction",
-				Data: map[string]interface{}{"from": "", "to": ""},
+				Data: map[string]any{"from": "", "to": ""},
 			},
 			viewID:      "view-5",
 			expectError: true,
@@ -519,7 +519,7 @@ func TestValidateDocumentForView(t *testing.T) {
 			doc: PrimitiveDocument{
 				ID:   "bae-6",
 				Type: "Transaction",
-				Data: map[string]interface{}{"from": nil},
+				Data: map[string]any{"from": nil},
 			},
 			viewID:      "view-6",
 			expectError: true,
@@ -529,7 +529,7 @@ func TestValidateDocumentForView(t *testing.T) {
 			doc: PrimitiveDocument{
 				ID:   "bae-7",
 				Type: "UnknownType",
-				Data: map[string]interface{}{"address": "0x123"},
+				Data: map[string]any{"address": "0x123"},
 			},
 			viewID:      "view-7",
 			expectError: false,
@@ -539,7 +539,7 @@ func TestValidateDocumentForView(t *testing.T) {
 			doc: PrimitiveDocument{
 				ID:   "bae-8",
 				Type: "UnknownType",
-				Data: map[string]interface{}{"unrelated": "value"},
+				Data: map[string]any{"unrelated": "value"},
 			},
 			viewID:      "view-8",
 			expectError: true,
@@ -608,7 +608,7 @@ func TestGetProcessingStats(t *testing.T) {
 	tests := []struct {
 		name     string
 		doc      PrimitiveDocument
-		expected map[string]interface{}
+		expected map[string]any
 	}{
 		{
 			name: "zero depth source document",
@@ -624,7 +624,7 @@ func TestGetProcessingStats(t *testing.T) {
 					OriginalDocID:    "bae-1",
 				},
 			},
-			expected: map[string]interface{}{
+			expected: map[string]any{
 				"processing_depth":  0,
 				"is_view_output":    false,
 				"source_collection": "Transaction",
@@ -648,7 +648,7 @@ func TestGetProcessingStats(t *testing.T) {
 					OriginalDocID:    "bae-orig",
 				},
 			},
-			expected: map[string]interface{}{
+			expected: map[string]any{
 				"processing_depth":  3,
 				"is_view_output":    true,
 				"source_collection": "Transaction",

--- a/pkg/host/attestationHandler.go
+++ b/pkg/host/attestationHandler.go
@@ -16,9 +16,12 @@ import (
 )
 
 // attestedBlocks tracks which blocks already have an attestation record (in-memory, for logging only).
-var attestedBlocks sync.Map
-var startTime time.Time
-// Document represents a document from DefraDB
+var (
+	attestedBlocks sync.Map  //nolint:gochecknoglobals
+	startTime      time.Time //nolint:gochecknoglobals,unused
+)
+
+// Document represents a document from DefraDB.
 type Document struct {
 	ID          string
 	Type        string
@@ -59,7 +62,7 @@ func (h *Host) processDocumentAttestationBatch(ctx context.Context, docs []Docum
 	return attestationService.HandleDocumentAttestationBatch(ctx, h.signatureVerifier, h.DefraNode, inputs, maxConcurrentVerifications)
 }
 
-// processAttestationEventsWithSubscription starts DefraDB event listeners
+// processAttestationEventsWithSubscription starts DefraDB event listeners.
 func (h *Host) processAttestationEventsWithSubscription(ctx context.Context) {
 	logger.Sugar.Info("Starting DefraDB event listener")
 	// Start event bus listener - handles both metrics AND attestation creation for all P2P docs
@@ -70,19 +73,36 @@ func (h *Host) processAttestationEventsWithSubscription(ctx context.Context) {
 	logger.Sugar.Info("Event listeners stopped")
 }
 
-// Known collection IDs - stored at startup for direct comparison
+// Known collection IDs - stored at startup for direct comparison.
 var (
-	blockSigCollectionID    string
-	blockCollectionID       string
-	transactionCollectionID string
-	logCollectionID         string
-	accessListCollectionID  string
+	blockSigCollectionID    string //nolint:gochecknoglobals
+	blockCollectionID       string //nolint:gochecknoglobals
+	transactionCollectionID string //nolint:gochecknoglobals
+	logCollectionID         string //nolint:gochecknoglobals
+	accessListCollectionID  string //nolint:gochecknoglobals
 )
+
+// collectionIDToName - mapping for ID to Name.
+var collectionIDToName = map[string]string{ //nolint:gochecknoglobals
+	blockSigCollectionID:    constants.CollectionBlockSignature,
+	blockCollectionID:       constants.CollectionBlock,
+	transactionCollectionID: constants.CollectionTransaction,
+	logCollectionID:         constants.CollectionLog,
+	accessListCollectionID:  constants.CollectionAccessListEntry,
+}
+
+// collectionsWithMetrics - mapping collection to bool.
+var collectionsWithMetrics = map[string]bool{ //nolint:gochecknoglobals
+	constants.CollectionBlockSignature:  true,
+	constants.CollectionTransaction:     true,
+	constants.CollectionLog:             true,
+	constants.CollectionAccessListEntry: true,
+}
 
 // initKnownCollectionIDs fetches the CollectionIDs for collections we care about at startup.
 func (h *Host) initKnownCollectionIDs(ctx context.Context) error {
 	if h.DefraNode == nil || h.DefraNode.DB == nil {
-		return fmt.Errorf("DefraNode not available")
+		return ErrDefraNodeUnavailable
 	}
 
 	// Get BlockSignature collection ID
@@ -106,20 +126,20 @@ func (h *Host) initKnownCollectionIDs(ctx context.Context) error {
 		}
 	}
 
-	logger.Sugar.Infof("Initialized %d known collection IDs", 5)
+	logger.Sugar.Infof("Initialized %d known collection IDs", knownCollectionIDs)
 	return nil
 }
 
-// docEvent represents a document event to be processed
+// docEvent represents a document event to be processed.
 type docEvent struct {
 	docID          string
 	collectionName string
 }
 
-// docQueue is the unified queue for all document processing with drop-oldest backpressure
-var docQueue chan docEvent
+// docQueue is the unified queue for all document processing with drop-oldest backpressure.
+var docQueue chan docEvent //nolint:gochecknoglobals
 
-// initDocQueue initializes the document queue with config values
+// initDocQueue initializes the document queue with config values.
 func (h *Host) initDocQueue() (workerCount, queueSize int) {
 	queueSize = h.config.Shinzo.DocQueueSize
 	if queueSize <= 0 {
@@ -133,7 +153,7 @@ func (h *Host) initDocQueue() (workerCount, queueSize int) {
 	return workerCount, queueSize
 }
 
-// enqueueDoc adds a document to the processing queue with drop-oldest backpressure
+// enqueueDoc adds a document to the processing queue with drop-oldest backpressure.
 func enqueueDoc(evt docEvent) {
 	for {
 		select {
@@ -155,15 +175,14 @@ func (h *Host) docWorker(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case evt := <-docQueue:
-			switch evt.collectionName {
-			case constants.CollectionBlockSignature:
+			if evt.collectionName == constants.CollectionBlockSignature {
 				h.processBlockSignatureFromEventBus(ctx, evt.docID)
 			}
 		}
 	}
 }
 
-// startEventBusListener subscribes to DefraDB's event bus to track document metrics
+// startEventBusListener subscribes to DefraDB's event bus to track document metrics.
 func (h *Host) startEventBusListener(ctx context.Context) {
 	if h.DefraNode == nil || h.DefraNode.DB == nil {
 		logger.Sugar.Warn("DefraNode not available, skipping event bus listener")
@@ -201,14 +220,9 @@ func (h *Host) startEventBusListener(ctx context.Context) {
 				return
 			}
 
-			switch msg.Name {
-			case event.UpdateName:
+			if msg.Name == event.UpdateName {
 				update, ok := msg.Data.(event.Update)
-				if !ok {
-					continue
-				}
-
-				if !update.IsRelay {
+				if !ok || !update.IsRelay {
 					continue
 				}
 
@@ -216,40 +230,19 @@ func (h *Host) startEventBusListener(ctx context.Context) {
 					h.metrics.IncrementDocumentsReceived()
 				}
 
-				switch update.CollectionID {
-				case blockSigCollectionID:
-					if h.metrics != nil {
-						h.metrics.IncrementDocumentByType(constants.CollectionBlockSignature)
-					}
-					enqueueDoc(docEvent{docID: update.DocID, collectionName: constants.CollectionBlockSignature})
-					if h.pruneQueue != nil {
-						h.pruneQueue.Push(constants.CollectionBlockSignature, update.DocID)
-					}
-				case blockCollectionID:
-					if h.pruneQueue != nil {
-						h.pruneQueue.Push(constants.CollectionBlock, update.DocID)
-					}
-				case transactionCollectionID:
-					if h.metrics != nil {
-						h.metrics.IncrementDocumentByType(constants.CollectionTransaction)
-					}
-					if h.pruneQueue != nil {
-						h.pruneQueue.Push(constants.CollectionTransaction, update.DocID)
-					}
-				case logCollectionID:
-					if h.metrics != nil {
-						h.metrics.IncrementDocumentByType(constants.CollectionLog)
-					}
-					if h.pruneQueue != nil {
-						h.pruneQueue.Push(constants.CollectionLog, update.DocID)
-					}
-				case accessListCollectionID:
-					if h.metrics != nil {
-						h.metrics.IncrementDocumentByType(constants.CollectionAccessListEntry)
-					}
-					if h.pruneQueue != nil {
-						h.pruneQueue.Push(constants.CollectionAccessListEntry, update.DocID)
-					}
+				collectionName, known := collectionIDToName[update.CollectionID]
+				if !known {
+					continue
+				}
+
+				if collectionsWithMetrics[collectionName] && h.metrics != nil {
+					h.metrics.IncrementDocumentByType(collectionName)
+				}
+				if collectionName == constants.CollectionBlockSignature {
+					enqueueDoc(docEvent{docID: update.DocID, collectionName: collectionName})
+				}
+				if h.pruneQueue != nil {
+					h.pruneQueue.Push(collectionName, update.DocID)
 				}
 			}
 		}
@@ -286,7 +279,7 @@ func (h *Host) processBlockSignatureFromEventBus(ctx context.Context, docID stri
 			select {
 			case <-ctx.Done():
 				return
-			case <-time.After(2 * time.Millisecond):
+			case <-time.After(attestationRetryDelayMs * time.Millisecond):
 			}
 		}
 	}
@@ -299,12 +292,11 @@ func (h *Host) processBlockSignatureFromEventBus(ctx context.Context, docID stri
 	h.processBlockSignatureDocument(ctx, doc)
 }
 
-// processBlockSignatureDocument extracts fields from a client.Document and processes them.
-func (h *Host) processBlockSignatureDocument(ctx context.Context, doc *client.Document) {
+// extractBlockSignatureCore extracts blockNumber and merkleRoot, returning a partial BlockSignature or error.
+func extractBlockSignatureCore(doc *client.Document) (*attestationService.BlockSignature, int64, error) {
 	blockNumberVal, err := doc.Get("blockNumber")
 	if err != nil {
-		logger.Sugar.Warnf("BlockSignature missing blockNumber: %v", err)
-		return
+		return nil, 0, fmt.Errorf("missing blockNumber: %w", err)
 	}
 	blockNumber, ok := blockNumberVal.(int64)
 	if !ok {
@@ -315,20 +307,21 @@ func (h *Host) processBlockSignatureDocument(ctx context.Context, doc *client.Do
 
 	merkleRootVal, err := doc.Get("merkleRoot")
 	if err != nil {
-		logger.Sugar.Warnf("BlockSignature for block %d missing merkleRoot: %v", blockNumber, err)
-		return
+		return nil, blockNumber, fmt.Errorf("block %d missing merkleRoot: %w", blockNumber, err)
 	}
 	merkleRoot, ok := merkleRootVal.(string)
 	if !ok || merkleRoot == "" {
-		logger.Sugar.Warnf("BlockSignature for block %d has empty merkleRoot", blockNumber)
-		return
+		return nil, blockNumber, fmt.Errorf("block %d: %w", blockNumber, ErrEmptyMerkleRoot)
 	}
 
-	blockSig := &attestationService.BlockSignature{
+	return &attestationService.BlockSignature{
 		BlockNumber: blockNumber,
 		MerkleRoot:  merkleRoot,
-	}
+	}, blockNumber, nil
+}
 
+// populateBlockSignatureFields fills in optional string/int fields on a BlockSignature from a document.
+func populateBlockSignatureFields(doc *client.Document, blockSig *attestationService.BlockSignature) {
 	if val, err := doc.Get("blockHash"); err == nil {
 		if s, ok := val.(string); ok {
 			blockSig.BlockHash = s
@@ -362,46 +355,75 @@ func (h *Host) processBlockSignatureDocument(ctx context.Context, doc *client.Do
 			blockSig.CreatedAt = s
 		}
 	}
-	if cidVal, cidErr := doc.Get("cids"); cidErr == nil && cidVal != nil {
-		switch v := cidVal.(type) {
-		case []string:
-			blockSig.CIDs = v
-		case []immutable.Option[string]:
-			for _, item := range v {
-				if item.HasValue() {
-					blockSig.CIDs = append(blockSig.CIDs, item.Value())
-				}
+}
+
+// populateBlockSignatureCIDs extracts the CID list from a document into a BlockSignature.
+func populateBlockSignatureCIDs(doc *client.Document, blockSig *attestationService.BlockSignature) {
+	cidVal, err := doc.Get("cids")
+	if err != nil || cidVal == nil {
+		return
+	}
+	switch v := cidVal.(type) {
+	case []string:
+		blockSig.CIDs = v
+	case []immutable.Option[string]:
+		for _, item := range v {
+			if item.HasValue() {
+				blockSig.CIDs = append(blockSig.CIDs, item.Value())
 			}
-		case []any:
-			for _, item := range v {
-				if s, ok := item.(string); ok {
-					blockSig.CIDs = append(blockSig.CIDs, s)
-				}
+		}
+	case []any:
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				blockSig.CIDs = append(blockSig.CIDs, s)
 			}
 		}
 	}
+}
 
-	if h.blockSignatureVerifier != nil {
-		if err := h.blockSignatureVerifier.VerifyBlockSignature(ctx, blockSig); err != nil {
-			logger.Sugar.Warnf("Invalid block signature for block %d: %v", blockSig.BlockNumber, err)
+// verifyBlockSignature verifies the signature and CID list, updating metrics on failure.
+// Returns false if verification fails and processing should stop.
+func (h *Host) verifyBlockSignature(blockSig *attestationService.BlockSignature) bool {
+	if err := h.blockSignatureVerifier.VerifyBlockSignature(blockSig); err != nil {
+		logger.Sugar.Warnf("Invalid block signature for block %d: %v", blockSig.BlockNumber, err)
+		if h.metrics != nil {
+			h.metrics.IncrementSignatureFailures()
+		}
+		return false
+	}
+
+	if len(blockSig.CIDs) > 0 {
+		cidMatch, cidErr := h.blockSignatureVerifier.VerifyCIDListAgainstMerkleRoot(blockSig)
+		if cidErr != nil {
+			logger.Sugar.Warnf("Block %d: CID list verification error: %v", blockSig.BlockNumber, cidErr)
+		} else if !cidMatch {
+			logger.Sugar.Warnf("Block %d: CID list does NOT match Merkle root", blockSig.BlockNumber)
 			if h.metrics != nil {
 				h.metrics.IncrementSignatureFailures()
 			}
-			return
+			return false
 		}
+	}
 
-		// Verify CID list against merkle root (if present)
-		if len(blockSig.CIDs) > 0 {
-			cidMatch, cidErr := h.blockSignatureVerifier.VerifyCIDListAgainstMerkleRoot(blockSig)
-			if cidErr != nil {
-				logger.Sugar.Warnf("Block %d: CID list verification error: %v", blockSig.BlockNumber, cidErr)
-			} else if !cidMatch {
-				logger.Sugar.Warnf("Block %d: CID list does NOT match Merkle root", blockSig.BlockNumber)
-				if h.metrics != nil {
-					h.metrics.IncrementSignatureFailures()
-				}
-				return
-			}
+	return true
+}
+
+// processBlockSignatureDocument extracts fields from a client.Document and processes them.
+func (h *Host) processBlockSignatureDocument(ctx context.Context, doc *client.Document) {
+	startTime := time.Now()
+
+	blockSig, blockNumber, err := extractBlockSignatureCore(doc)
+	if err != nil {
+		logger.Sugar.Warnf("BlockSignature extraction failed: %v (block %d)", err, blockNumber)
+		return
+	}
+
+	populateBlockSignatureFields(doc, blockSig)
+	populateBlockSignatureCIDs(doc, blockSig)
+
+	if h.blockSignatureVerifier != nil {
+		if !h.verifyBlockSignature(blockSig) {
+			return
 		}
 
 		if h.metrics != nil {
@@ -409,9 +431,9 @@ func (h *Host) processBlockSignatureDocument(ctx context.Context, doc *client.Do
 		}
 
 		h.blockSignatureVerifier.AddBlockSignature(blockSig)
-
 		h.processAttestationsFromBlockSignature(ctx, blockSig)
 	}
+
 	if h.metrics != nil {
 		h.metrics.UpdateLastProcessingTime(float64(time.Since(startTime).Milliseconds()))
 	}
@@ -432,19 +454,19 @@ func (h *Host) processAttestationsFromBlockSignature(ctx context.Context, blockS
 	}
 
 	record := &constants.AttestationRecord{
-		AttestedDocId: blockAttestedID,
-		SourceDocIds:  []string{blockSig.SignatureIdentity},
+		AttestedDocID: blockAttestedID,
+		SourceDocIDs:  []string{blockSig.SignatureIdentity},
 		CIDs:          blockSig.CIDs,
 		DocType:       "Block",
 		VoteCount:     1,
 	}
 
 	var lastErr error
-	for attempt := range 5 {
+	for attempt := range maxAttestationRetries {
 		if err := attestationService.PostAttestationRecord(ctx, h.DefraNode, record); err != nil {
 			lastErr = err
 			if strings.Contains(err.Error(), "transaction conflict") || strings.Contains(err.Error(), "Please retry") {
-				time.Sleep(time.Duration(10*(1<<attempt)) * time.Millisecond)
+				time.Sleep(time.Duration(attestationBackoffBase*(1<<attempt)) * time.Millisecond)
 				continue
 			}
 			// Non-retryable error
@@ -456,16 +478,16 @@ func (h *Host) processAttestationsFromBlockSignature(ctx context.Context, blockS
 		}
 		// Success
 		if _, existed := attestedBlocks.LoadOrStore(blockNumber, true); existed {
-			logger.Sugar.Infof("Updated attestation for block %d (indexer: %s)", blockNumber, truncateString(blockSig.SignatureIdentity, 16))
+			logger.Sugar.Infof("Updated attestation for block %d (indexer: %s)", blockNumber, truncateString(blockSig.SignatureIdentity, identityTruncateLength))
 		} else {
 			if h.metrics != nil {
 				h.metrics.IncrementAttestationsCreated()
 				h.metrics.IncrementDocumentByType(constants.CollectionBlock)
 			}
-			logger.Sugar.Infof("Created attestation for block %d (indexer: %s)", blockNumber, truncateString(blockSig.SignatureIdentity, 16))
+			logger.Sugar.Infof("Created attestation for block %d (indexer: %s)", blockNumber, truncateString(blockSig.SignatureIdentity, identityTruncateLength))
 		}
 		if h.metrics != nil {
-			h.metrics.UpdateMostRecentBlock(uint64(blockNumber))
+			h.metrics.UpdateMostRecentBlock(uint64(blockNumber)) //nolint:gosec // block numbers are always positive
 		}
 		return
 	}

--- a/pkg/host/attestationHandler.go
+++ b/pkg/host/attestationHandler.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
 	attestationService "github.com/shinzonetwork/shinzo-host-client/pkg/attestation"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/constants"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/event"
 	"github.com/sourcenetwork/immutable"

--- a/pkg/host/attestationHandler_test.go
+++ b/pkg/host/attestationHandler_test.go
@@ -32,6 +32,8 @@ func init() {
 
 // extractDocIDFromMutationResult extracts the _docID from a DefraDB mutation result.
 // DefraDB may return the list as []map[string]any or []any depending on version.
+//
+//nolint:unparam
 func extractDocIDFromMutationResult(t *testing.T, result *client.RequestResult, collectionName string) string {
 	t.Helper()
 	dataMap, ok := result.GQL.Data.(map[string]any)
@@ -178,7 +180,7 @@ func TestProcessAttestationEventsWithSubscription_ContextCancelled(t *testing.T)
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately
-	// Should return promptly since context is already cancelled
+	// Should return promptly since context is already canceled
 	done := make(chan struct{})
 	go func() {
 		h.processAttestationEventsWithSubscription(ctx)
@@ -360,7 +362,7 @@ func TestStartEventBusListener_NilDefraNode(t *testing.T) {
 // processBlockSignatureFromEventBus
 // ---------------------------------------------------------------------------
 
-func TestProcessBlockSignatureFromEventBus_NilDefraNode(t *testing.T) {
+func TestProcessBlockSignatureFromEventBus_NilDefraNode(_ *testing.T) {
 	h := &Host{
 		DefraNode: nil,
 	}
@@ -368,7 +370,7 @@ func TestProcessBlockSignatureFromEventBus_NilDefraNode(t *testing.T) {
 	h.processBlockSignatureFromEventBus(context.Background(), "test-doc-id")
 }
 
-func TestProcessBlockSignatureFromEventBus_ContextCancelled(t *testing.T) {
+func TestProcessBlockSignatureFromEventBus_ContextCancelled(_ *testing.T) {
 	h := &Host{
 		DefraNode: nil,
 	}
@@ -391,7 +393,7 @@ func TestProcessBlockSignatureFromEventBus_ContextCancelled(t *testing.T) {
 // processAttestationsFromBlockSignature
 // ---------------------------------------------------------------------------
 
-func TestProcessAttestationsFromBlockSignature_NilDefraNode(t *testing.T) {
+func TestProcessAttestationsFromBlockSignature_NilDefraNode(_ *testing.T) {
 	h := &Host{
 		DefraNode: nil,
 	}
@@ -404,7 +406,7 @@ func TestProcessAttestationsFromBlockSignature_NilDefraNode(t *testing.T) {
 	h.processAttestationsFromBlockSignature(context.Background(), blockSig)
 }
 
-func TestProcessAttestationsFromBlockSignature_NoCIDs(t *testing.T) {
+func TestProcessAttestationsFromBlockSignature_NoCIDs(_ *testing.T) {
 	h := &Host{
 		DefraNode: nil,
 		metrics:   server.NewHostMetrics(),
@@ -504,14 +506,14 @@ func TestProcessAttestationsFromBlockSignature_EmptyBlockAttestedID(t *testing.T
 	require.Equal(t, "block:42:abc123", blockAttestedID)
 
 	record := &constants.AttestationRecord{
-		AttestedDocId: blockAttestedID,
-		SourceDocIds:  []string{blockSig.SignatureIdentity},
+		AttestedDocID: blockAttestedID,
+		SourceDocIDs:  []string{blockSig.SignatureIdentity},
 		CIDs:          blockSig.CIDs,
 		DocType:       "Block",
 		VoteCount:     1,
 	}
-	require.Equal(t, "block:42:abc123", record.AttestedDocId)
-	require.Equal(t, []string{"0xsigner"}, record.SourceDocIds)
+	require.Equal(t, "block:42:abc123", record.AttestedDocID)
+	require.Equal(t, []string{"0xsigner"}, record.SourceDocIDs)
 	require.Equal(t, []string{"cid1", "cid2"}, record.CIDs)
 	require.Equal(t, "Block", record.DocType)
 	require.Equal(t, 1, record.VoteCount)
@@ -555,7 +557,7 @@ func TestInitKnownCollectionIDs_WithRealDefraDB(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	h := &Host{
 		DefraNode: defraNode,
@@ -597,7 +599,7 @@ func TestStartEventBusListener_WithRealDefraDB_WritesDoc(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	metrics := server.NewHostMetrics()
 	cfg := *DefaultConfig
@@ -648,7 +650,7 @@ func TestStartEventBusListener_WithRealDefraDB(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	cfg := *DefaultConfig
 	h := &Host{
@@ -683,7 +685,7 @@ func TestProcessBlockSignatureFromEventBus_WithRealDefraDB_InvalidDocID(t *testi
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	h := &Host{
 		DefraNode: defraNode,
@@ -698,7 +700,7 @@ func TestProcessBlockSignatureFromEventBus_WithRealDefraDB_NonExistentDoc(t *tes
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	h := &Host{
 		DefraNode: defraNode,
@@ -717,7 +719,7 @@ func TestProcessBlockSignatureDocument_WithRealDefraDB(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	// Create a BlockSignature document in DefraDB
 	mutation := fmt.Sprintf(`mutation {
@@ -770,7 +772,7 @@ func TestProcessBlockSignatureDocument_WithVerifier(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	// Create a BlockSignature document with invalid signature (will fail verification)
 	mutation := fmt.Sprintf(`mutation {
@@ -824,7 +826,7 @@ func TestProcessDocumentAttestationBatch_WithVersionData(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	cfg := *DefaultConfig
 	cfg.Shinzo.MaxConcurrentVerifications = 10
@@ -870,12 +872,12 @@ func TestProcessDocumentAttestationBatch_WithVersionData(t *testing.T) {
 	_ = err
 }
 
-func TestProcessDocumentAttestationBatch_MultipleDocsWithMixedVersionData(t *testing.T) {
+func TestProcessDocumentAttestationBatch_MultipleDocsWithMixedVersionData(_ *testing.T) {
 	cfg := *DefaultConfig
 	cfg.Shinzo.MaxConcurrentVerifications = 5
 
 	h := &Host{
-		config: &cfg,
+		config:            &cfg,
 		signatureVerifier: attestationService.NewDefraSignatureVerifier(nil, nil),
 	}
 
@@ -930,7 +932,7 @@ func TestProcessAttestationsFromBlockSignature_WithRealDefraDB(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	metrics := server.NewHostMetrics()
 
@@ -968,7 +970,7 @@ func TestProcessAttestationsFromBlockSignature_WithRealDefraDB_NoCIDs(t *testing
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	h := &Host{
 		DefraNode: defraNode,
@@ -998,7 +1000,7 @@ func TestProcessBlockSignatureDocument_WithCIDs(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	// Create a BlockSignature document with cids populated
 	mutation := fmt.Sprintf(`mutation {
@@ -1046,7 +1048,7 @@ func TestProcessBlockSignatureDocument_ZeroBlockNumber(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	// Create a BlockSignature with blockNumber=0 to test type handling
 	mutation := fmt.Sprintf(`mutation {
@@ -1085,7 +1087,7 @@ func TestProcessBlockSignatureDocument_EmptyMerkleRoot(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	// Create a BlockSignature with empty merkleRoot
 	mutation := fmt.Sprintf(`mutation {
@@ -1128,7 +1130,7 @@ func TestProcessBlockSignatureDocument_WithValidSignatureAndCIDs(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	// Generate an Ed25519 key pair
 	privKey, err := crypto.GenerateKey(crypto.KeyTypeEd25519)
@@ -1208,7 +1210,7 @@ func TestProcessBlockSignatureFromEventBus_WithRealDefraDB_FullPath(t *testing.T
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	// Create a BlockSignature document
 	mutation := fmt.Sprintf(`mutation {
@@ -1250,7 +1252,7 @@ func TestProcessAttestationsFromBlockSignature_ExistedPath(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	metrics := server.NewHostMetrics()
 	h := &Host{
@@ -1289,7 +1291,7 @@ func TestProcessAttestationsFromBlockSignature_MultipleIndexers_PreservesBothIde
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	metrics := server.NewHostMetrics()
 	h := &Host{
@@ -1325,9 +1327,9 @@ func TestProcessAttestationsFromBlockSignature_MultipleIndexers_PreservesBothIde
 	require.Len(t, records, 1, "Should have exactly one attestation record for this block")
 
 	record := records[0]
-	require.Contains(t, record.SourceDocIds, "indexer-A", "Should contain first indexer's identity")
-	require.Contains(t, record.SourceDocIds, "indexer-B", "Should contain second indexer's identity")
-	require.Len(t, record.SourceDocIds, 2, "Should have exactly 2 indexer identities")
+	require.Contains(t, record.SourceDocIDs, "indexer-A", "Should contain first indexer's identity")
+	require.Contains(t, record.SourceDocIDs, "indexer-B", "Should contain second indexer's identity")
+	require.Len(t, record.SourceDocIDs, 2, "Should have exactly 2 indexer identities")
 }
 
 // ---------------------------------------------------------------------------
@@ -1339,7 +1341,7 @@ func TestProcessBlockSignatureDocument_ValidSigCIDMismatch(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	// Generate Ed25519 key pair
 	privKey, err := crypto.GenerateKey(crypto.KeyTypeEd25519)
@@ -1406,7 +1408,7 @@ func TestProcessBlockSignatureDocument_ValidSigCIDMismatch(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// processBlockSignatureFromEventBus - context cancelled during retry loop
+// processBlockSignatureFromEventBus - context canceled during retry loop
 // ---------------------------------------------------------------------------
 
 func TestProcessBlockSignatureFromEventBus_ContextCancelledDuringRetry(t *testing.T) {
@@ -1414,7 +1416,7 @@ func TestProcessBlockSignatureFromEventBus_ContextCancelledDuringRetry(t *testin
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	h := &Host{
 		DefraNode: defraNode,
@@ -1437,7 +1439,7 @@ func TestStartEventBusListener_WithMetricsAndCollections(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	metrics := server.NewHostMetrics()
 	cfg := *DefaultConfig

--- a/pkg/host/attestationHandler_test.go
+++ b/pkg/host/attestationHandler_test.go
@@ -13,11 +13,11 @@ import (
 
 	gocid "github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
-	"github.com/shinzonetwork/shinzo-host-client/pkg/defradb"
-	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
 	"github.com/shinzonetwork/shinzo-host-client/config"
 	attestationService "github.com/shinzonetwork/shinzo-host-client/pkg/attestation"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/constants"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/defradb"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
 	localschema "github.com/shinzonetwork/shinzo-host-client/pkg/schema"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/server"
 	"github.com/sourcenetwork/defradb/client"

--- a/pkg/host/attestationHandler_test.go
+++ b/pkg/host/attestationHandler_test.go
@@ -555,7 +555,7 @@ func TestRetryableErrorDetection(t *testing.T) {
 func TestInitKnownCollectionIDs_WithRealDefraDB(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchema()))
 	require.NoError(t, err)
 	defer func() { _ = defraNode.Close(ctx) }()
 
@@ -597,7 +597,7 @@ func TestInitKnownCollectionIDs_NilDB(t *testing.T) {
 func TestStartEventBusListener_WithRealDefraDB_WritesDoc(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchema()))
 	require.NoError(t, err)
 	defer func() { _ = defraNode.Close(ctx) }()
 
@@ -648,7 +648,7 @@ func TestStartEventBusListener_WithRealDefraDB_WritesDoc(t *testing.T) {
 func TestStartEventBusListener_WithRealDefraDB(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchema()))
 	require.NoError(t, err)
 	defer func() { _ = defraNode.Close(ctx) }()
 
@@ -683,7 +683,7 @@ func TestStartEventBusListener_WithRealDefraDB(t *testing.T) {
 func TestProcessBlockSignatureFromEventBus_WithRealDefraDB_InvalidDocID(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchema()))
 	require.NoError(t, err)
 	defer func() { _ = defraNode.Close(ctx) }()
 
@@ -698,7 +698,7 @@ func TestProcessBlockSignatureFromEventBus_WithRealDefraDB_InvalidDocID(t *testi
 func TestProcessBlockSignatureFromEventBus_WithRealDefraDB_NonExistentDoc(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchema()))
 	require.NoError(t, err)
 	defer func() { _ = defraNode.Close(ctx) }()
 
@@ -717,7 +717,7 @@ func TestProcessBlockSignatureFromEventBus_WithRealDefraDB_NonExistentDoc(t *tes
 func TestProcessBlockSignatureDocument_WithRealDefraDB(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchema()))
 	require.NoError(t, err)
 	defer func() { _ = defraNode.Close(ctx) }()
 
@@ -770,7 +770,7 @@ func TestProcessBlockSignatureDocument_WithRealDefraDB(t *testing.T) {
 func TestProcessBlockSignatureDocument_WithVerifier(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchema()))
 	require.NoError(t, err)
 	defer func() { _ = defraNode.Close(ctx) }()
 
@@ -824,7 +824,7 @@ func TestProcessBlockSignatureDocument_WithVerifier(t *testing.T) {
 func TestProcessDocumentAttestationBatch_WithVersionData(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchema()))
 	require.NoError(t, err)
 	defer func() { _ = defraNode.Close(ctx) }()
 
@@ -930,7 +930,7 @@ func TestProcessDocumentAttestationBatch_MultipleDocsWithMixedVersionData(_ *tes
 func TestProcessAttestationsFromBlockSignature_WithRealDefraDB(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchema()))
 	require.NoError(t, err)
 	defer func() { _ = defraNode.Close(ctx) }()
 
@@ -968,7 +968,7 @@ func TestProcessAttestationsFromBlockSignature_WithRealDefraDB(t *testing.T) {
 func TestProcessAttestationsFromBlockSignature_WithRealDefraDB_NoCIDs(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchema()))
 	require.NoError(t, err)
 	defer func() { _ = defraNode.Close(ctx) }()
 
@@ -998,7 +998,7 @@ func TestProcessAttestationsFromBlockSignature_WithRealDefraDB_NoCIDs(t *testing
 func TestProcessBlockSignatureDocument_WithCIDs(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchema()))
 	require.NoError(t, err)
 	defer func() { _ = defraNode.Close(ctx) }()
 
@@ -1046,7 +1046,7 @@ func TestProcessBlockSignatureDocument_WithCIDs(t *testing.T) {
 func TestProcessBlockSignatureDocument_ZeroBlockNumber(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchema()))
 	require.NoError(t, err)
 	defer func() { _ = defraNode.Close(ctx) }()
 
@@ -1085,7 +1085,7 @@ func TestProcessBlockSignatureDocument_ZeroBlockNumber(t *testing.T) {
 func TestProcessBlockSignatureDocument_EmptyMerkleRoot(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchema()))
 	require.NoError(t, err)
 	defer func() { _ = defraNode.Close(ctx) }()
 
@@ -1128,7 +1128,7 @@ func makeTestCID(data string) string {
 func TestProcessBlockSignatureDocument_WithValidSignatureAndCIDs(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchema()))
 	require.NoError(t, err)
 	defer func() { _ = defraNode.Close(ctx) }()
 
@@ -1208,7 +1208,7 @@ func TestProcessBlockSignatureDocument_WithValidSignatureAndCIDs(t *testing.T) {
 func TestProcessBlockSignatureFromEventBus_WithRealDefraDB_FullPath(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchema()))
 	require.NoError(t, err)
 	defer func() { _ = defraNode.Close(ctx) }()
 
@@ -1250,7 +1250,7 @@ func TestProcessBlockSignatureFromEventBus_WithRealDefraDB_FullPath(t *testing.T
 func TestProcessAttestationsFromBlockSignature_ExistedPath(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchema()))
 	require.NoError(t, err)
 	defer func() { _ = defraNode.Close(ctx) }()
 
@@ -1289,7 +1289,7 @@ func TestProcessAttestationsFromBlockSignature_ExistedPath(t *testing.T) {
 func TestProcessAttestationsFromBlockSignature_MultipleIndexers_PreservesBothIdentities(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchema()))
 	require.NoError(t, err)
 	defer func() { _ = defraNode.Close(ctx) }()
 
@@ -1332,6 +1332,12 @@ func TestProcessAttestationsFromBlockSignature_MultipleIndexers_PreservesBothIde
 	require.Len(t, record.SourceDocIDs, 2, "Should have exactly 2 indexer identities")
 }
 
+func TestDebugSchema(t *testing.T) {
+	schema := localschema.GetSchema()
+	t.Log(schema)
+	require.Contains(t, schema, "source_doc")
+}
+
 // ---------------------------------------------------------------------------
 // processBlockSignatureDocument - valid signature, CID mismatch path
 // ---------------------------------------------------------------------------
@@ -1339,7 +1345,7 @@ func TestProcessAttestationsFromBlockSignature_MultipleIndexers_PreservesBothIde
 func TestProcessBlockSignatureDocument_ValidSigCIDMismatch(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchema()))
 	require.NoError(t, err)
 	defer func() { _ = defraNode.Close(ctx) }()
 
@@ -1414,7 +1420,7 @@ func TestProcessBlockSignatureDocument_ValidSigCIDMismatch(t *testing.T) {
 func TestProcessBlockSignatureFromEventBus_ContextCancelledDuringRetry(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchema()))
 	require.NoError(t, err)
 	defer func() { _ = defraNode.Close(ctx) }()
 
@@ -1437,7 +1443,7 @@ func TestProcessBlockSignatureFromEventBus_ContextCancelledDuringRetry(t *testin
 func TestStartEventBusListener_WithMetricsAndCollections(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchema()))
 	require.NoError(t, err)
 	defer func() { _ = defraNode.Close(ctx) }()
 

--- a/pkg/host/constants.go
+++ b/pkg/host/constants.go
@@ -1,0 +1,36 @@
+package host
+
+import "time"
+
+const (
+	// defaultMaxP2PRetries is a const for the max p2p retries.
+	defaultMaxP2PRetries = 5
+	// defaultRetryBaseDelayMs is a const for a base delay in ms.
+	defaultRetryBaseDelayMs = 1000
+	// defaultReconnectIntervalMs is a const for reconnect interval in ms.
+	defaultReconnectIntervalMs = 60000
+	// blockSignatureCacheSize is a const for blockSig cache size.
+	blockSignatureCacheSize = 10000
+	// openBrowserDelaySecs is a delay for opening the browser.
+	openBrowserDelaySecs = 2
+	// peerResolutionTimeoutSecs is a const for resolution timeout in s.
+	peerResolutionTimeoutSecs = 5
+	// healthServerShutdownTimeoutSecs is a const for shutdown timeout in s.
+	healthServerShutdownTimeoutSecs = 5
+	// defaultMaxProcessingDepth is a const for max processing depth.
+	defaultMaxProcessingDepth = 5
+	// knownCollectionIDs is a const for known collection ids is a const for the number of known collection ids.
+	knownCollectionIDs = 5
+	// maxAttestationRetries is a const for the number of max attestation retries.
+	maxAttestationRetries = 5
+	// attestationRetryDelayMs is a const for the attestation retry delay in ms.
+	attestationRetryDelayMs = 2
+	// attestationBackoffBase is the base number of backoff for attestations.
+	attestationBackoffBase = 10
+	// identityTruncateLength is a const for the identity tracation.
+	identityTruncateLength = 16
+	// nanosecondsPerMillisecond is a const for the number of ns per ms.
+	nanosecondsPerMillisecond = 1_000_000.0
+	// defaultTimeout is a const for the default timeout in s.
+	defaultTimeout = 5 * time.Second
+)

--- a/pkg/host/constants_test.go
+++ b/pkg/host/constants_test.go
@@ -1,0 +1,8 @@
+package host
+
+const (
+	testQueryBlocks   = "SELECT * FROM blocks"
+	testQueryTest     = "SELECT * FROM test"
+	testViewSDL       = "type TestView { field: String }"
+	testSnapshotsPath = "/snapshots"
+)

--- a/pkg/host/errors.go
+++ b/pkg/host/errors.go
@@ -1,0 +1,16 @@
+package host
+
+import "errors"
+
+var ( //nolint:revive
+	ErrDefraNodeUnavailable = errors.New("DefraNode not available")                      //nolint:revive
+	ErrViewManagerNil       = errors.New("ViewManager not initialized")                  //nolint:revive
+	ErrViewMissingQuery     = errors.New("view missing query")                           //nolint:revive
+	ErrViewMissingSDL       = errors.New("view missing SDL")                             //nolint:revive
+	ErrDefraDBNotReady      = errors.New("DefraDB failed to become ready")               //nolint:revive
+	ErrUnsupportedPlatform  = errors.New("unsupported platform")                         //nolint:revive
+	ErrInvalidIPAddress     = errors.New("invalid IP address")                           //nolint:revive
+	ErrNoPeerIDMismatchInfo = errors.New("error does not contain peer ID mismatch info") //nolint:revive
+	ErrMissingFilterFields  = errors.New("document missing required filter fields")      //nolint:revive
+	ErrEmptyMerkleRoot      = errors.New("empty merkleRoot")
+)

--- a/pkg/host/errors_test.go
+++ b/pkg/host/errors_test.go
@@ -1,0 +1,15 @@
+package host
+
+import "errors"
+
+var (
+	errPeerIDMismatchDial = errors.New(
+		"all dials failed\n  * [/ip4/34.9.109.135/tcp/9171] failed to negotiate security protocol: " +
+			"peer id mismatch: expected 12D3KooWCS9HHoiqfu1YRBiLM5spAbDGiHb2NtXEGUoHYTcCtEfy, " +
+			"but remote key matches 12D3KooWPBbKmsSsFiTW2X4sY4uuCUEazSFZkAdY8Egm4mQsiSEF",
+	)
+	errConnectionRefused    = errors.New("connection refused")
+	errTransactionConflict  = errors.New("transaction conflict: cannot write")
+	errOperationFailedRetry = errors.New("operation failed: Please retry")
+	errEmptyMessage         = errors.New("")
+)

--- a/pkg/host/host.go
+++ b/pkg/host/host.go
@@ -16,17 +16,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/shinzonetwork/shinzo-host-client/pkg/defradb"
-	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
-	"github.com/shinzonetwork/shinzo-host-client/pkg/pruner"
-	"github.com/shinzonetwork/shinzo-host-client/pkg/signer"
 	"github.com/shinzonetwork/shinzo-host-client/config"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/attestation"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/constants"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/defradb"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
 	playgroundserver "github.com/shinzonetwork/shinzo-host-client/pkg/playground"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/pruner"
 	localschema "github.com/shinzonetwork/shinzo-host-client/pkg/schema"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/server"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/shinzohub"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/signer"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/view"
 	"github.com/sourcenetwork/corelog"
 	"github.com/sourcenetwork/defradb/client"
@@ -660,7 +660,7 @@ func waitForDefraDB(ctx context.Context, defraNode *node.Node) error {
 	query := `{ ` + constants.CollectionBlock + ` { __typename } }`
 
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		_, err := defradb.QuerySingle[map[string]interface{}](ctx, defraNode, query)
+		_, err := defradb.QuerySingle[map[string]any](ctx, defraNode, query)
 		if err == nil {
 			fmt.Println("Defra is responsive!")
 			return nil

--- a/pkg/host/host.go
+++ b/pkg/host/host.go
@@ -2,6 +2,7 @@ package host
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -23,7 +24,6 @@ import (
 	"github.com/shinzonetwork/shinzo-host-client/pkg/attestation"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/constants"
 	playgroundserver "github.com/shinzonetwork/shinzo-host-client/pkg/playground"
-	"github.com/shinzonetwork/shinzo-host-client/pkg/schema"
 	localschema "github.com/shinzonetwork/shinzo-host-client/pkg/schema"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/server"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/shinzohub"
@@ -33,7 +33,7 @@ import (
 	"github.com/sourcenetwork/defradb/node"
 )
 
-// parseTimeoutOrDefault parses a duration string or returns a default value
+// parseTimeoutOrDefault parses a duration string or returns a default value.
 func parseTimeoutOrDefault(timeoutStr string, defaultDuration time.Duration) time.Duration {
 	if timeoutStr == "" {
 		return defaultDuration
@@ -48,7 +48,7 @@ func parseTimeoutOrDefault(timeoutStr string, defaultDuration time.Duration) tim
 	return duration
 }
 
-// maxInt returns the maximum of two integers
+// maxInt returns the maximum of two integers.
 func maxInt(a, b int) int {
 	if a > b {
 		return a
@@ -56,18 +56,19 @@ func maxInt(a, b int) int {
 	return b
 }
 
-var DefaultConfig *config.Config = func() *config.Config {
+// DefaultConfig provides a template for host configuration with sensible defaults.
+var DefaultConfig *config.Config = func() *config.Config { //nolint:gochecknoglobals
 	cfg := &config.Config{
 		DefraDB: config.DefraDBConfig{
-			Url:           "localhost:9181",
+			URL:           "localhost:9181",
 			KeyringSecret: "test-keyring-secret-for-testing",
 			P2P: config.DefraDBP2PConfig{
 				Enabled:             true,
 				BootstrapPeers:      []string{},
 				ListenAddr:          "/ip4/0.0.0.0/tcp/9171",
-				MaxRetries:          5,
-				RetryBaseDelayMs:    1000,
-				ReconnectIntervalMs: 60000,
+				MaxRetries:          defaultMaxP2PRetries,
+				RetryBaseDelayMs:    defaultRetryBaseDelayMs,
+				ReconnectIntervalMs: defaultReconnectIntervalMs,
 				EnableAutoReconnect: true,
 			},
 			Store: config.DefraDBStoreConfig{
@@ -87,6 +88,7 @@ var DefaultConfig *config.Config = func() *config.Config {
 	return cfg
 }()
 
+// Host represents the main application state and components of the Shinzo host. It manages the DefraDB node, P2P network, view manager, processing pipeline, health server, and other core functionalities of the host application.
 type Host struct {
 	DefraNode      *node.Node
 	NetworkHandler *defra.NetworkHandler // P2P network control
@@ -106,23 +108,25 @@ type Host struct {
 	processingPipeline *ProcessingPipeline // Complete message processing pipeline
 
 	// VIEW MANAGEMENT SYSTEM: Handle lens transformations and view lifecycle
-	viewManager *view.ViewManager // Manages view lifecycle and processing
+	viewManager *view.Manager // Manages view lifecycle and processing
 
 	healthServer *server.HealthServer
 	metrics      *server.HostMetrics
 
-	mostRecentBlockReceived uint64
+	// mostRecentBlockReceived uint64
 
-	pruner         *pruner.Pruner     // Document pruner for removing old blocks
-	pruneQueue     *pruner.EventQueue // FIFO queue tracking replicated docIDs
-	pruneGuardStop context.CancelFunc // Stops the prune guard goroutine
+	pruner     *pruner.Pruner     // Document pruner for removing old blocks
+	pruneQueue *pruner.EventQueue // FIFO queue tracking replicated docIDs
+	// pruneGuardStop context.CancelFunc // Stops the prune guard goroutine
 }
 
+// StartHosting starts the host application with the provided configuration. It initializes DefraDB, sets up the processing pipeline, view manager, and health server, and optionally subscribes to ShinzoHub events. This is the main entry point for starting the host.
 func StartHosting(cfg *config.Config) (*Host, error) {
 	return StartHostingWithEventSubscription(cfg)
 }
 
-func StartHostingWithEventSubscription(cfg *config.Config) (*Host, error) {
+// StartHostingWithEventSubscription starts the host with optional event subscription to ShinzoHub for view registrations and other events. This is the main entry point for starting the host application.
+func StartHostingWithEventSubscription(cfg *config.Config) (*Host, error) { //nolint:funlen // TODO: fix funlen
 	if cfg == nil {
 		cfg = DefaultConfig
 	}
@@ -147,7 +151,7 @@ func StartHostingWithEventSubscription(cfg *config.Config) (*Host, error) {
 		constants.AllCollections...,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("error starting defra instance: %v", err)
+		return nil, fmt.Errorf("error starting defra instance: %w", err)
 	}
 
 	// P2P peers will be added after ViewManager is initialized (see below)
@@ -183,12 +187,12 @@ func StartHostingWithEventSubscription(cfg *config.Config) (*Host, error) {
 	if isPlaygroundEnabled() && defraNode.APIURL != "" {
 		playgroundHandler, err := playgroundserver.NewServer(defraNode.APIURL)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create playground server: %v", err)
+			return nil, fmt.Errorf("failed to create playground server: %w", err)
 		}
 
 		// Start playground server on a different port (defradb port + 1)
 		// Parse the defradb URL to get the port and increment it
-		playgroundAddr := cfg.DefraDB.Url
+		playgroundAddr := cfg.DefraDB.URL
 		if defraNode.APIURL != "" {
 			playgroundAddr = defraNode.APIURL
 		}
@@ -198,12 +202,13 @@ func StartHostingWithEventSubscription(cfg *config.Config) (*Host, error) {
 		}
 
 		playgroundServer = &http.Server{
-			Addr:    playgroundAddr,
-			Handler: playgroundHandler,
+			Addr:              playgroundAddr,
+			Handler:           playgroundHandler,
+			ReadHeaderTimeout: defaultTimeout,
 		}
 
 		go func() {
-			if err := playgroundServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			if err := playgroundServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 				logger.Sugar.Errorf("Playground server error: %v", err)
 			}
 		}()
@@ -225,7 +230,7 @@ func StartHostingWithEventSubscription(cfg *config.Config) (*Host, error) {
 
 	// Initialize ViewManager and load persisted views
 	// This handles: 1) Fetch views from ShinzoHub, 2) Load local views, 3) Download WASM files, 4) Register views
-	newHost.viewManager = view.NewViewManager(defraNode, cfg.HostConfig.LensRegistryPath)
+	newHost.viewManager = view.NewManager(defraNode, cfg.HostConfig.LensRegistryPath)
 
 	// Hook up metrics callback for view tracking
 	newHost.viewManager.SetMetricsCallback(func() *server.HostMetrics {
@@ -324,7 +329,7 @@ func StartHostingWithEventSubscription(cfg *config.Config) (*Host, error) {
 		}
 
 		if err != nil {
-			return nil, fmt.Errorf("error starting event subscription: %v", err)
+			return nil, fmt.Errorf("error starting event subscription: %w", err)
 		}
 	}
 
@@ -338,15 +343,15 @@ func StartHostingWithEventSubscription(cfg *config.Config) (*Host, error) {
 
 	// Initialize and start health server
 	var healthDefraURL string
-	if cfg.DefraDB.Url != "" {
-		healthDefraURL = cfg.DefraDB.Url
+	if cfg.DefraDB.URL != "" {
+		healthDefraURL = cfg.DefraDB.URL
 	} else if defraNode != nil && defraNode.APIURL != "" {
 		healthDefraURL = defraNode.APIURL
 	}
 
 	if defraNode != nil {
 		newHost.signatureVerifier = attestation.NewDefraSignatureVerifier(defraNode, newHost.metrics)
-		newHost.blockSignatureVerifier = attestation.NewBlockSignatureVerifier(10000) // Cache last 10000 blocks
+		newHost.blockSignatureVerifier = attestation.NewBlockSignatureVerifier(blockSignatureCacheSize)
 		newHost.blockCIDCollector = attestation.NewBlockCIDCollector()
 		logger.Sugar.Info("🔐 Optimized signature verifier initialized (with block signature support)")
 	}
@@ -395,7 +400,7 @@ func StartHostingWithEventSubscription(cfg *config.Config) (*Host, error) {
 
 	if cfg.HostConfig.OpenBrowserOnStart {
 		go func() {
-			time.Sleep(2 * time.Second)
+			time.Sleep(openBrowserDelaySecs * time.Second)
 			if err := openBrowser(metricsURL); err != nil {
 				logger.Sugar.Debugf("Could not open browser automatically: %v", err)
 			} else {
@@ -413,36 +418,37 @@ func StartHostingWithEventSubscription(cfg *config.Config) (*Host, error) {
 	return newHost, nil
 }
 
-// HealthChecker interface implementation for Host
+// IsHealthy returns check for defra + processing pipeline health. This is used by the health server to determine if the host is healthy and ready to serve requests.
 func (h *Host) IsHealthy() bool {
 	// Check if DefraDB is accessible and processing pipeline is running
 	return h.DefraNode != nil && h.processingPipeline != nil
 }
 
+// GetCurrentBlock returns the most recent block height that the host has processed, based on the host's metrics. This is used for monitoring the progress of block processing and data freshness.
 func (h *Host) GetCurrentBlock() int64 {
 	if h.metrics != nil {
-		return int64(atomic.LoadUint64(&h.metrics.MostRecentBlock))
+		return int64(atomic.LoadUint64(&h.metrics.MostRecentBlock)) //nolint:gosec // block numbers won't exceed int64 max
 	}
 	return 0
 }
 
-// ProcessViewRegistrationEvent processes a view registration event
+// ProcessViewRegistrationEvent processes a view registration event.
 func (h *Host) ProcessViewRegistrationEvent(ctx context.Context, event shinzohub.ViewRegisteredEvent) error {
 	if h.viewManager == nil {
-		return fmt.Errorf("ViewManager not initialized")
+		return ErrViewManagerNil
 	}
 
 	// Validate view has required fields
 	if event.View.Data.Query == "" {
-		return fmt.Errorf("view %s missing query", event.View.Name)
+		return fmt.Errorf("view %s: %w", event.View.Name, ErrViewMissingQuery)
 	}
 	if event.View.Data.Sdl == "" {
-		return fmt.Errorf("view %s missing SDL", event.View.Name)
+		return fmt.Errorf("view %s: %w", event.View.Name, ErrViewMissingSDL)
 	}
 
 	// Write WASM to disk
 	if len(event.View.Data.Transform.Lenses) > 0 {
-		if err := event.View.PostWasmToFile(ctx, h.LensRegistryPath); err != nil {
+		if err := event.View.PostWasmToFile(h.LensRegistryPath); err != nil {
 			return fmt.Errorf("failed to write WASM for view %s: %w", event.View.Name, err)
 		}
 	}
@@ -460,6 +466,7 @@ func (h *Host) ProcessViewRegistrationEvent(ctx context.Context, event shinzohub
 	return nil
 }
 
+// GetLastProcessedTime returns the timestamp of the most recently processed block, based on the host's metrics. This is used for monitoring the freshness of the data being processed by the host.
 func (h *Host) GetLastProcessedTime() time.Time {
 	if h.metrics != nil {
 		return h.metrics.LastDocumentTime
@@ -467,6 +474,7 @@ func (h *Host) GetLastProcessedTime() time.Time {
 	return time.Time{}
 }
 
+// GetPeerInfo returns information about the host's P2P network status, including whether P2P is enabled, the host's own peer ID and addresses, and a list of currently connected peers. This is used for monitoring and debugging the P2P network status of the host.
 func (h *Host) GetPeerInfo() (*server.P2PInfo, error) {
 	p2pInfo := &server.P2PInfo{
 		Enabled:  h.NetworkHandler != nil,
@@ -524,6 +532,7 @@ func (h *Host) GetPeerInfo() (*server.P2PInfo, error) {
 	return p2pInfo, nil
 }
 
+// SignMessages signs a message using both DefraDB node keys and P2P keys, returning the signed messages for attestation registration and peer ID registration. This is used for proving ownership of the host in the attestation system and P2P network.
 func (h *Host) SignMessages(message string) (server.DefraPKRegistration, server.PeerIDRegistration, error) {
 	// Use the signer package approach like the indexer
 	signedMsg, err := signer.SignWithDefraKeys(message, h.DefraNode, h.config.ToAppConfig())
@@ -557,14 +566,17 @@ func (h *Host) SignMessages(message string) (server.DefraPKRegistration, server.
 		}, nil
 }
 
+// GetNodePublicKey retrieves the public key of the DefraDB node using the signer package. This is used for attestation registration and verification.
 func (h *Host) GetNodePublicKey() (string, error) {
 	return signer.GetDefraPublicKey(h.DefraNode, h.config.ToAppConfig())
 }
 
+// GetPeerPublicKey retrieves the P2P public key of the host using the signer package. This is used for peer ID registration and verification in the P2P network.
 func (h *Host) GetPeerPublicKey() (string, error) {
 	return signer.GetP2PPublicKey(h.DefraNode, h.config.ToAppConfig())
 }
 
+// incrementPort takes a URL string, parses it, increments the port by 1, and returns the modified URL string. It handles URLs with or without protocols and returns an error if the URL is invalid or the port cannot be parsed.
 func incrementPort(apiURL string) (string, error) {
 	// Ensure URL has protocol
 	if !strings.HasPrefix(apiURL, "http://") && !strings.HasPrefix(apiURL, "https://") {
@@ -573,22 +585,23 @@ func incrementPort(apiURL string) (string, error) {
 
 	parsed, err := url.Parse(apiURL)
 	if err != nil {
-		return "", fmt.Errorf("invalid URL %s: %v", apiURL, err)
+		return "", fmt.Errorf("invalid URL %s: %w", apiURL, err)
 	}
 
 	host, portStr, err := net.SplitHostPort(parsed.Host)
 	if err != nil {
-		return "", fmt.Errorf("invalid host:port %s: %v", parsed.Host, err)
+		return "", fmt.Errorf("invalid host:port %s: %w", parsed.Host, err)
 	}
 
 	port, err := strconv.Atoi(portStr)
 	if err != nil {
-		return "", fmt.Errorf("invalid port %s: %v", portStr, err)
+		return "", fmt.Errorf("invalid port %s: %w", portStr, err)
 	}
 
 	return net.JoinHostPort(host, strconv.Itoa(port+1)), nil
 }
 
+// Close gracefully shuts down the host, including the DefraDB node, processing pipeline, health server, playground server, and pruner. It ensures all resources are cleaned up properly.
 func (h *Host) Close(ctx context.Context) error {
 	h.webhookCleanupFunction()
 	h.processingCancel() // Stop the block processing goroutine (now includes block monitoring)
@@ -624,19 +637,19 @@ func (h *Host) Close(ctx context.Context) error {
 	return nil
 }
 
-// GetMetricsHandler returns an HTTP handler for the metrics endpoint
+// GetMetricsHandler returns an HTTP handler for the metrics endpoint.
 func (h *Host) GetMetricsHandler() http.Handler {
 	if h.metrics == nil {
 		// Return a handler that returns empty metrics if not initialized
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			w.Write([]byte(`{"error": "metrics not initialized"}`))
+			_, _ = w.Write([]byte(`{"error": "metrics not initialized"}`))
 		})
 	}
 	return h.metrics
 }
 
-// waitForDefraDB waits for a DefraDB instance to be ready by using app-sdk's QuerySingle
+// waitForDefraDB waits for a DefraDB instance to be ready by using app-sdk's QuerySingle.
 func waitForDefraDB(ctx context.Context, defraNode *node.Node) error {
 	fmt.Println("Waiting for defra...")
 	maxAttempts := 30
@@ -645,7 +658,7 @@ func waitForDefraDB(ctx context.Context, defraNode *node.Node) error {
 	query := `{ ` + constants.CollectionBlock + ` { __typename } }`
 
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		_, err := defra.QuerySingle[map[string]interface{}](ctx, defraNode, query)
+		_, err := defra.QuerySingle[map[string]any](ctx, defraNode, query)
 		if err == nil {
 			fmt.Println("Defra is responsive!")
 			return nil
@@ -657,7 +670,7 @@ func waitForDefraDB(ctx context.Context, defraNode *node.Node) error {
 		}
 	}
 
-	return fmt.Errorf("DefraDB failed to become ready after %d retry attempts", maxAttempts)
+	return fmt.Errorf("after %d retry attempts: %w", maxAttempts, ErrDefraDBNotReady)
 }
 
 func (h *Host) handleIncomingEvents(ctx context.Context, channel <-chan shinzohub.ShinzoEvent) {
@@ -692,7 +705,7 @@ func (h *Host) handleIncomingEvents(ctx context.Context, channel <-chan shinzohu
 
 				// 2. Ensure WASM files are written to disk (decodes base64 and writes to lens registry)
 				if len(registeredEvent.View.Data.Transform.Lenses) > 0 {
-					if err := registeredEvent.View.PostWasmToFile(ctx, h.LensRegistryPath); err != nil {
+					if err := registeredEvent.View.PostWasmToFile(h.LensRegistryPath); err != nil {
 						logger.Sugar.Errorf("❌ Failed to write WASM files for view %s: %v", registeredEvent.View.Name, err)
 						continue
 					}
@@ -717,9 +730,9 @@ func (h *Host) handleIncomingEvents(ctx context.Context, channel <-chan shinzohu
 					hostEvent.Owner, hostEvent.DID, hostEvent.ConnectionString)
 
 				if h.NetworkHandler != nil && hostEvent.ConnectionString != "" {
-					resolved := resolveBootstrapPeers(context.Background(),
+					resolved := resolveBootstrapPeers(ctx,
 						[]string{hostEvent.ConnectionString},
-						5*time.Second,
+						peerResolutionTimeoutSecs*time.Second,
 					)
 					for _, addr := range resolved {
 						if err := h.NetworkHandler.AddPeer(addr); err != nil {
@@ -736,9 +749,9 @@ func (h *Host) handleIncomingEvents(ctx context.Context, channel <-chan shinzohu
 					indexerEvent.SourceChainID, indexerEvent.ConnectionString)
 
 				if h.NetworkHandler != nil && indexerEvent.ConnectionString != "" {
-					resolved := resolveBootstrapPeers(context.Background(),
+					resolved := resolveBootstrapPeers(ctx,
 						[]string{indexerEvent.ConnectionString},
-						5*time.Second,
+						peerResolutionTimeoutSecs*time.Second,
 					)
 					for _, addr := range resolved {
 						if err := h.NetworkHandler.AddPeer(addr); err != nil {
@@ -759,10 +772,11 @@ func (h *Host) handleIncomingEvents(ctx context.Context, channel <-chan shinzohu
 // monitorHighestBlockNumber has been removed - block monitoring is now handled
 // by the event-driven processAllViews goroutine for better efficiency
 
+// StartHostingWithTestConfig starts the host with a test configuration, including a temporary DefraDB store path and dynamic health server port. This is used for testing to avoid conflicts with existing instances and to ensure isolation.
 func StartHostingWithTestConfig(t *testing.T) (*Host, error) {
 	testConfig := DefaultConfig
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	testConfig.DefraDB.Url = "127.0.0.1:0"
+	testConfig.DefraDB.URL = "127.0.0.1:0"
 
 	// Set start height to 0 for tests to process all documents
 	testConfig.Shinzo.StartHeight = 0
@@ -776,22 +790,22 @@ func StartHostingWithTestConfig(t *testing.T) (*Host, error) {
 	// Override health server with dynamic port for tests
 	if host.healthServer != nil {
 		// Stop the configured health server
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), healthServerShutdownTimeoutSecs*time.Second)
 		defer cancel()
-		host.healthServer.Stop(ctx)
+		_ = host.healthServer.Stop(ctx)
 
 		// Find an available port
-		listener, err := net.Listen("tcp", ":0")
+		listener, err := net.Listen("tcp", ":0") //nolint:gosec
 		if err != nil {
 			return nil, fmt.Errorf("failed to find available port: %w", err)
 		}
 		port := listener.Addr().(*net.TCPAddr).Port
-		listener.Close()
+		_ = listener.Close()
 
 		// Create new health server with dynamic port
 		healthDefraURL := ""
-		if testConfig.DefraDB.Url != "" {
-			healthDefraURL = "http://" + testConfig.DefraDB.Url
+		if testConfig.DefraDB.URL != "" {
+			healthDefraURL = "http://" + testConfig.DefraDB.URL
 		}
 		host.healthServer = server.NewHealthServer(port, host, healthDefraURL, host.metrics)
 
@@ -808,15 +822,16 @@ func StartHostingWithTestConfig(t *testing.T) (*Host, error) {
 	return host, nil
 }
 
+// isPlaygroundEnabled checks the environment variable to determine if the GraphQL Playground should be enabled. This allows for dynamic control over the playground feature without changing code, which is useful for testing and different deployment environments.
 func isPlaygroundEnabled() bool {
 	return playgroundEnabled
 }
 
-// applySchema applies the GraphQL schema to DefraDB node
+// applySchema applies the GraphQL schema to DefraDB node.
 func applySchema(ctx context.Context, defraNode *node.Node) error {
 	fmt.Println("Applying schema...")
 
-	_, err := defraNode.DB.AddSchema(ctx, schema.GetSchemaForBuild())
+	_, err := defraNode.DB.AddSchema(ctx, localschema.GetSchemaForBuild())
 	if err != nil && strings.Contains(err.Error(), "collection already exists") {
 		fmt.Println("Schema already exists, trying to add new types individually...")
 		// Try adding Config__LastProcessedPage separately in case it's new
@@ -830,15 +845,15 @@ func applySchema(ctx context.Context, defraNode *node.Node) error {
 	return err
 }
 
-// RegisterViewWithManager registers a view and manages its lifecycle
+// RegisterViewWithManager registers a view and manages its lifecycle.
 func (h *Host) RegisterViewWithManager(ctx context.Context, v view.View) error {
 	if h.viewManager == nil {
-		return fmt.Errorf("ViewManager not initialized")
+		return ErrViewManagerNil
 	}
 	return h.viewManager.RegisterView(ctx, &v)
 }
 
-// GetActiveViewNames returns names of all active views
+// GetActiveViewNames returns names of all active views.
 func (h *Host) GetActiveViewNames() []string {
 	if h.viewManager == nil {
 		return []string{}
@@ -848,10 +863,10 @@ func (h *Host) GetActiveViewNames() []string {
 
 // execCommand is the function used to create exec.Cmd instances.
 // Overridden in tests to avoid actually opening browsers.
-var execCommand = exec.Command
+var execCommand = exec.Command //nolint:gochecknoglobals
 
 // openBrowser opens the specified URL in the default browser
-// Works on macOS, Linux, and Windows
+// Works on macOS, Linux, and Windows.
 func openBrowser(url string) error {
 	var cmd *exec.Cmd
 	switch runtime.GOOS {
@@ -862,7 +877,7 @@ func openBrowser(url string) error {
 	case "linux":
 		cmd = execCommand("xdg-open", url)
 	default:
-		return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
+		return fmt.Errorf("platform %s: %w", runtime.GOOS, ErrUnsupportedPlatform)
 	}
 	return cmd.Start()
 }

--- a/pkg/host/host.go
+++ b/pkg/host/host.go
@@ -145,7 +145,7 @@ func StartHostingWithEventSubscription(cfg *config.Config) (*Host, error) { //no
 
 	defraNode, networkHandler, err := defra.StartDefraInstance(
 		cfg.ToAppConfig(),
-		defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()),
+		defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchema()),
 		nil,
 		replicationFilter,
 		constants.AllCollections...,
@@ -831,7 +831,7 @@ func isPlaygroundEnabled() bool {
 func applySchema(ctx context.Context, defraNode *node.Node) error {
 	fmt.Println("Applying schema...")
 
-	_, err := defraNode.DB.AddSchema(ctx, localschema.GetSchemaForBuild())
+	_, err := defraNode.DB.AddSchema(ctx, localschema.GetSchema())
 	if err != nil && strings.Contains(err.Error(), "collection already exists") {
 		fmt.Println("Schema already exists, trying to add new types individually...")
 		// Try adding Config__LastProcessedPage separately in case it's new

--- a/pkg/host/host_test.go
+++ b/pkg/host/host_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/shinzonetwork/shinzo-host-client/config"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/defradb"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
-	"github.com/shinzonetwork/shinzo-host-client/config"
 	localschema "github.com/shinzonetwork/shinzo-host-client/pkg/schema"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/server"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/shinzohub"

--- a/pkg/host/host_test.go
+++ b/pkg/host/host_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/shinzonetwork/shinzo-app-sdk/pkg/defra"
 	"github.com/shinzonetwork/shinzo-app-sdk/pkg/logger"
 	"github.com/shinzonetwork/shinzo-host-client/config"
+	localschema "github.com/shinzonetwork/shinzo-host-client/pkg/schema"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/server"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/shinzohub"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/view"
-	localschema "github.com/shinzonetwork/shinzo-host-client/pkg/schema"
 	indexerschema "github.com/shinzonetwork/shinzo-indexer-client/pkg/schema"
 	"github.com/shinzonetwork/viewbundle-go"
 	"github.com/stretchr/testify/require"
@@ -135,7 +135,7 @@ func TestIncrementPort(t *testing.T) {
 
 func TestDefaultConfig(t *testing.T) {
 	require.NotNil(t, DefaultConfig)
-	require.Equal(t, "localhost:9181", DefaultConfig.DefraDB.Url)
+	require.Equal(t, "localhost:9181", DefaultConfig.DefraDB.URL)
 	require.True(t, DefaultConfig.DefraDB.P2P.Enabled)
 	require.Equal(t, 1, DefaultConfig.Shinzo.MinimumAttestations)
 	require.True(t, DefaultConfig.Logger.Development)
@@ -147,7 +147,7 @@ func TestHost_IsHealthy(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	host := &Host{
 		DefraNode:          defraNode,
@@ -171,7 +171,7 @@ func TestHost_IsHealthy_NoPipeline(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	host := &Host{
 		DefraNode:          defraNode,
@@ -225,9 +225,9 @@ func TestHost_GetActiveViewNames(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
-	vm := view.NewViewManager(defraNode, t.TempDir())
+	vm := view.NewManager(defraNode, t.TempDir())
 
 	host := &Host{
 		DefraNode:   defraNode,
@@ -269,7 +269,7 @@ func TestHost_Close(t *testing.T) {
 		processingCancel: func() {
 			cancelCalled = true
 		},
-		viewManager: view.NewViewManager(defraNode, t.TempDir()),
+		viewManager: view.NewManager(defraNode, t.TempDir()),
 	}
 
 	err = host.Close(ctx)
@@ -294,11 +294,11 @@ func TestHost_WithRealDefraDB(t *testing.T) {
 	// Create a real DefraDB instance with the indexer schema
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(indexerschema.GetSchema()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	cfg := &config.Config{
 		DefraDB: config.DefraDBConfig{
-			Url: "localhost:9181",
+			URL: "localhost:9181",
 			Store: config.DefraDBStoreConfig{
 				Path: t.TempDir(),
 			},
@@ -308,7 +308,7 @@ func TestHost_WithRealDefraDB(t *testing.T) {
 		},
 	}
 
-	vm := view.NewViewManager(defraNode, cfg.HostConfig.LensRegistryPath)
+	vm := view.NewManager(defraNode, cfg.HostConfig.LensRegistryPath)
 
 	host := &Host{
 		DefraNode:              defraNode,
@@ -335,10 +335,10 @@ func TestHost_ViewManagerIntegration(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	registryPath := t.TempDir()
-	vm := view.NewViewManager(defraNode, registryPath)
+	vm := view.NewManager(defraNode, registryPath)
 
 	host := &Host{
 		DefraNode:        defraNode,
@@ -519,8 +519,9 @@ func TestHost_Close_WithPlaygroundServer(t *testing.T) {
 
 	// Create a playground server that's not actually listening
 	playgroundServer := &http.Server{
-		Addr:    ":0",
-		Handler: http.NewServeMux(),
+		Addr:              ":0",
+		Handler:           http.NewServeMux(),
+		ReadHeaderTimeout: defaultTimeout,
 	}
 
 	host := &Host{
@@ -570,10 +571,10 @@ func TestHost_ProcessViewRegistrationEvent_MissingQuery(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	host := &Host{
-		viewManager: view.NewViewManager(defraNode, t.TempDir()),
+		viewManager: view.NewManager(defraNode, t.TempDir()),
 	}
 
 	// No query set (nil)
@@ -591,10 +592,10 @@ func TestHost_ProcessViewRegistrationEvent_MissingSDL(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	host := &Host{
-		viewManager: view.NewViewManager(defraNode, t.TempDir()),
+		viewManager: view.NewManager(defraNode, t.TempDir()),
 	}
 
 	query := "SELECT * FROM something"
@@ -617,10 +618,10 @@ func TestHost_ProcessViewRegistrationEvent_EmptyQuery(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	host := &Host{
-		viewManager: view.NewViewManager(defraNode, t.TempDir()),
+		viewManager: view.NewManager(defraNode, t.TempDir()),
 	}
 
 	emptyStr := ""
@@ -643,10 +644,10 @@ func TestHost_ProcessViewRegistrationEvent_EmptySDL(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	host := &Host{
-		viewManager: view.NewViewManager(defraNode, t.TempDir()),
+		viewManager: view.NewManager(defraNode, t.TempDir()),
 	}
 
 	query := "SELECT * FROM something"
@@ -696,7 +697,7 @@ func TestIsPlaygroundEnabled(t *testing.T) {
 
 func TestOpenBrowser_DoesNotPanic(t *testing.T) {
 	original := execCommand
-	execCommand = func(name string, arg ...string) *exec.Cmd {
+	execCommand = func(_ string, _ ...string) *exec.Cmd {
 		return exec.Command("echo", "mock-browser")
 	}
 	defer func() { execCommand = original }()
@@ -802,11 +803,11 @@ func TestHandleIncomingEvents_ViewRegisteredEvent_NilViewManager(t *testing.T) {
 		close(done)
 	}()
 
-	query := "SELECT * FROM blocks"
+	query := testQueryBlocks
 	sdl := "type Block { hash: String }"
 	ch <- &shinzohub.ViewRegisteredEvent{
 		ViewAddress: "0xkey1",
-		Creator: "creator1",
+		Creator:     "creator1",
 		View: view.View{
 			Name: "TestView",
 			Data: viewbundle.View{
@@ -844,7 +845,7 @@ func TestHandleIncomingEvents_ViewRegisteredEvent_MissingQuery(t *testing.T) {
 	// View with nil Query
 	ch <- &shinzohub.ViewRegisteredEvent{
 		ViewAddress: "0xkey1",
-		Creator: "creator1",
+		Creator:     "creator1",
 		View: view.View{
 			Name: "TestView",
 		},
@@ -878,7 +879,7 @@ func TestHandleIncomingEvents_ViewRegisteredEvent_EmptyQuery(t *testing.T) {
 	emptyQuery := ""
 	ch <- &shinzohub.ViewRegisteredEvent{
 		ViewAddress: "0xkey1",
-		Creator: "creator1",
+		Creator:     "creator1",
 		View: view.View{
 			Name: "TestView",
 			Data: viewbundle.View{
@@ -912,10 +913,10 @@ func TestHandleIncomingEvents_ViewRegisteredEvent_MissingSDL(t *testing.T) {
 		close(done)
 	}()
 
-	query := "SELECT * FROM blocks"
+	query := testQueryBlocks
 	ch <- &shinzohub.ViewRegisteredEvent{
 		ViewAddress: "0xkey1",
-		Creator: "creator1",
+		Creator:     "creator1",
 		View: view.View{
 			Name: "TestView",
 			Data: viewbundle.View{
@@ -949,11 +950,11 @@ func TestHandleIncomingEvents_ViewRegisteredEvent_EmptySDL(t *testing.T) {
 		close(done)
 	}()
 
-	query := "SELECT * FROM blocks"
+	query := testQueryBlocks
 	emptySDL := ""
 	ch <- &shinzohub.ViewRegisteredEvent{
 		ViewAddress: "0xkey1",
-		Creator: "creator1",
+		Creator:     "creator1",
 		View: view.View{
 			Name: "TestView",
 			Data: viewbundle.View{
@@ -1016,7 +1017,7 @@ func TestHost_GetPeerInfo_WithDefraDB(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	nh := &defra.NetworkHandler{}
 	h := &Host{
@@ -1039,10 +1040,10 @@ func TestHost_ProcessViewRegistrationEvent_WithLenses(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	registryPath := t.TempDir()
-	vm := view.NewViewManager(defraNode, registryPath)
+	vm := view.NewManager(defraNode, registryPath)
 
 	h := &Host{
 		DefraNode:        defraNode,
@@ -1051,11 +1052,11 @@ func TestHost_ProcessViewRegistrationEvent_WithLenses(t *testing.T) {
 		metrics:          server.NewHostMetrics(),
 	}
 
-	query := "SELECT * FROM test"
-	sdl := "type TestView { field: String }"
+	query := testQueryTest
+	sdl := testViewSDL
 	event := shinzohub.ViewRegisteredEvent{
 		ViewAddress: "0xkey1",
-		Creator: "creator1",
+		Creator:     "creator1",
 		View: view.View{
 			Name: "TestViewLens",
 			Data: viewbundle.View{
@@ -1081,10 +1082,10 @@ func TestHost_ProcessViewRegistrationEvent_WithViewManager(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	registryPath := t.TempDir()
-	vm := view.NewViewManager(defraNode, registryPath)
+	vm := view.NewManager(defraNode, registryPath)
 
 	h := &Host{
 		DefraNode:        defraNode,
@@ -1093,11 +1094,11 @@ func TestHost_ProcessViewRegistrationEvent_WithViewManager(t *testing.T) {
 		metrics:          server.NewHostMetrics(),
 	}
 
-	query := "SELECT * FROM test"
-	sdl := "type TestView { field: String }"
+	query := testQueryTest
+	sdl := testViewSDL
 	event := shinzohub.ViewRegisteredEvent{
 		ViewAddress: "0xkey1",
-		Creator: "creator1",
+		Creator:     "creator1",
 		View: view.View{
 			Name: "TestView",
 			Data: viewbundle.View{
@@ -1121,16 +1122,16 @@ func TestHost_RegisterViewWithManager_WithViewManager(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
-	vm := view.NewViewManager(defraNode, t.TempDir())
+	vm := view.NewManager(defraNode, t.TempDir())
 	h := &Host{
 		DefraNode:   defraNode,
 		viewManager: vm,
 	}
 
-	query := "SELECT * FROM test"
-	sdl := "type TestView { field: String }"
+	query := testQueryTest
+	sdl := testViewSDL
 	v := view.View{
 		Name: "TestView",
 		Data: viewbundle.View{
@@ -1153,14 +1154,15 @@ func TestHost_Close_WithViewManager(t *testing.T) {
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
 
-	vm := view.NewViewManager(defraNode, t.TempDir())
+	vm := view.NewManager(defraNode, t.TempDir())
 
 	pp := NewProcessingPipeline(context.Background(), &Host{}, 10, 1, 10, 50, false)
 	pp.Start()
 
 	playgroundServer := &http.Server{
-		Addr:    ":0",
-		Handler: http.NewServeMux(),
+		Addr:              ":0",
+		Handler:           http.NewServeMux(),
+		ReadHeaderTimeout: defaultTimeout,
 	}
 
 	h := &Host{
@@ -1182,7 +1184,7 @@ func TestHost_Close_WithViewManager(t *testing.T) {
 
 func TestOpenBrowser_ReturnsNoError(t *testing.T) {
 	original := execCommand
-	execCommand = func(name string, arg ...string) *exec.Cmd {
+	execCommand = func(_ string, _ ...string) *exec.Cmd {
 		return exec.Command("echo", "mock-browser")
 	}
 	defer func() { execCommand = original }()
@@ -1197,7 +1199,7 @@ func TestOpenBrowser_ReturnsNoError(t *testing.T) {
 
 func TestStartHosting_NilConfig_UsesDefault(t *testing.T) {
 	require.NotNil(t, DefaultConfig)
-	require.Equal(t, "localhost:9181", DefaultConfig.DefraDB.Url)
+	require.Equal(t, "localhost:9181", DefaultConfig.DefraDB.URL)
 }
 
 // ---------------------------------------------------------------------------
@@ -1210,7 +1212,7 @@ func TestHost_GetPeerInfo_WithP2PEnabled(t *testing.T) {
 	// Start a DefraDB instance that includes P2P
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(indexerschema.GetSchema()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	nh := &defra.NetworkHandler{}
 	h := &Host{
@@ -1236,7 +1238,7 @@ func TestHost_SignMessages_WithRealDefraDB(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(indexerschema.GetSchema()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	h := &Host{
 		DefraNode: defraNode,
@@ -1264,7 +1266,7 @@ func TestHost_GetNodePublicKey_WithRealDefraDB(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(indexerschema.GetSchema()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	h := &Host{
 		DefraNode: defraNode,
@@ -1285,7 +1287,7 @@ func TestHost_GetPeerPublicKey_WithRealDefraDB(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(indexerschema.GetSchema()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	h := &Host{
 		DefraNode: defraNode,
@@ -1379,10 +1381,10 @@ func TestHandleIncomingEvents_ViewRegisteredEvent_WithLenses(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	registryPath := t.TempDir()
-	vm := view.NewViewManager(defraNode, registryPath)
+	vm := view.NewManager(defraNode, registryPath)
 
 	h := &Host{
 		viewManager:      vm,
@@ -1399,12 +1401,12 @@ func TestHandleIncomingEvents_ViewRegisteredEvent_WithLenses(t *testing.T) {
 		close(done)
 	}()
 
-	query := "SELECT * FROM blocks"
+	query := testQueryBlocks
 	sdl := "type TestView { hash: String }"
 	// View with lenses that have invalid WASM (will fail PostWasmToFile but exercises the path)
 	ch <- &shinzohub.ViewRegisteredEvent{
 		ViewAddress: "0xkey1",
-		Creator: "creator1",
+		Creator:     "creator1",
 		View: view.View{
 			Name: "TestViewWithLenses",
 			Data: viewbundle.View{
@@ -1436,10 +1438,10 @@ func TestHandleIncomingEvents_ViewRegisteredEvent_WithViewManager(t *testing.T) 
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	registryPath := t.TempDir()
-	vm := view.NewViewManager(defraNode, registryPath)
+	vm := view.NewManager(defraNode, registryPath)
 
 	h := &Host{
 		viewManager:      vm,
@@ -1456,11 +1458,11 @@ func TestHandleIncomingEvents_ViewRegisteredEvent_WithViewManager(t *testing.T) 
 		close(done)
 	}()
 
-	query := "SELECT * FROM blocks"
+	query := testQueryBlocks
 	sdl := "type TestView { hash: String }"
 	ch <- &shinzohub.ViewRegisteredEvent{
 		ViewAddress: "0xkey1",
-		Creator: "creator1",
+		Creator:     "creator1",
 		View: view.View{
 			Name: "TestView",
 			Data: viewbundle.View{
@@ -1490,7 +1492,7 @@ func TestApplySchema_WithRealDefraDB(t *testing.T) {
 	// Start with mock schema applier (no schema applied yet)
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	// First call should succeed (adding schema)
 	err = applySchema(ctx, defraNode)
@@ -1510,7 +1512,7 @@ func TestWaitForDefraDB_WithRealDefraDB(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	// Should succeed quickly since DefraDB is already ready
 	err = waitForDefraDB(ctx, defraNode)
@@ -1597,10 +1599,10 @@ func TestHandleIncomingEvents_ViewRegisteredEvent_WithBase64Lens(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	registryPath := t.TempDir()
-	vm := view.NewViewManager(defraNode, registryPath)
+	vm := view.NewManager(defraNode, registryPath)
 
 	h := &Host{
 		viewManager:      vm,
@@ -1622,7 +1624,7 @@ func TestHandleIncomingEvents_ViewRegisteredEvent_WithBase64Lens(t *testing.T) {
 	// Use valid base64 (tiny fake WASM) so PostWasmToFile succeeds
 	ch <- &shinzohub.ViewRegisteredEvent{
 		ViewAddress: "0xkey1",
-		Creator: "creator1",
+		Creator:     "creator1",
 		View: view.View{
 			Name: "TestLensView",
 			Data: viewbundle.View{
@@ -1658,10 +1660,10 @@ func TestHandleIncomingEvents_ViewRegisteredEvent_NoLenses_WithViewManager(t *te
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	registryPath := t.TempDir()
-	vm := view.NewViewManager(defraNode, registryPath)
+	vm := view.NewManager(defraNode, registryPath)
 
 	h := &Host{
 		viewManager:      vm,
@@ -1682,7 +1684,7 @@ func TestHandleIncomingEvents_ViewRegisteredEvent_NoLenses_WithViewManager(t *te
 	sdl := "type NoLensView { address: String }"
 	ch <- &shinzohub.ViewRegisteredEvent{
 		ViewAddress: "0xkey2",
-		Creator: "creator2",
+		Creator:     "creator2",
 		View: view.View{
 			Name: "NoLensView",
 			Data: viewbundle.View{
@@ -1720,7 +1722,7 @@ func TestHost_Close_Full(t *testing.T) {
 	}
 
 	h.processingPipeline.Start()
-	go h.healthServer.Start()
+	go func() { _ = h.healthServer.Start() }()
 	time.Sleep(50 * time.Millisecond)
 
 	err = h.Close(ctx)

--- a/pkg/host/host_test.go
+++ b/pkg/host/host_test.go
@@ -1510,7 +1510,7 @@ func TestApplySchema_WithRealDefraDB(t *testing.T) {
 func TestWaitForDefraDB_WithRealDefraDB(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchema()))
 	require.NoError(t, err)
 	defer func() { _ = defraNode.Close(ctx) }()
 
@@ -1708,7 +1708,7 @@ func TestHandleIncomingEvents_ViewRegisteredEvent_NoLenses_WithViewManager(t *te
 func TestHost_Close_Full(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchema()))
 	require.NoError(t, err)
 
 	metrics := server.NewHostMetrics()

--- a/pkg/host/peer_discovery.go
+++ b/pkg/host/peer_discovery.go
@@ -22,6 +22,11 @@ const DefaultPeerDiscoveryTimeout = 10 * time.Second
 // DefaultP2PPort is the default libp2p port used when only an IP is provided.
 const DefaultP2PPort = "9171"
 
+type result struct {
+	index int
+	addr  string
+}
+
 // resolveBootstrapPeers takes a list of peer addresses (which may or may not include
 // a /p2p/<peerID> component) and returns fully-qualified multiaddrs with peer IDs.
 // Discovery requests are run in parallel to avoid sequential timeout delays.
@@ -37,11 +42,6 @@ const DefaultP2PPort = "9171"
 func resolveBootstrapPeers(ctx context.Context, peers []string, timeout time.Duration) []string {
 	if timeout <= 0 {
 		timeout = DefaultPeerDiscoveryTimeout
-	}
-
-	type result struct {
-		index int
-		addr  string
 	}
 
 	results := make([]result, 0, len(peers))
@@ -96,17 +96,23 @@ func resolveBootstrapPeers(ctx context.Context, peers []string, timeout time.Dur
 	wg.Wait()
 
 	// Sort by original index to maintain config ordering
+	sorted := makeSortedArray(results, peers)
+
+	return sorted
+}
+
+func makeSortedArray(results []result, peers []string) []string {
+	// Sort by original index to maintain config ordering
 	sorted := make([]string, 0, len(results))
 	indexMap := make(map[int]string, len(results))
 	for _, r := range results {
 		indexMap[r.index] = r.addr
 	}
-	for i := 0; i < len(peers); i++ {
+	for i := range peers {
 		if addr, ok := indexMap[i]; ok {
 			sorted = append(sorted, addr)
 		}
 	}
-
 	return sorted
 }
 
@@ -137,7 +143,7 @@ func normalizeToMultiaddr(addr string) (ma.Multiaddr, error) {
 func buildMultiaddr(host, port string) (ma.Multiaddr, error) {
 	ip := net.ParseIP(host)
 	if ip == nil {
-		return nil, fmt.Errorf("invalid IP address: %s", host)
+		return nil, fmt.Errorf("IP address %s: %w", host, ErrInvalidIPAddress)
 	}
 
 	proto := "ip4"
@@ -171,7 +177,7 @@ func discoverPeerID(ctx context.Context, targetAddr ma.Multiaddr, timeout time.D
 	if err != nil {
 		return "", fmt.Errorf("failed to create discovery host: %w", err)
 	}
-	defer tmpHost.Close()
+	defer func() { _ = tmpHost.Close() }()
 
 	// Use a well-known bogus peer ID; the security handshake will reject it
 	// and return ErrPeerIDMismatch containing the actual peer ID.
@@ -194,7 +200,7 @@ func discoverPeerID(ctx context.Context, targetAddr ma.Multiaddr, timeout time.D
 	// Extract the actual peer ID from the typed error
 	actualPeerID, extractErr := extractPeerIDFromError(err)
 	if extractErr != nil {
-		return "", fmt.Errorf("connection failed and could not extract peer ID: %w (original error: %v)", extractErr, err)
+		return "", fmt.Errorf("connection failed and could not extract peer ID: %w (original error: %w)", extractErr, err)
 	}
 
 	return fmt.Sprintf("%s/p2p/%s", targetAddr.String(), actualPeerID.String()), nil
@@ -216,15 +222,15 @@ func extractPeerIDFromError(err error) (peer.ID, error) {
 
 // extractPeerIDFromMismatchString is a fallback that parses the peer ID from
 // the error string when errors.As cannot unwrap the typed error.
-// Expected format: "...but remote key matches 12D3KooW..."
+// Expected format: "...but remote key matches 12D3KooW...".
 func extractPeerIDFromMismatchString(errMsg string) (peer.ID, error) {
 	const marker = "but remote key matches "
-	idx := strings.Index(errMsg, marker)
-	if idx == -1 {
-		return "", fmt.Errorf("error does not contain peer ID mismatch info")
+	_, after, ok := strings.Cut(errMsg, marker)
+	if !ok {
+		return "", ErrNoPeerIDMismatchInfo
 	}
 
-	remainder := errMsg[idx+len(marker):]
+	remainder := after
 
 	// The peer ID ends at the next delimiter or end of string
 	peerIDStr := remainder

--- a/pkg/host/peer_discovery_test.go
+++ b/pkg/host/peer_discovery_test.go
@@ -122,11 +122,7 @@ func TestExtractPeerIDFromError_WrappedTypedError(t *testing.T) {
 func TestExtractPeerIDFromError_StringFallback(t *testing.T) {
 	// Simulate an error that doesn't unwrap to ErrPeerIDMismatch
 	// but contains the expected string format
-	errMsg := fmt.Errorf(
-		"all dials failed\n  * [/ip4/34.9.109.135/tcp/9171] failed to negotiate security protocol: "+
-			"peer id mismatch: expected 12D3KooWCS9HHoiqfu1YRBiLM5spAbDGiHb2NtXEGUoHYTcCtEfy, "+
-			"but remote key matches 12D3KooWPBbKmsSsFiTW2X4sY4uuCUEazSFZkAdY8Egm4mQsiSEF.",
-	)
+	errMsg := errPeerIDMismatchDial
 
 	actualID, err := extractPeerIDFromError(errMsg)
 	require.NoError(t, err)
@@ -136,7 +132,7 @@ func TestExtractPeerIDFromError_StringFallback(t *testing.T) {
 }
 
 func TestExtractPeerIDFromError_NoMismatchInfo(t *testing.T) {
-	_, err := extractPeerIDFromError(fmt.Errorf("connection refused"))
+	_, err := extractPeerIDFromError(errConnectionRefused)
 	require.Error(t, err)
 }
 

--- a/pkg/host/playground_disabled.go
+++ b/pkg/host/playground_disabled.go
@@ -2,6 +2,5 @@
 
 package host
 
-// playgroundEnabled is set to false when not built with the hostplayground tag
-var playgroundEnabled = false
-
+// playgroundEnabled is set to false when not built with the hostplayground tag.
+const playgroundEnabled = false

--- a/pkg/host/playground_enabled.go
+++ b/pkg/host/playground_enabled.go
@@ -4,4 +4,3 @@ package host
 
 // playgroundEnabled is set to true when built with the hostplayground tag
 var playgroundEnabled = true
-

--- a/pkg/host/processingPipeline.go
+++ b/pkg/host/processingPipeline.go
@@ -32,7 +32,7 @@ type DocumentJob struct {
 // ProcessingPipeline coordinates document processing with bounded workers and queue.
 type ProcessingPipeline struct {
 	host   *Host
-	ctx    context.Context
+	ctx    context.Context // nolint:containedctx
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
 
@@ -50,7 +50,7 @@ type ProcessingPipeline struct {
 	useBlockSignatures bool
 
 	// Metrics for monitoring
-	queuedCount              int64
+	// queuedCount              int64
 	processedCount           int64
 	droppedCount             int64
 	pendingAttestationsCount int64
@@ -138,7 +138,7 @@ func (pp *ProcessingPipeline) batchWriter(writerID int) {
 		processingTime := time.Since(startTime)
 
 		if pp.host.metrics != nil {
-			avgProcessingTimeMs := float64(processingTime.Nanoseconds()) / float64(len(batch)) / 1000000.0
+			avgProcessingTimeMs := float64(processingTime.Nanoseconds()) / float64(len(batch)) / nanosecondsPerMillisecond
 			pp.host.metrics.UpdateLastProcessingTime(avgProcessingTimeMs)
 		}
 
@@ -167,7 +167,7 @@ func (pp *ProcessingPipeline) batchWriter(writerID int) {
 
 		case <-pp.ctx.Done():
 			flushBatch()
-			logger.Sugar.Debugf("BatchWriter %d stopped (context cancelled)", writerID)
+			logger.Sugar.Debugf("BatchWriter %d stopped (context canceled)", writerID)
 			return
 		}
 	}
@@ -261,7 +261,7 @@ func (pp *ProcessingPipeline) processAttestationAsync(docs []Document) {
 		}
 
 		delay := min(baseDelay*time.Duration(1<<attempt), maxDelay)
-		jitter := time.Duration(float64(delay) * (0.5 + rand.Float64()))
+		jitter := time.Duration(float64(delay) * (0.5 + rand.Float64())) //nolint:gosec,mnd // weak random is acceptable for jitter calculation
 		if attempt < maxRetries-1 {
 			select {
 			case <-time.After(jitter):

--- a/pkg/host/processingPipeline_test.go
+++ b/pkg/host/processingPipeline_test.go
@@ -2,7 +2,6 @@ package host
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -94,22 +93,22 @@ func TestIsTransactionConflict(t *testing.T) {
 		},
 		{
 			name: "transaction conflict",
-			err:  errors.New("transaction conflict: cannot write"),
+			err:  errTransactionConflict,
 			want: true,
 		},
 		{
 			name: "please retry",
-			err:  errors.New("operation failed: Please retry"),
+			err:  errOperationFailedRetry,
 			want: true,
 		},
 		{
 			name: "unrelated error",
-			err:  errors.New("connection refused"),
+			err:  errConnectionRefused,
 			want: false,
 		},
 		{
 			name: "empty error message",
-			err:  errors.New(""),
+			err:  errEmptyMessage,
 			want: false,
 		},
 	}
@@ -126,7 +125,7 @@ func TestIsTransactionConflict(t *testing.T) {
 // Start / Stop lifecycle
 // ---------------------------------------------------------------------------
 
-func TestProcessingPipeline_StartStop(t *testing.T) {
+func TestProcessingPipeline_StartStop(_ *testing.T) {
 	pp := NewProcessingPipeline(context.Background(), &Host{}, 10, 2, 10, 50, false)
 
 	// Start should not panic
@@ -136,12 +135,12 @@ func TestProcessingPipeline_StartStop(t *testing.T) {
 	pp.Stop()
 }
 
-func TestProcessingPipeline_StopWithPendingJobs(t *testing.T) {
+func TestProcessingPipeline_StopWithPendingJobs(_ *testing.T) {
 	pp := NewProcessingPipeline(context.Background(), &Host{}, 100, 1, 10, 50, true)
 	pp.Start()
 
 	// Enqueue some jobs before stopping
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		pp.jobQueue <- DocumentJob{
 			docID:       "doc-" + string(rune('a'+i)),
 			docType:     "Block",
@@ -176,7 +175,7 @@ func TestDocumentJob_Fields(t *testing.T) {
 // processBatch
 // ---------------------------------------------------------------------------
 
-func TestProcessBatch_EmptyJobs(t *testing.T) {
+func TestProcessBatch_EmptyJobs(_ *testing.T) {
 	pp := NewProcessingPipeline(context.Background(), &Host{}, 10, 1, 10, 50, false)
 	defer pp.cancel()
 
@@ -184,7 +183,7 @@ func TestProcessBatch_EmptyJobs(t *testing.T) {
 	pp.processBatch(0, []DocumentJob{})
 }
 
-func TestProcessBatch_NilJobs(t *testing.T) {
+func TestProcessBatch_NilJobs(_ *testing.T) {
 	pp := NewProcessingPipeline(context.Background(), &Host{}, 10, 1, 10, 50, false)
 	defer pp.cancel()
 
@@ -400,7 +399,7 @@ func TestBatchWriter_QueueClosed(t *testing.T) {
 // Stop with pending attestations
 // ---------------------------------------------------------------------------
 
-func TestProcessingPipeline_StopWithPendingAttestations(t *testing.T) {
+func TestProcessingPipeline_StopWithPendingAttestations(_ *testing.T) {
 	host := &Host{
 		metrics: server.NewHostMetrics(),
 		config:  DefaultConfig,
@@ -795,7 +794,7 @@ func TestProcessBatch_WithBlockSignatures_MostRecentBlock(t *testing.T) {
 // Full end-to-end pipeline - context cancellation during processing
 // ---------------------------------------------------------------------------
 
-func TestProcessingPipeline_ContextCancellation(t *testing.T) {
+func TestProcessingPipeline_ContextCancellation(_ *testing.T) {
 	metrics := server.NewHostMetrics()
 	host := &Host{
 		metrics: metrics,

--- a/pkg/host/processingPipeline_test.go
+++ b/pkg/host/processingPipeline_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
 	attestationService "github.com/shinzonetwork/shinzo-host-client/pkg/attestation"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/server"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/host/queryService.go
+++ b/pkg/host/queryService.go
@@ -8,13 +8,13 @@ import (
 	"github.com/shinzonetwork/shinzo-host-client/pkg/constants"
 )
 
-// QueryService provides dynamic query building capabilities for different collection types
+// QueryService provides dynamic query building capabilities for different collection types.
 type QueryService struct {
 	// Cache of field mappings for each collection type
 	fieldCache map[string][]string
 }
 
-// NewQueryService creates a new instance of QueryService
+// NewQueryService creates a new instance of QueryService.
 func NewQueryService() *QueryService {
 	qs := &QueryService{
 		fieldCache: make(map[string][]string),
@@ -23,9 +23,10 @@ func NewQueryService() *QueryService {
 	return qs
 }
 
-// CollectionType represents the different attestation collection types
+// CollectionType represents the different attestation collection types.
 type CollectionType string
 
+// Collection type constants define the available collection types for querying.
 const (
 	CollectionBlock           CollectionType = "Block"
 	CollectionTransaction     CollectionType = "Transaction"
@@ -33,7 +34,7 @@ const (
 	CollectionAccessListEntry CollectionType = "AccessListEntry"
 )
 
-// initializeFieldMappings extracts field names from attestation types using reflection
+// initializeFieldMappings extracts field names from attestation types using reflection.
 func (qs *QueryService) initializeFieldMappings() {
 	// Block fields
 	blockFields := qs.extractFields(constants.Block{})
@@ -52,8 +53,8 @@ func (qs *QueryService) initializeFieldMappings() {
 	qs.fieldCache[string(CollectionAccessListEntry)] = accessListFields
 }
 
-// extractFields uses reflection to extract field names from a struct
-func (qs *QueryService) extractFields(model interface{}) []string {
+// extractFields uses reflection to extract field names from a struct.
+func (qs *QueryService) extractFields(model any) []string {
 	t := reflect.TypeOf(model)
 	if t.Kind() == reflect.Ptr {
 		t = t.Elem()
@@ -84,7 +85,7 @@ func (qs *QueryService) extractFields(model interface{}) []string {
 	return fields
 }
 
-// extractNestedFields extracts fields from nested struct types
+// extractNestedFields extracts fields from nested struct types.
 func (qs *QueryService) extractNestedFields(t reflect.Type) []string {
 	if t.Kind() == reflect.Ptr {
 		t = t.Elem()
@@ -102,7 +103,7 @@ func (qs *QueryService) extractNestedFields(t reflect.Type) []string {
 	return fields
 }
 
-// GetFieldsForCollection returns all available fields for a given collection type
+// GetFieldsForCollection returns all available fields for a given collection type.
 func (qs *QueryService) GetFieldsForCollection(collectionType CollectionType) []string {
 	fields, exists := qs.fieldCache[string(collectionType)]
 	if !exists {
@@ -113,8 +114,8 @@ func (qs *QueryService) GetFieldsForCollection(collectionType CollectionType) []
 	return append([]string{"_docID", "_version"}, fields...)
 }
 
-// BuildDynamicQuery creates a query for the specified collection type with optional filters
-func (qs *QueryService) BuildDynamicQuery(collectionType CollectionType, filters map[string]interface{}) string {
+// BuildDynamicQuery creates a query for the specified collection type with optional filters.
+func (qs *QueryService) BuildDynamicQuery(collectionType CollectionType, filters map[string]any) string {
 	fields := qs.GetFieldsForCollection(collectionType)
 	fieldsStr := strings.Join(fields, " ")
 
@@ -132,8 +133,8 @@ func (qs *QueryService) BuildDynamicQuery(collectionType CollectionType, filters
 	return fmt.Sprintf("%s(filter: %s) { %s }", collectionName, filterStr, fieldsStr)
 }
 
-// BuildNestedQuery creates a query that includes nested relationships
-func (qs *QueryService) BuildNestedQuery(primaryCollection CollectionType, nestedCollections []CollectionType, filters map[string]interface{}) string {
+// BuildNestedQuery creates a query that includes nested relationships.
+func (qs *QueryService) BuildNestedQuery(primaryCollection CollectionType, nestedCollections []CollectionType, filters map[string]any) string {
 	// Start with primary collection
 	query := qs.BuildDynamicQuery(primaryCollection, filters)
 
@@ -150,7 +151,7 @@ func (qs *QueryService) BuildNestedQuery(primaryCollection CollectionType, neste
 	return query
 }
 
-// getCollectionName maps collection types to their actual DefraDB collection names
+// getCollectionName maps collection types to their actual DefraDB collection names.
 func (qs *QueryService) getCollectionName(collectionType CollectionType) string {
 	switch collectionType {
 	case CollectionBlock:
@@ -166,8 +167,8 @@ func (qs *QueryService) getCollectionName(collectionType CollectionType) string 
 	}
 }
 
-// buildFilterString converts a filter map to GraphQL filter syntax
-func (qs *QueryService) buildFilterString(filters map[string]interface{}) string {
+// buildFilterString converts a filter map to GraphQL filter syntax.
+func (qs *QueryService) buildFilterString(filters map[string]any) string {
 	if len(filters) == 0 {
 		return ""
 	}
@@ -192,7 +193,7 @@ func (qs *QueryService) buildFilterString(filters map[string]interface{}) string
 	return fmt.Sprintf("{ %s }", strings.Join(filterPairs, " "))
 }
 
-// GetCollectionHierarchy returns the natural nesting relationships between collections
+// GetCollectionHierarchy returns the natural nesting relationships between collections.
 func (qs *QueryService) GetCollectionHierarchy() map[CollectionType][]CollectionType {
 	return map[CollectionType][]CollectionType{
 		CollectionBlock:           {CollectionTransaction},
@@ -202,8 +203,8 @@ func (qs *QueryService) GetCollectionHierarchy() map[CollectionType][]Collection
 	}
 }
 
-// BuildHierarchicalQuery creates a query that respects the natural hierarchy of collections
-func (qs *QueryService) BuildHierarchicalQuery(rootCollection CollectionType, filters map[string]interface{}) string {
+// BuildHierarchicalQuery creates a query that respects the natural hierarchy of collections.
+func (qs *QueryService) BuildHierarchicalQuery(rootCollection CollectionType, filters map[string]any) string {
 	hierarchy := qs.GetCollectionHierarchy()
 
 	// Start with root collection (without nested collections first)

--- a/pkg/host/queryService.go
+++ b/pkg/host/queryService.go
@@ -61,8 +61,7 @@ func (qs *QueryService) extractFields(model any) []string {
 	}
 
 	var fields []string
-	for i := 0; i < t.NumField(); i++ {
-		field := t.Field(i)
+	for field := range t.Fields() {
 		jsonTag := field.Tag.Get("json")
 		if jsonTag != "" && jsonTag != "-" {
 			// Handle nested structs by including their fields too
@@ -92,8 +91,7 @@ func (qs *QueryService) extractNestedFields(t reflect.Type) []string {
 	}
 
 	var fields []string
-	for i := 0; i < t.NumField(); i++ {
-		field := t.Field(i)
+	for field := range t.Fields() {
 		jsonTag := field.Tag.Get("json")
 		if jsonTag != "" && jsonTag != "-" {
 			fields = append(fields, jsonTag)

--- a/pkg/host/queryService_test.go
+++ b/pkg/host/queryService_test.go
@@ -124,7 +124,7 @@ func TestBuildDynamicQuery(t *testing.T) {
 	tests := []struct {
 		name           string
 		collectionType CollectionType
-		filters        map[string]interface{}
+		filters        map[string]any
 		mustContain    []string
 		mustNotContain []string
 	}{
@@ -138,20 +138,20 @@ func TestBuildDynamicQuery(t *testing.T) {
 		{
 			name:           "empty filter map produces simple query",
 			collectionType: CollectionTransaction,
-			filters:        map[string]interface{}{},
+			filters:        map[string]any{},
 			mustContain:    []string{"Ethereum__Mainnet__Transaction {", "_docID"},
 			mustNotContain: []string{"filter:"},
 		},
 		{
 			name:           "with string filter",
 			collectionType: CollectionTransaction,
-			filters:        map[string]interface{}{"from": "0xabc"},
+			filters:        map[string]any{"from": "0xabc"},
 			mustContain:    []string{"Ethereum__Mainnet__Transaction(filter:", "from: {_eq: \"0xabc\"}"},
 		},
 		{
 			name:           "with bool filter",
 			collectionType: CollectionTransaction,
-			filters:        map[string]interface{}{"status": true},
+			filters:        map[string]any{"status": true},
 			mustContain:    []string{"filter:", "status: {_eq: true}"},
 		},
 	}
@@ -174,11 +174,11 @@ func TestBuildNestedQuery(t *testing.T) {
 	qs := NewQueryService()
 
 	tests := []struct {
-		name              string
-		primary           CollectionType
-		nested            []CollectionType
-		filters           map[string]interface{}
-		mustContain       []string
+		name        string
+		primary     CollectionType
+		nested      []CollectionType
+		filters     map[string]any
+		mustContain []string
 	}{
 		{
 			name:    "block with nested transaction",
@@ -205,7 +205,7 @@ func TestBuildNestedQuery(t *testing.T) {
 			name:    "nested query with filters",
 			primary: CollectionBlock,
 			nested:  []CollectionType{CollectionTransaction},
-			filters: map[string]interface{}{"number": int64(100)},
+			filters: map[string]any{"number": int64(100)},
 			mustContain: []string{
 				"Ethereum__Mainnet__Block(filter:",
 				"Ethereum__Mainnet__Transaction",
@@ -272,13 +272,13 @@ func TestBuildFilterString(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		filters     map[string]interface{}
+		filters     map[string]any
 		expectEmpty bool
 		mustContain []string
 	}{
 		{
 			name:        "empty map returns empty string",
-			filters:     map[string]interface{}{},
+			filters:     map[string]any{},
 			expectEmpty: true,
 		},
 		{
@@ -288,7 +288,7 @@ func TestBuildFilterString(t *testing.T) {
 		},
 		{
 			name:    "string value",
-			filters: map[string]interface{}{"from": "0xabc"},
+			filters: map[string]any{"from": "0xabc"},
 			mustContain: []string{
 				"{ ",
 				"from: {_eq: \"0xabc\"}",
@@ -297,35 +297,35 @@ func TestBuildFilterString(t *testing.T) {
 		},
 		{
 			name:    "int64 value",
-			filters: map[string]interface{}{"blockNumber": int64(42)},
+			filters: map[string]any{"blockNumber": int64(42)},
 			mustContain: []string{
 				"blockNumber: {_eq: 42}",
 			},
 		},
 		{
 			name:    "float64 value",
-			filters: map[string]interface{}{"gasPrice": float64(1.5)},
+			filters: map[string]any{"gasPrice": float64(1.5)},
 			mustContain: []string{
 				"gasPrice: {_eq: 1.500000}",
 			},
 		},
 		{
 			name:    "bool value",
-			filters: map[string]interface{}{"status": true},
+			filters: map[string]any{"status": true},
 			mustContain: []string{
 				"status: {_eq: true}",
 			},
 		},
 		{
 			name:    "bool false value",
-			filters: map[string]interface{}{"removed": false},
+			filters: map[string]any{"removed": false},
 			mustContain: []string{
 				"removed: {_eq: false}",
 			},
 		},
 		{
 			name:    "unknown type falls back to string representation",
-			filters: map[string]interface{}{"custom": []int{1, 2, 3}},
+			filters: map[string]any{"custom": []int{1, 2, 3}},
 			mustContain: []string{
 				"custom: {_eq: \"[1 2 3]\"}",
 			},
@@ -403,7 +403,7 @@ func TestBuildHierarchicalQuery(t *testing.T) {
 	tests := []struct {
 		name           string
 		root           CollectionType
-		filters        map[string]interface{}
+		filters        map[string]any
 		mustContain    []string
 		mustNotContain []string
 	}{
@@ -422,7 +422,7 @@ func TestBuildHierarchicalQuery(t *testing.T) {
 		{
 			name:    "block with children and filters",
 			root:    CollectionBlock,
-			filters: map[string]interface{}{"hash": "0xabc"},
+			filters: map[string]any{"hash": "0xabc"},
 			mustContain: []string{
 				"Ethereum__Mainnet__Block(filter:",
 				"hash: {_eq: \"0xabc\"}",
@@ -459,7 +459,7 @@ func TestBuildHierarchicalQuery(t *testing.T) {
 		{
 			name:    "access list entry with no children and filters",
 			root:    CollectionAccessListEntry,
-			filters: map[string]interface{}{"address": "0x123"},
+			filters: map[string]any{"address": "0x123"},
 			mustContain: []string{
 				"Ethereum__Mainnet__AccessListEntry(filter:",
 				"address: {_eq: \"0x123\"}",
@@ -581,7 +581,7 @@ func TestExtractNestedFields_PointerType(t *testing.T) {
 	}
 
 	qs := NewQueryService()
-	fields := qs.extractNestedFields(reflect.TypeOf(&Inner{}))
+	fields := qs.extractNestedFields(reflect.TypeFor[*Inner]())
 	require.Contains(t, fields, "field1")
 	require.Contains(t, fields, "field2")
 }
@@ -592,7 +592,7 @@ func TestExtractNestedFields_NoJsonTags(t *testing.T) {
 	}
 
 	qs := NewQueryService()
-	fields := qs.extractNestedFields(reflect.TypeOf(NoTags{}))
+	fields := qs.extractNestedFields(reflect.TypeFor[NoTags]())
 	require.Empty(t, fields)
 }
 
@@ -603,7 +603,7 @@ func TestExtractNestedFields_WithDashTag(t *testing.T) {
 	}
 
 	qs := NewQueryService()
-	fields := qs.extractNestedFields(reflect.TypeOf(WithDash{}))
+	fields := qs.extractNestedFields(reflect.TypeFor[WithDash]())
 	require.Contains(t, fields, "visible")
 	require.NotContains(t, fields, "-")
 }
@@ -614,12 +614,12 @@ func TestExtractNestedFields_WithDashTag(t *testing.T) {
 
 func TestBuildFilterString_Uint64Value(t *testing.T) {
 	qs := NewQueryService()
-	result := qs.buildFilterString(map[string]interface{}{"blockNum": uint64(99)})
+	result := qs.buildFilterString(map[string]any{"blockNum": uint64(99)})
 	require.Contains(t, result, "blockNum: {_eq: 99}")
 }
 
 func TestBuildFilterString_IntValue(t *testing.T) {
 	qs := NewQueryService()
-	result := qs.buildFilterString(map[string]interface{}{"count": 42})
+	result := qs.buildFilterString(map[string]any{"count": 42})
 	require.Contains(t, result, "count: {_eq: 42}")
 }

--- a/pkg/host/replication_filter.go
+++ b/pkg/host/replication_filter.go
@@ -251,13 +251,13 @@ func fieldUint64(fields map[string]any, key string) (uint64, bool) {
 	}
 	switch n := v.(type) {
 	case int64:
-		return uint64(n), true
+		return uint64(n), true //nolint:gosec
 	case uint64:
 		return n, true
 	case float64:
 		return uint64(n), true
 	case int:
-		return uint64(n), true
+		return uint64(n), true //nolint:gosec // int to uint64 conversion is safe here, negative values won't occur
 	}
 	return 0, false
 }

--- a/pkg/host/replication_filter_test.go
+++ b/pkg/host/replication_filter_test.go
@@ -1196,7 +1196,7 @@ func TestGroupMatches_LogMultipleTopicFilters(t *testing.T) {
 	group := config.FilterGroup{
 		Enabled: true,
 		Topics: []config.TopicFilter{
-			{Topic0: "0xApproval"},  // Won't match
+			{Topic0: "0xApproval"}, // Won't match
 			{Topic0: "0xTransfer"}, // Will match
 		},
 	}

--- a/pkg/host/shinzohub_view_fetching_test.go
+++ b/pkg/host/shinzohub_view_fetching_test.go
@@ -89,8 +89,8 @@ func TestHostIntegration_ShinzoHubViewFetching(t *testing.T) {
 
 		t.Logf("🔍 Executing known query for %s", viewName)
 		t.Logf("📄 Query: %s", query)
-		
-		results, err := defradb.QueryArray[map[string]interface{}](ctx, h.DefraNode, query)
+
+		results, err := defradb.QueryArray[map[string]any](ctx, h.DefraNode, query)
 		if err != nil {
 			t.Logf("⚠️ %s query error: %v", viewName, err)
 			continue

--- a/pkg/host/shinzohub_view_fetching_test.go
+++ b/pkg/host/shinzohub_view_fetching_test.go
@@ -9,9 +9,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const UsdcEvent_Query = "{ UsdcEvent_0x1bd1afe59e721667b09f9997bff449c3f199531d1aba2bac206fe8132356eda0 { hash blockNumber from to logAddress event signature arguments }}"
-const Erc20Event_Query = "{ Erc20Event_0x9c3455147dfe9a5aca44797a2481fefa51bf00dd4fff7af9fbdfd1e4d4dc7de4 { hash blockNumber from to logAddress event signature arguments }}"
-// TestHostIntegration_ShinzoHubViewFetching tests the complete ShinzoHub view fetching and registration process
+const (
+	USDCEventQuery  = "{ UsdcEvent_0x1bd1afe59e721667b09f9997bff449c3f199531d1aba2bac206fe8132356eda0 { hash blockNumber from to logAddress event signature arguments }}"
+	ERC20EventQuery = "{ Erc20Event_0x9c3455147dfe9a5aca44797a2481fefa51bf00dd4fff7af9fbdfd1e4d4dc7de4 { hash blockNumber from to logAddress event signature arguments }}"
+)
+
+// TestHostIntegration_ShinzoHubViewFetching tests the complete ShinzoHub view fetching and registration process.
 func TestHostIntegration_ShinzoHubViewFetching(t *testing.T) {
 	ctx := context.Background()
 
@@ -21,27 +24,26 @@ func TestHostIntegration_ShinzoHubViewFetching(t *testing.T) {
 	// testConfig.DefraDB.Store.Path = "../../.defra"
 	// testConfig.DefraDB.KeyringSecret = "pingpong"
 	testConfig.DefraDB.Store.Path = t.TempDir()
-	
+
 	// Enable P2P
 	testConfig.DefraDB.P2P.Enabled = true
 	testConfig.DefraDB.P2P.BootstrapPeers = []string{
 		"/ip4/35.209.45.53/tcp/9171/p2p/12D3KooWGqjj1ZeaM5WYuvopSFh8rnsoTYje91mhzwgQGchRAJKa",
 	}
-	
+
 	// Enable debug logging to see SDL schemas
 	testConfig.Logger.Development = true
-	
+
 	// Use ShinzoHub devnet RPC URL from config.yaml
 	testConfig.Shinzo.HubBaseURL = "rpc.devnet.shinzo.network:26657"
-	
+
 	h, err := StartHostingWithEventSubscription(&testConfig)
 	require.NoError(t, err)
-	defer h.Close(ctx)
+	defer func() { _ = h.Close(ctx) }()
 
 	// Step 2: Check if our target views were loaded from ShinzoHub
 	viewNames := h.GetActiveViewNames()
 	t.Logf("📋 Found %d active views: %v", len(viewNames), viewNames)
-	
 
 	// Look for our target views
 	var targetViews []string
@@ -49,7 +51,7 @@ func TestHostIntegration_ShinzoHubViewFetching(t *testing.T) {
 		"UsdcEvent_0x1bd1afe59e721667b09f9997bff449c3f199531d1aba2bac206fe8132356eda0",
 		"Erc20Event_0x9c3455147dfe9a5aca44797a2481fefa51bf00dd4fff7af9fbdfd1e4d4dc7de4",
 	}
-	
+
 	for _, targetName := range targetViewNames {
 		for _, viewName := range viewNames {
 			if viewName == targetName {
@@ -58,12 +60,12 @@ func TestHostIntegration_ShinzoHubViewFetching(t *testing.T) {
 			}
 		}
 	}
-	
+
 	if len(targetViews) == 0 {
 		t.Skip("Target views not found in ShinzoHub - skipping test")
 		return
 	}
-	
+
 	t.Logf("🎯 Found %d target views from ShinzoHub: %v", len(targetViews), targetViews)
 
 	// Step 5: Give views time to process the data
@@ -72,34 +74,34 @@ func TestHostIntegration_ShinzoHubViewFetching(t *testing.T) {
 	// Step 6: Query the ShinzoHub views using their known queries
 	for _, viewName := range targetViews {
 		t.Logf("🔍 Testing ShinzoHub view query: %s", viewName)
-		
+
 		// Use the appropriate known query for each view
 		var query string
 		switch viewName {
 		case "UsdcEvent_0x1bd1afe59e721667b09f9997bff449c3f199531d1aba2bac206fe8132356eda0":
-			query = UsdcEvent_Query
+			query = USDCEventQuery
 		case "Erc20Event_0x9c3455147dfe9a5aca44797a2481fefa51bf00dd4fff7af9fbdfd1e4d4dc7de4":
-			query = Erc20Event_Query
+			query = ERC20EventQuery
 		default:
 			t.Logf("⚠️ No known query for view %s", viewName)
 			continue
 		}
-		
+
 		t.Logf("🔍 Executing known query for %s", viewName)
 		t.Logf("📄 Query: %s", query)
-		
-		results, err := defra.QueryArray[map[string]interface{}](ctx, h.DefraNode, query)
+
+		results, err := defra.QueryArray[map[string]any](ctx, h.DefraNode, query)
 		if err != nil {
 			t.Logf("⚠️ %s query error: %v", viewName, err)
 			continue
 		}
-		
+
 		if len(results) > 0 {
 			t.Logf("✅ %s view returned %d results", viewName, len(results))
 			result := results[0]
 			actualFields := getSortedKeys(result)
 			t.Logf("📊 %s actual fields in result: %v", viewName, actualFields)
-			
+
 			// Log a sample result
 			t.Logf("📊 %s sample result: %v", viewName, result)
 		} else {
@@ -113,8 +115,8 @@ func TestHostIntegration_ShinzoHubViewFetching(t *testing.T) {
 	t.Logf("✅ Target views queried with SDL-based queries")
 }
 
-// Helper function to get sorted keys from a map for logging
-func getSortedKeys(m map[string]interface{}) []string {
+// Helper function to get sorted keys from a map for logging.
+func getSortedKeys(m map[string]any) []string {
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)

--- a/pkg/host/snapshot_bootstrap.go
+++ b/pkg/host/snapshot_bootstrap.go
@@ -8,9 +8,9 @@ import (
 	"path/filepath"
 	"sort"
 
-	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
 	attestationService "github.com/shinzonetwork/shinzo-host-client/pkg/attestation"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/constants"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/snapshot"
 	"github.com/sourcenetwork/defradb/node"
 

--- a/pkg/host/snapshot_bootstrap.go
+++ b/pkg/host/snapshot_bootstrap.go
@@ -17,25 +17,39 @@ import (
 	hostConfig "github.com/shinzonetwork/shinzo-host-client/config"
 )
 
-// bootstrapFromSnapshots downloads and imports historical snapshots before P2P starts.
+// bootstrapFromSnapshots imports historical snapshots from an indexer to seed the local DB.
 func bootstrapFromSnapshots(ctx context.Context, defraNode *node.Node, snapCfg hostConfig.SnapshotConfig) {
 	logger.Sugar.Infof("Bootstrapping from snapshots (indexer: %s, ranges: %d)",
 		snapCfg.IndexerURL, len(snapCfg.HistoricalRanges))
 
+	needed, client, err := resolveNeededSnapshots(ctx, defraNode, snapCfg)
+	if err != nil || len(needed) == 0 {
+		return
+	}
+
+	imported := importSnapshots(ctx, defraNode, client, needed)
+
+	if imported > 0 {
+		rebuildIndexes(ctx, defraNode)
+	}
+
+	logger.Sugar.Infof("Snapshot bootstrap complete: %d/%d snapshots imported", imported, len(needed))
+}
+
+// resolveNeededSnapshots lists available snapshots and filters to those not yet imported.
+func resolveNeededSnapshots(ctx context.Context, defraNode *node.Node, snapCfg hostConfig.SnapshotConfig) ([]snapshot.Info, *snapshot.Client, error) {
 	client := snapshot.NewClient(snapCfg.IndexerURL)
 
 	available, err := client.ListSnapshots()
 	if err != nil {
 		logger.Sugar.Warnf("Failed to list snapshots from indexer: %v", err)
-		return
+		return nil, nil, err
 	}
-
 	if len(available) == 0 {
 		logger.Sugar.Info("No snapshots available from indexer")
-		return
+		return nil, nil, nil
 	}
 
-	// Query existing block range to skip already-imported snapshots.
 	existingMin, existingMax := getExistingBlockRange(ctx, defraNode)
 	if existingMax > 0 {
 		logger.Sugar.Infof("Existing blocks in DB: %d-%d", existingMin, existingMax)
@@ -44,57 +58,66 @@ func bootstrapFromSnapshots(ctx context.Context, defraNode *node.Node, snapCfg h
 	needed := findCoveringSnapshots(available, snapCfg.HistoricalRanges, existingMin, existingMax)
 	if len(needed) == 0 {
 		logger.Sugar.Info("No new snapshots needed (all ranges already covered or no signed snapshots)")
-		return
+		return nil, nil, nil
 	}
 
 	logger.Sugar.Infof("Found %d snapshots to import (skipped already-imported ranges)", len(needed))
+	return needed, client, nil
+}
 
+// importSnapshots downloads and imports each snapshot, returning the count of successful imports.
+func importSnapshots(ctx context.Context, defraNode *node.Node, client *snapshot.Client, needed []snapshot.Info) int {
 	tmpDir := os.TempDir()
 	var imported int
 
 	for _, snap := range needed {
-		sig := snap.Signature
-		if sig == nil {
-			logger.Sugar.Warnf("Snapshot %s is marked signed but has no signature data", snap.Filename)
-			continue
-		}
-
-		tmpPath := filepath.Join(tmpDir, snap.Filename)
-		logger.Sugar.Infof("Downloading snapshot %s (%d bytes)...", snap.Filename, snap.SizeBytes)
-		if err := client.DownloadSnapshot(snap.Filename, tmpPath); err != nil {
-			logger.Sugar.Warnf("Failed to download snapshot %s: %v", snap.Filename, err)
-			continue
-		}
-
-		result, err := snapshot.ImportWithVerification(ctx, defraNode, tmpPath, sig)
-		os.Remove(tmpPath)
-		if err != nil {
+		if err := importSingleSnapshot(ctx, defraNode, client, snap, tmpDir); err != nil {
 			logger.Sugar.Warnf("Failed to import snapshot %s: %v", snap.Filename, err)
 			continue
 		}
-
-		logger.Sugar.Infof("Imported snapshot %s: blocks %d-%d",
-			snap.Filename, result.StartBlock, result.EndBlock)
-
-		createSnapshotAttestation(ctx, defraNode, sig)
 		imported++
 	}
 
-	// Rebuild indexes once after all snapshots are imported (not per-snapshot).
-	if imported > 0 {
-		logger.Sugar.Infof("Rebuilding indexes for %d collections...", len(constants.AllCollections))
-		if err := snapshot.RebuildAllIndexes(ctx, defraNode, constants.AllCollections); err != nil {
-			logger.Sugar.Warnf("Failed to rebuild indexes after snapshot import: %v", err)
-		}
+	return imported
+}
+
+// importSingleSnapshot downloads, verifies, and imports one snapshot.
+func importSingleSnapshot(ctx context.Context, defraNode *node.Node, client *snapshot.Client, snap snapshot.Info, tmpDir string) error {
+	if snap.Signature == nil {
+		logger.Sugar.Warnf("Snapshot %s is marked signed but has no signature data", snap.Filename)
+		return fmt.Errorf("missing signature") // nolint:err113
 	}
 
-	logger.Sugar.Infof("Snapshot bootstrap complete: %d/%d snapshots imported", imported, len(needed))
+	tmpPath := filepath.Join(tmpDir, snap.Filename)
+	logger.Sugar.Infof("Downloading snapshot %s (%d bytes)...", snap.Filename, snap.SizeBytes)
+	if err := client.DownloadSnapshot(snap.Filename, tmpPath); err != nil {
+		return fmt.Errorf("download: %w", err) // nolint:err113
+	}
+
+	result, err := snapshot.ImportWithVerification(ctx, defraNode, tmpPath, snap.Signature)
+	_ = os.Remove(tmpPath)
+	if err != nil {
+		return fmt.Errorf("import: %w", err) // nolint:err113
+	}
+
+	logger.Sugar.Infof("Imported snapshot %s: blocks %d-%d", snap.Filename, result.StartBlock, result.EndBlock)
+	createSnapshotAttestation(ctx, defraNode, snap.Signature)
+
+	return nil
+}
+
+// rebuildIndexes rebuilds all collection indexes after snapshot import.
+func rebuildIndexes(ctx context.Context, defraNode *node.Node) {
+	logger.Sugar.Infof("Rebuilding indexes for %d collections...", len(constants.AllCollections))
+	if err := snapshot.RebuildAllIndexes(ctx, defraNode, constants.AllCollections); err != nil {
+		logger.Sugar.Warnf("Failed to rebuild indexes after snapshot import: %v", err)
+	}
 }
 
 // findCoveringSnapshots returns signed snapshots overlapping the requested ranges,
 // skipping snapshots whose block range is already fully present in the DB.
-func findCoveringSnapshots(available []snapshot.SnapshotInfo, ranges []hostConfig.BlockRange, existingMin, existingMax int64) []snapshot.SnapshotInfo {
-	var needed []snapshot.SnapshotInfo
+func findCoveringSnapshots(available []snapshot.Info, ranges []hostConfig.BlockRange, existingMin, existingMax int64) []snapshot.Info {
+	var needed []snapshot.Info
 	seen := make(map[string]bool)
 
 	for _, r := range ranges {
@@ -168,7 +191,7 @@ func getExistingBlockRange(ctx context.Context, defraNode *node.Node) (int64, in
 }
 
 // createSnapshotAttestation records an attestation for an imported snapshot.
-func createSnapshotAttestation(ctx context.Context, defraNode *node.Node, sig *snapshot.SnapshotSignatureData) {
+func createSnapshotAttestation(ctx context.Context, defraNode *node.Node, sig *snapshot.SignatureData) {
 	if len(sig.BlockSigMerkleRoots) == 0 {
 		logger.Sugar.Warnf("Skipping attestation for snapshot %d-%d: no block sig merkle roots",
 			sig.StartBlock, sig.EndBlock)
@@ -176,8 +199,8 @@ func createSnapshotAttestation(ctx context.Context, defraNode *node.Node, sig *s
 	}
 
 	record := &constants.AttestationRecord{
-		AttestedDocId: fmt.Sprintf("snapshot:%d-%d", sig.StartBlock, sig.EndBlock),
-		SourceDocIds:  []string{sig.SignatureIdentity},
+		AttestedDocID: fmt.Sprintf("snapshot:%d-%d", sig.StartBlock, sig.EndBlock),
+		SourceDocIDs:  []string{sig.SignatureIdentity},
 		CIDs:          sig.BlockSigMerkleRoots,
 		DocType:       "Snapshot",
 		VoteCount:     1,
@@ -188,6 +211,6 @@ func createSnapshotAttestation(ctx context.Context, defraNode *node.Node, sig *s
 			sig.StartBlock, sig.EndBlock, err)
 	} else {
 		logger.Sugar.Infof("Created attestation for snapshot %d-%d (signer: %s)",
-			sig.StartBlock, sig.EndBlock, truncateString(sig.SignatureIdentity, 16))
+			sig.StartBlock, sig.EndBlock, truncateString(sig.SignatureIdentity, identityTruncateLength))
 	}
 }

--- a/pkg/host/snapshot_bootstrap_test.go
+++ b/pkg/host/snapshot_bootstrap_test.go
@@ -8,9 +8,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	hostConfig "github.com/shinzonetwork/shinzo-host-client/config"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/defradb"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
-	hostConfig "github.com/shinzonetwork/shinzo-host-client/config"
 	localschema "github.com/shinzonetwork/shinzo-host-client/pkg/schema"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/snapshot"
 	"github.com/stretchr/testify/require"

--- a/pkg/host/snapshot_bootstrap_test.go
+++ b/pkg/host/snapshot_bootstrap_test.go
@@ -25,8 +25,8 @@ func init() {
 // ---------------------------------------------------------------------------
 
 func TestFindCoveringSnapshots_NoOverlap(t *testing.T) {
-	available := []snapshot.SnapshotInfo{
-		{Filename: "snap-1-100.tar", StartBlock: 1, EndBlock: 100, Signed: true, Signature: &snapshot.SnapshotSignatureData{}},
+	available := []snapshot.Info{
+		{Filename: "snap-1-100.tar", StartBlock: 1, EndBlock: 100, Signed: true, Signature: &snapshot.SignatureData{}},
 	}
 	ranges := []hostConfig.BlockRange{
 		{Start: 200, End: 300},
@@ -37,9 +37,9 @@ func TestFindCoveringSnapshots_NoOverlap(t *testing.T) {
 }
 
 func TestFindCoveringSnapshots_FullOverlap(t *testing.T) {
-	available := []snapshot.SnapshotInfo{
-		{Filename: "snap-100-200.tar", StartBlock: 100, EndBlock: 200, Signed: true, Signature: &snapshot.SnapshotSignatureData{}},
-		{Filename: "snap-150-250.tar", StartBlock: 150, EndBlock: 250, Signed: true, Signature: &snapshot.SnapshotSignatureData{}},
+	available := []snapshot.Info{
+		{Filename: "snap-100-200.tar", StartBlock: 100, EndBlock: 200, Signed: true, Signature: &snapshot.SignatureData{}},
+		{Filename: "snap-150-250.tar", StartBlock: 150, EndBlock: 250, Signed: true, Signature: &snapshot.SignatureData{}},
 	}
 	ranges := []hostConfig.BlockRange{
 		{Start: 100, End: 250},
@@ -53,9 +53,9 @@ func TestFindCoveringSnapshots_FullOverlap(t *testing.T) {
 }
 
 func TestFindCoveringSnapshots_AlreadyImported(t *testing.T) {
-	available := []snapshot.SnapshotInfo{
-		{Filename: "snap-100-200.tar", StartBlock: 100, EndBlock: 200, Signed: true, Signature: &snapshot.SnapshotSignatureData{}},
-		{Filename: "snap-300-400.tar", StartBlock: 300, EndBlock: 400, Signed: true, Signature: &snapshot.SnapshotSignatureData{}},
+	available := []snapshot.Info{
+		{Filename: "snap-100-200.tar", StartBlock: 100, EndBlock: 200, Signed: true, Signature: &snapshot.SignatureData{}},
+		{Filename: "snap-300-400.tar", StartBlock: 300, EndBlock: 400, Signed: true, Signature: &snapshot.SignatureData{}},
 	}
 	ranges := []hostConfig.BlockRange{
 		{Start: 50, End: 500},
@@ -68,9 +68,9 @@ func TestFindCoveringSnapshots_AlreadyImported(t *testing.T) {
 }
 
 func TestFindCoveringSnapshots_UnsignedFiltered(t *testing.T) {
-	available := []snapshot.SnapshotInfo{
+	available := []snapshot.Info{
 		{Filename: "snap-100-200.tar", StartBlock: 100, EndBlock: 200, Signed: false},
-		{Filename: "snap-200-300.tar", StartBlock: 200, EndBlock: 300, Signed: true, Signature: &snapshot.SnapshotSignatureData{}},
+		{Filename: "snap-200-300.tar", StartBlock: 200, EndBlock: 300, Signed: true, Signature: &snapshot.SignatureData{}},
 	}
 	ranges := []hostConfig.BlockRange{
 		{Start: 100, End: 300},
@@ -82,8 +82,8 @@ func TestFindCoveringSnapshots_UnsignedFiltered(t *testing.T) {
 }
 
 func TestFindCoveringSnapshots_DeduplicationByFilename(t *testing.T) {
-	available := []snapshot.SnapshotInfo{
-		{Filename: "snap-100-200.tar", StartBlock: 100, EndBlock: 200, Signed: true, Signature: &snapshot.SnapshotSignatureData{}},
+	available := []snapshot.Info{
+		{Filename: "snap-100-200.tar", StartBlock: 100, EndBlock: 200, Signed: true, Signature: &snapshot.SignatureData{}},
 	}
 	// Two ranges that both overlap the same snapshot
 	ranges := []hostConfig.BlockRange{
@@ -97,10 +97,10 @@ func TestFindCoveringSnapshots_DeduplicationByFilename(t *testing.T) {
 }
 
 func TestFindCoveringSnapshots_SortedByStartBlock(t *testing.T) {
-	available := []snapshot.SnapshotInfo{
-		{Filename: "snap-300-400.tar", StartBlock: 300, EndBlock: 400, Signed: true, Signature: &snapshot.SnapshotSignatureData{}},
-		{Filename: "snap-100-200.tar", StartBlock: 100, EndBlock: 200, Signed: true, Signature: &snapshot.SnapshotSignatureData{}},
-		{Filename: "snap-200-300.tar", StartBlock: 200, EndBlock: 300, Signed: true, Signature: &snapshot.SnapshotSignatureData{}},
+	available := []snapshot.Info{
+		{Filename: "snap-300-400.tar", StartBlock: 300, EndBlock: 400, Signed: true, Signature: &snapshot.SignatureData{}},
+		{Filename: "snap-100-200.tar", StartBlock: 100, EndBlock: 200, Signed: true, Signature: &snapshot.SignatureData{}},
+		{Filename: "snap-200-300.tar", StartBlock: 200, EndBlock: 300, Signed: true, Signature: &snapshot.SignatureData{}},
 	}
 	ranges := []hostConfig.BlockRange{
 		{Start: 50, End: 500},
@@ -123,8 +123,8 @@ func TestFindCoveringSnapshots_EmptyAvailable(t *testing.T) {
 }
 
 func TestFindCoveringSnapshots_EmptyRanges(t *testing.T) {
-	available := []snapshot.SnapshotInfo{
-		{Filename: "snap-100-200.tar", StartBlock: 100, EndBlock: 200, Signed: true, Signature: &snapshot.SnapshotSignatureData{}},
+	available := []snapshot.Info{
+		{Filename: "snap-100-200.tar", StartBlock: 100, EndBlock: 200, Signed: true, Signature: &snapshot.SignatureData{}},
 	}
 
 	result := findCoveringSnapshots(available, nil, 0, 0)
@@ -133,8 +133,8 @@ func TestFindCoveringSnapshots_EmptyRanges(t *testing.T) {
 
 func TestFindCoveringSnapshots_PartiallyImportedStillIncluded(t *testing.T) {
 	// A snapshot that extends beyond the existing range should still be included
-	available := []snapshot.SnapshotInfo{
-		{Filename: "snap-50-300.tar", StartBlock: 50, EndBlock: 300, Signed: true, Signature: &snapshot.SnapshotSignatureData{}},
+	available := []snapshot.Info{
+		{Filename: "snap-50-300.tar", StartBlock: 50, EndBlock: 300, Signed: true, Signature: &snapshot.SignatureData{}},
 	}
 	ranges := []hostConfig.BlockRange{
 		{Start: 1, End: 400},
@@ -148,8 +148,8 @@ func TestFindCoveringSnapshots_PartiallyImportedStillIncluded(t *testing.T) {
 
 func TestFindCoveringSnapshots_ExistingMaxZeroDoesNotSkip(t *testing.T) {
 	// When existingMax is 0, the "already imported" check is skipped entirely
-	available := []snapshot.SnapshotInfo{
-		{Filename: "snap-1-100.tar", StartBlock: 1, EndBlock: 100, Signed: true, Signature: &snapshot.SnapshotSignatureData{}},
+	available := []snapshot.Info{
+		{Filename: "snap-1-100.tar", StartBlock: 1, EndBlock: 100, Signed: true, Signature: &snapshot.SignatureData{}},
 	}
 	ranges := []hostConfig.BlockRange{
 		{Start: 1, End: 100},
@@ -160,8 +160,8 @@ func TestFindCoveringSnapshots_ExistingMaxZeroDoesNotSkip(t *testing.T) {
 }
 
 func TestFindCoveringSnapshots_SnapshotEndBeforeRangeStart(t *testing.T) {
-	available := []snapshot.SnapshotInfo{
-		{Filename: "snap-1-50.tar", StartBlock: 1, EndBlock: 50, Signed: true, Signature: &snapshot.SnapshotSignatureData{}},
+	available := []snapshot.Info{
+		{Filename: "snap-1-50.tar", StartBlock: 1, EndBlock: 50, Signed: true, Signature: &snapshot.SignatureData{}},
 	}
 	ranges := []hostConfig.BlockRange{
 		{Start: 100, End: 200},
@@ -172,8 +172,8 @@ func TestFindCoveringSnapshots_SnapshotEndBeforeRangeStart(t *testing.T) {
 }
 
 func TestFindCoveringSnapshots_SnapshotStartAfterRangeEnd(t *testing.T) {
-	available := []snapshot.SnapshotInfo{
-		{Filename: "snap-300-400.tar", StartBlock: 300, EndBlock: 400, Signed: true, Signature: &snapshot.SnapshotSignatureData{}},
+	available := []snapshot.Info{
+		{Filename: "snap-300-400.tar", StartBlock: 300, EndBlock: 400, Signed: true, Signature: &snapshot.SignatureData{}},
 	}
 	ranges := []hostConfig.BlockRange{
 		{Start: 100, End: 200},
@@ -185,8 +185,8 @@ func TestFindCoveringSnapshots_SnapshotStartAfterRangeEnd(t *testing.T) {
 
 func TestFindCoveringSnapshots_BoundaryOverlap(t *testing.T) {
 	// Snapshot endBlock equals range start - still overlaps
-	available := []snapshot.SnapshotInfo{
-		{Filename: "snap-50-100.tar", StartBlock: 50, EndBlock: 100, Signed: true, Signature: &snapshot.SnapshotSignatureData{}},
+	available := []snapshot.Info{
+		{Filename: "snap-50-100.tar", StartBlock: 50, EndBlock: 100, Signed: true, Signature: &snapshot.SignatureData{}},
 	}
 	ranges := []hostConfig.BlockRange{
 		{Start: 100, End: 200},
@@ -197,10 +197,10 @@ func TestFindCoveringSnapshots_BoundaryOverlap(t *testing.T) {
 }
 
 func TestFindCoveringSnapshots_MultipleRangesMultipleSnapshots(t *testing.T) {
-	available := []snapshot.SnapshotInfo{
-		{Filename: "snap-1-100.tar", StartBlock: 1, EndBlock: 100, Signed: true, Signature: &snapshot.SnapshotSignatureData{}},
-		{Filename: "snap-200-300.tar", StartBlock: 200, EndBlock: 300, Signed: true, Signature: &snapshot.SnapshotSignatureData{}},
-		{Filename: "snap-500-600.tar", StartBlock: 500, EndBlock: 600, Signed: true, Signature: &snapshot.SnapshotSignatureData{}},
+	available := []snapshot.Info{
+		{Filename: "snap-1-100.tar", StartBlock: 1, EndBlock: 100, Signed: true, Signature: &snapshot.SignatureData{}},
+		{Filename: "snap-200-300.tar", StartBlock: 200, EndBlock: 300, Signed: true, Signature: &snapshot.SignatureData{}},
+		{Filename: "snap-500-600.tar", StartBlock: 500, EndBlock: 600, Signed: true, Signature: &snapshot.SignatureData{}},
 	}
 	ranges := []hostConfig.BlockRange{
 		{Start: 50, End: 150},
@@ -220,9 +220,9 @@ func TestFindCoveringSnapshots_MultipleRangesMultipleSnapshots(t *testing.T) {
 func TestBootstrapFromSnapshots_NoSnapshotsAvailable(t *testing.T) {
 	// Create a mock HTTP server that returns empty snapshots list
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/snapshots" {
+		if r.URL.Path == testSnapshotsPath {
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]any{"snapshots": []any{}})
+			_ = json.NewEncoder(w).Encode(map[string]any{"snapshots": []any{}})
 			return
 		}
 		http.NotFound(w, r)
@@ -232,7 +232,7 @@ func TestBootstrapFromSnapshots_NoSnapshotsAvailable(t *testing.T) {
 	ctx := context.Background()
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	cfg := hostConfig.SnapshotConfig{
 		Enabled:    true,
@@ -248,7 +248,7 @@ func TestBootstrapFromSnapshots_NoSnapshotsAvailable(t *testing.T) {
 
 func TestBootstrapFromSnapshots_ListSnapshotsFails(t *testing.T) {
 	// Create a mock HTTP server that returns an error
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer server.Close()
@@ -256,7 +256,7 @@ func TestBootstrapFromSnapshots_ListSnapshotsFails(t *testing.T) {
 	ctx := context.Background()
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	cfg := hostConfig.SnapshotConfig{
 		Enabled:    true,
@@ -273,12 +273,12 @@ func TestBootstrapFromSnapshots_ListSnapshotsFails(t *testing.T) {
 func TestBootstrapFromSnapshots_NoNeededSnapshots(t *testing.T) {
 	// Create a mock HTTP server that returns snapshots outside the requested range
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/snapshots" {
-			snaps := []snapshot.SnapshotInfo{
-				{Filename: "snap-500-600.tar", StartBlock: 500, EndBlock: 600, Signed: true, Signature: &snapshot.SnapshotSignatureData{}},
+		if r.URL.Path == testSnapshotsPath {
+			snaps := []snapshot.Info{
+				{Filename: "snap-500-600.tar", StartBlock: 500, EndBlock: 600, Signed: true, Signature: &snapshot.SignatureData{}},
 			}
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]any{"snapshots": snaps})
+			_ = json.NewEncoder(w).Encode(map[string]any{"snapshots": snaps})
 			return
 		}
 		http.NotFound(w, r)
@@ -288,7 +288,7 @@ func TestBootstrapFromSnapshots_NoNeededSnapshots(t *testing.T) {
 	ctx := context.Background()
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	cfg := hostConfig.SnapshotConfig{
 		Enabled:    true,
@@ -305,12 +305,12 @@ func TestBootstrapFromSnapshots_NoNeededSnapshots(t *testing.T) {
 func TestBootstrapFromSnapshots_NilSignature(t *testing.T) {
 	// Create a mock HTTP server that returns a snapshot with nil signature
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/snapshots" {
-			snaps := []snapshot.SnapshotInfo{
+		if r.URL.Path == testSnapshotsPath {
+			snaps := []snapshot.Info{
 				{Filename: "snap-1-100.tar", StartBlock: 1, EndBlock: 100, Signed: true, Signature: nil},
 			}
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]any{"snapshots": snaps})
+			_ = json.NewEncoder(w).Encode(map[string]any{"snapshots": snaps})
 			return
 		}
 		http.NotFound(w, r)
@@ -320,7 +320,7 @@ func TestBootstrapFromSnapshots_NilSignature(t *testing.T) {
 	ctx := context.Background()
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	cfg := hostConfig.SnapshotConfig{
 		Enabled:    true,
@@ -338,15 +338,15 @@ func TestBootstrapFromSnapshots_DownloadFails(t *testing.T) {
 	// Create a mock HTTP server that lists snapshots but download fails
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/snapshots":
-			snaps := []snapshot.SnapshotInfo{
+		case testSnapshotsPath:
+			snaps := []snapshot.Info{
 				{
 					Filename:   "snap-1-100.tar",
 					StartBlock: 1,
 					EndBlock:   100,
 					SizeBytes:  1024,
 					Signed:     true,
-					Signature: &snapshot.SnapshotSignatureData{
+					Signature: &snapshot.SignatureData{
 						StartBlock:        1,
 						EndBlock:          100,
 						SignatureIdentity: "test-signer",
@@ -354,7 +354,7 @@ func TestBootstrapFromSnapshots_DownloadFails(t *testing.T) {
 				},
 			}
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]any{"snapshots": snaps})
+			_ = json.NewEncoder(w).Encode(map[string]any{"snapshots": snaps})
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -364,7 +364,7 @@ func TestBootstrapFromSnapshots_DownloadFails(t *testing.T) {
 	ctx := context.Background()
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	cfg := hostConfig.SnapshotConfig{
 		Enabled:    true,
@@ -387,7 +387,7 @@ func TestGetExistingBlockRange_EmptyDB(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	minBlock, maxBlock := getExistingBlockRange(ctx, defraNode)
 	require.Equal(t, int64(0), minBlock)
@@ -403,9 +403,9 @@ func TestCreateSnapshotAttestation_NoBlockSigMerkleRoots(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
-	sig := &snapshot.SnapshotSignatureData{
+	sig := &snapshot.SignatureData{
 		StartBlock:          1,
 		EndBlock:            100,
 		SignatureIdentity:   "test-signer",
@@ -421,9 +421,9 @@ func TestCreateSnapshotAttestation_WithMerkleRoots(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
-	sig := &snapshot.SnapshotSignatureData{
+	sig := &snapshot.SignatureData{
 		StartBlock:          1,
 		EndBlock:            100,
 		SignatureIdentity:   "test-signer",
@@ -436,7 +436,7 @@ func TestCreateSnapshotAttestation_WithMerkleRoots(t *testing.T) {
 }
 
 func TestCreateSnapshotAttestation_RecordFormat(t *testing.T) {
-	sig := &snapshot.SnapshotSignatureData{
+	sig := &snapshot.SignatureData{
 		StartBlock:          1,
 		EndBlock:            100,
 		SignatureIdentity:   "test-signer",
@@ -457,7 +457,7 @@ func TestGetExistingBlockRange_WithBlocksInDB(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	// Insert some blocks with different block numbers
 	for _, num := range []int{10, 20, 30} {
@@ -484,7 +484,7 @@ func TestGetExistingBlockRange_SingleBlock(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	// Insert a single block
 	mutation := `mutation {
@@ -513,9 +513,9 @@ func TestCreateSnapshotAttestation_SuccessVerifyRecord(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
-	sig := &snapshot.SnapshotSignatureData{
+	sig := &snapshot.SignatureData{
 		StartBlock:          500,
 		EndBlock:            600,
 		SignatureIdentity:   "test-signer-identity",
@@ -542,9 +542,9 @@ func TestCreateSnapshotAttestation_SuccessVerifyRecord(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestFindCoveringSnapshots_AllAlreadyImported(t *testing.T) {
-	available := []snapshot.SnapshotInfo{
-		{Filename: "snap-100-150.tar", StartBlock: 100, EndBlock: 150, Signed: true, Signature: &snapshot.SnapshotSignatureData{}},
-		{Filename: "snap-200-250.tar", StartBlock: 200, EndBlock: 250, Signed: true, Signature: &snapshot.SnapshotSignatureData{}},
+	available := []snapshot.Info{
+		{Filename: "snap-100-150.tar", StartBlock: 100, EndBlock: 150, Signed: true, Signature: &snapshot.SignatureData{}},
+		{Filename: "snap-200-250.tar", StartBlock: 200, EndBlock: 250, Signed: true, Signature: &snapshot.SignatureData{}},
 	}
 	ranges := []hostConfig.BlockRange{
 		{Start: 1, End: 500},
@@ -556,11 +556,11 @@ func TestFindCoveringSnapshots_AllAlreadyImported(t *testing.T) {
 }
 
 func TestFindCoveringSnapshots_MixedSignedAndExisting(t *testing.T) {
-	available := []snapshot.SnapshotInfo{
-		{Filename: "snap-10-50.tar", StartBlock: 10, EndBlock: 50, Signed: true, Signature: &snapshot.SnapshotSignatureData{}},
+	available := []snapshot.Info{
+		{Filename: "snap-10-50.tar", StartBlock: 10, EndBlock: 50, Signed: true, Signature: &snapshot.SignatureData{}},
 		{Filename: "snap-60-80.tar", StartBlock: 60, EndBlock: 80, Signed: false},
-		{Filename: "snap-90-120.tar", StartBlock: 90, EndBlock: 120, Signed: true, Signature: &snapshot.SnapshotSignatureData{}},
-		{Filename: "snap-100-110.tar", StartBlock: 100, EndBlock: 110, Signed: true, Signature: &snapshot.SnapshotSignatureData{}},
+		{Filename: "snap-90-120.tar", StartBlock: 90, EndBlock: 120, Signed: true, Signature: &snapshot.SignatureData{}},
+		{Filename: "snap-100-110.tar", StartBlock: 100, EndBlock: 110, Signed: true, Signature: &snapshot.SignatureData{}},
 	}
 	ranges := []hostConfig.BlockRange{
 		{Start: 1, End: 200},
@@ -579,9 +579,9 @@ func TestCreateSnapshotAttestation_NilBlockSigMerkleRoots(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
-	sig := &snapshot.SnapshotSignatureData{
+	sig := &snapshot.SignatureData{
 		StartBlock:          1,
 		EndBlock:            100,
 		SignatureIdentity:   "test-signer",
@@ -596,15 +596,15 @@ func TestBootstrapFromSnapshots_DownloadSucceeds_ImportFails(t *testing.T) {
 	// Create a mock HTTP server that serves a "snapshot" (invalid tar file)
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/snapshots":
-			snaps := []snapshot.SnapshotInfo{
+		case testSnapshotsPath:
+			snaps := []snapshot.Info{
 				{
 					Filename:   "snap-1-100.tar",
 					StartBlock: 1,
 					EndBlock:   100,
 					SizeBytes:  64,
 					Signed:     true,
-					Signature: &snapshot.SnapshotSignatureData{
+					Signature: &snapshot.SignatureData{
 						StartBlock:          1,
 						EndBlock:            100,
 						SignatureIdentity:   "test-signer",
@@ -613,11 +613,11 @@ func TestBootstrapFromSnapshots_DownloadSucceeds_ImportFails(t *testing.T) {
 				},
 			}
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]any{"snapshots": snaps})
+			_ = json.NewEncoder(w).Encode(map[string]any{"snapshots": snaps})
 		case "/snapshots/snap-1-100.tar":
 			// Serve a small invalid tar file
 			w.Header().Set("Content-Type", "application/octet-stream")
-			w.Write([]byte("this is not a real tar file but serves as a test payload"))
+			_, _ = w.Write([]byte("this is not a real tar file but serves as a test payload"))
 		default:
 			http.NotFound(w, r)
 		}
@@ -627,7 +627,7 @@ func TestBootstrapFromSnapshots_DownloadSucceeds_ImportFails(t *testing.T) {
 	ctx := context.Background()
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	cfg := hostConfig.SnapshotConfig{
 		Enabled:    true,

--- a/pkg/host/snapshot_bootstrap_test.go
+++ b/pkg/host/snapshot_bootstrap_test.go
@@ -230,7 +230,7 @@ func TestBootstrapFromSnapshots_NoSnapshotsAvailable(t *testing.T) {
 	defer server.Close()
 
 	ctx := context.Background()
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchema()))
 	require.NoError(t, err)
 	defer func() { _ = defraNode.Close(ctx) }()
 
@@ -254,7 +254,7 @@ func TestBootstrapFromSnapshots_ListSnapshotsFails(t *testing.T) {
 	defer server.Close()
 
 	ctx := context.Background()
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchema()))
 	require.NoError(t, err)
 	defer func() { _ = defraNode.Close(ctx) }()
 
@@ -286,7 +286,7 @@ func TestBootstrapFromSnapshots_NoNeededSnapshots(t *testing.T) {
 	defer server.Close()
 
 	ctx := context.Background()
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchema()))
 	require.NoError(t, err)
 	defer func() { _ = defraNode.Close(ctx) }()
 
@@ -318,7 +318,7 @@ func TestBootstrapFromSnapshots_NilSignature(t *testing.T) {
 	defer server.Close()
 
 	ctx := context.Background()
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchema()))
 	require.NoError(t, err)
 	defer func() { _ = defraNode.Close(ctx) }()
 
@@ -362,7 +362,7 @@ func TestBootstrapFromSnapshots_DownloadFails(t *testing.T) {
 	defer server.Close()
 
 	ctx := context.Background()
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchema()))
 	require.NoError(t, err)
 	defer func() { _ = defraNode.Close(ctx) }()
 
@@ -385,7 +385,7 @@ func TestBootstrapFromSnapshots_DownloadFails(t *testing.T) {
 func TestGetExistingBlockRange_EmptyDB(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchema()))
 	require.NoError(t, err)
 	defer func() { _ = defraNode.Close(ctx) }()
 
@@ -401,7 +401,7 @@ func TestGetExistingBlockRange_EmptyDB(t *testing.T) {
 func TestCreateSnapshotAttestation_NoBlockSigMerkleRoots(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchema()))
 	require.NoError(t, err)
 	defer func() { _ = defraNode.Close(ctx) }()
 
@@ -419,7 +419,7 @@ func TestCreateSnapshotAttestation_NoBlockSigMerkleRoots(t *testing.T) {
 func TestCreateSnapshotAttestation_WithMerkleRoots(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchema()))
 	require.NoError(t, err)
 	defer func() { _ = defraNode.Close(ctx) }()
 
@@ -455,7 +455,7 @@ func TestCreateSnapshotAttestation_RecordFormat(t *testing.T) {
 func TestGetExistingBlockRange_WithBlocksInDB(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchema()))
 	require.NoError(t, err)
 	defer func() { _ = defraNode.Close(ctx) }()
 
@@ -482,7 +482,7 @@ func TestGetExistingBlockRange_WithBlocksInDB(t *testing.T) {
 func TestGetExistingBlockRange_SingleBlock(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchema()))
 	require.NoError(t, err)
 	defer func() { _ = defraNode.Close(ctx) }()
 
@@ -511,7 +511,7 @@ func TestGetExistingBlockRange_SingleBlock(t *testing.T) {
 func TestCreateSnapshotAttestation_SuccessVerifyRecord(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchema()))
 	require.NoError(t, err)
 	defer func() { _ = defraNode.Close(ctx) }()
 
@@ -577,7 +577,7 @@ func TestFindCoveringSnapshots_MixedSignedAndExisting(t *testing.T) {
 func TestCreateSnapshotAttestation_NilBlockSigMerkleRoots(t *testing.T) {
 	ctx := context.Background()
 
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchema()))
 	require.NoError(t, err)
 	defer func() { _ = defraNode.Close(ctx) }()
 
@@ -625,7 +625,7 @@ func TestBootstrapFromSnapshots_DownloadSucceeds_ImportFails(t *testing.T) {
 	defer svr.Close()
 
 	ctx := context.Background()
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchemaForBuild()))
+	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, defra.NewSchemaApplierFromProvidedSchema(localschema.GetSchema()))
 	require.NoError(t, err)
 	defer func() { _ = defraNode.Close(ctx) }()
 

--- a/pkg/logger/zap.go
+++ b/pkg/logger/zap.go
@@ -10,7 +10,7 @@ import (
 
 // Sugar is the package-level sugared logger. Call Init before first use; until
 // then it is nil and call sites will panic on dereference.
-var Sugar *zap.SugaredLogger
+var Sugar *zap.SugaredLogger //nolint:gochecknoglobals
 
 // Init builds a tee'd zap logger that writes to stdout and, when logsDir is
 // writable, also to logsDir/logfile.log (all levels) and logsDir/errorfile.log
@@ -31,18 +31,18 @@ func Init(development bool, logsDir string) {
 
 	var cores []zapcore.Core
 
-	if err := os.MkdirAll(logsDir, 0755); err == nil {
+	if err := os.MkdirAll(logsDir, 0o750); err == nil { // nolint:mnd
 		logFile := filepath.Join(logsDir, "logfile.log")
 		errorFile := filepath.Join(logsDir, "errorfile.log")
 
-		if logFileWriter, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666); err == nil {
+		if logFileWriter, err := os.OpenFile(filepath.Clean(logFile), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600); err == nil { // nolint:mnd
 			consoleCore := zapcore.NewCore(zapcore.NewConsoleEncoder(encoderConfig), consoleWriter, zapLevel)
 			cores = append(cores, consoleCore)
 
 			logFileCore := zapcore.NewCore(zapcore.NewConsoleEncoder(encoderConfig), zapcore.AddSync(logFileWriter), zapLevel)
 			cores = append(cores, logFileCore)
 
-			if errorFileWriter, err := os.OpenFile(errorFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666); err == nil {
+			if errorFileWriter, err := os.OpenFile(filepath.Clean(errorFile), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600); err == nil { // nolint:mnd
 				errorCore := zapcore.NewCore(
 					zapcore.NewConsoleEncoder(encoderConfig),
 					zapcore.AddSync(errorFileWriter),

--- a/pkg/playground/server_noop.go
+++ b/pkg/playground/server_noop.go
@@ -4,10 +4,9 @@ package playground
 
 import "net/http"
 
-// NewServer returns a no-op handler when playground is not enabled
-func NewServer(defraAPIURL string) (http.Handler, error) {
+// NewServer returns a no-op handler when playground is not enabled.
+func NewServer(_ string) (http.Handler, error) {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	}), nil
 }
-

--- a/pkg/pruner/docid_codec.go
+++ b/pkg/pruner/docid_codec.go
@@ -2,7 +2,6 @@ package pruner
 
 import (
 	"encoding/hex"
-	"fmt"
 	"strings"
 	"sync"
 )
@@ -17,8 +16,8 @@ const uuidSize = 16
 
 // docIDPrefix is the constant version prefix shared by all DefraDB document IDs.
 var (
-	docIDPrefix     string
-	docIDPrefixOnce sync.Once
+	docIDPrefix     string    //nolint:gochecknoglobals
+	docIDPrefixOnce sync.Once //nolint:gochecknoglobals
 )
 
 // extractUUID extracts the 16-byte UUID from a docID string. Captures the
@@ -26,7 +25,7 @@ var (
 func extractUUID(docID string) ([uuidSize]byte, error) {
 	idx := strings.IndexByte(docID, '-')
 	if idx < 0 {
-		return [uuidSize]byte{}, fmt.Errorf("invalid docID format: %s", docID)
+		return [uuidSize]byte{}, ErrInvalidDocIDFormat
 	}
 	docIDPrefixOnce.Do(func() {
 		docIDPrefix = docID[:idx]
@@ -37,8 +36,8 @@ func extractUUID(docID string) ([uuidSize]byte, error) {
 // parseUUIDHex parses a UUID string (with hyphens) into 16 raw bytes.
 func parseUUIDHex(uuidStr string) ([uuidSize]byte, error) {
 	clean := strings.ReplaceAll(uuidStr, "-", "")
-	if len(clean) != 32 {
-		return [uuidSize]byte{}, fmt.Errorf("invalid UUID: %s", uuidStr)
+	if len(clean) != 32 { //nolint:mnd
+		return [uuidSize]byte{}, ErrInvalidUUID
 	}
 	var result [uuidSize]byte
 	_, err := hex.Decode(result[:], []byte(clean))

--- a/pkg/pruner/errors.go
+++ b/pkg/pruner/errors.go
@@ -1,0 +1,10 @@
+package pruner
+
+import "errors"
+
+var (
+	// ErrInvalidDocIDFormat is returned when a docID string does not match the expected format.
+	ErrInvalidDocIDFormat = errors.New("invalid docID format")
+	// ErrInvalidUUID is returned when a string cannot be parsed as a valid UUID.
+	ErrInvalidUUID = errors.New("invalid UUID")
+)

--- a/pkg/pruner/event_queue.go
+++ b/pkg/pruner/event_queue.go
@@ -4,6 +4,7 @@ import (
 	"encoding/gob"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sync"
 )
 
@@ -48,7 +49,7 @@ type EventQueue struct {
 // blockCollection is the name of the Block collection (used to identify block entries).
 func NewEventQueue(collections CollectionConfig) *EventQueue {
 	q := &EventQueue{
-		entries:         make([]eventEntry, 0, 1024),
+		entries:         make([]eventEntry, 0, 1024), //nolint:mnd
 		collectionNames: make(map[byte]string),
 		collectionEnums: make(map[string]byte),
 	}
@@ -218,14 +219,14 @@ func (q *EventQueue) BlockCount() int {
 func (q *EventQueue) LoadFromFile(path string) (int, error) {
 	q.filePath = path
 
-	f, err := os.Open(path)
+	f, err := os.Open(filepath.Clean(path))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return 0, nil
 		}
 		return 0, fmt.Errorf("failed to open queue file: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	var snap eventQueueSnapshot
 	if err := gob.NewDecoder(f).Decode(&snap); err != nil {
@@ -270,29 +271,29 @@ func (q *EventQueue) Save() error {
 	q.mu.Unlock()
 
 	if len(snap.Entries) == 0 {
-		os.Remove(q.filePath)
+		_ = os.Remove(q.filePath)
 		return nil
 	}
 
 	tmpPath := q.filePath + ".tmp"
-	f, err := os.Create(tmpPath)
+	f, err := os.Create(filepath.Clean(tmpPath))
 	if err != nil {
 		return fmt.Errorf("failed to create temp file: %w", err)
 	}
 
 	if err := gob.NewEncoder(f).Encode(snap); err != nil {
-		f.Close()
-		os.Remove(tmpPath)
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
 		return fmt.Errorf("failed to encode queue: %w", err)
 	}
 
 	if err := f.Close(); err != nil {
-		os.Remove(tmpPath)
+		_ = os.Remove(tmpPath)
 		return fmt.Errorf("failed to close temp file: %w", err)
 	}
 
 	if err := os.Rename(tmpPath, q.filePath); err != nil {
-		os.Remove(tmpPath)
+		_ = os.Remove(tmpPath)
 		return fmt.Errorf("failed to rename temp file: %w", err)
 	}
 

--- a/pkg/pruner/pruner.go
+++ b/pkg/pruner/pruner.go
@@ -281,7 +281,6 @@ func (p *Pruner) startupCleanup(ctx context.Context) error {
 		lowest, cutoffBlock, toPrune, cutoffBlock+1, highest)
 
 	totalPurged, err := p.pruneBlockRange(ctx, lowest, cutoffBlock)
-
 	if err != nil {
 		logger.Sugar.Errorf("Startup: failed to prune blocks %d-%d: %v", lowest, cutoffBlock, err)
 		return err
@@ -317,12 +316,18 @@ func (p *Pruner) runStorageGC() {
 // Used by the indexer queue (no P2P) and as a fallback when the queue is underfilled.
 func (p *Pruner) filterBasedPrune(ctx context.Context) error {
 	highest, err := p.getHighestBlockNumber(ctx)
-	if err != nil || highest == 0 {
+	if err != nil {
+		return err
+	}
+	if highest == 0 {
 		return nil
 	}
 
 	lowest, err := p.getLowestBlockNumber(ctx)
-	if err != nil || lowest == 0 {
+	if err != nil {
+		return err
+	}
+	if lowest == 0 {
 		return nil
 	}
 
@@ -408,7 +413,7 @@ func (p *Pruner) queryOldestDocIDs(ctx context.Context, collectionName, fieldNam
 
 	result := p.defraNode.DB.ExecRequest(ctx, query)
 	if len(result.GQL.Errors) > 0 {
-		return nil, fmt.Errorf("query failed for %s: %v", collectionName, result.GQL.Errors[0])
+		return nil, fmt.Errorf("query failed for %s: %w", collectionName, result.GQL.Errors[0])
 	}
 
 	data, ok := result.GQL.Data.(map[string]any)
@@ -423,24 +428,30 @@ func (p *Pruner) queryOldestDocIDs(ctx context.Context, collectionName, fieldNam
 	var docIDs []string
 
 	switch docs := raw.(type) {
-	case []map[string]interface{}:
+	case []map[string]any:
 		for _, docMap := range docs {
 			bn, err := parseBlockNumber(docMap[fieldName])
-			if err != nil || bn > maxBlockNumber {
-				break // ordered ASC, so once we exceed maxBlockNumber we're done
+			if err != nil {
+				return nil, err
+			}
+			if bn > maxBlockNumber {
+				break
 			}
 			if docID, ok := docMap["_docID"].(string); ok {
 				docIDs = append(docIDs, docID)
 			}
 		}
-	case []interface{}:
+	case []any:
 		for _, doc := range docs {
-			docMap, ok := doc.(map[string]interface{})
+			docMap, ok := doc.(map[string]any)
 			if !ok {
 				continue
 			}
 			bn, err := parseBlockNumber(docMap[fieldName])
-			if err != nil || bn > maxBlockNumber {
+			if err != nil {
+				return nil, err
+			}
+			if bn > maxBlockNumber {
 				break
 			}
 			if docID, ok := docMap["_docID"].(string); ok {
@@ -511,14 +522,14 @@ func (p *Pruner) getHighestBlockNumber(ctx context.Context) (int64, error) {
 }
 
 func (p *Pruner) extractBlockNumber(gqlData any) (int64, error) {
-	data, ok := gqlData.(map[string]interface{})
+	data, ok := gqlData.(map[string]any)
 	if !ok {
 		return 0, nil
 	}
 
 	blocksRaw := data[p.collections.BlockCollection]
 
-	if blocksTyped, ok := blocksRaw.([]map[string]interface{}); ok {
+	if blocksTyped, ok := blocksRaw.([]map[string]any); ok {
 		if len(blocksTyped) == 0 {
 			return 0, nil
 		}
@@ -528,12 +539,12 @@ func (p *Pruner) extractBlockNumber(gqlData any) (int64, error) {
 		return 0, nil
 	}
 
-	blocks, ok := blocksRaw.([]interface{})
+	blocks, ok := blocksRaw.([]any)
 	if !ok || len(blocks) == 0 {
 		return 0, nil
 	}
 
-	block, ok := blocks[0].(map[string]interface{})
+	block, ok := blocks[0].(map[string]any)
 	if !ok {
 		return 0, nil
 	}
@@ -544,7 +555,7 @@ func (p *Pruner) extractBlockNumber(gqlData any) (int64, error) {
 	return 0, nil
 }
 
-func parseBlockNumber(number interface{}) (int64, error) {
+func parseBlockNumber(number any) (int64, error) {
 	switch v := number.(type) {
 	case float64:
 		return int64(v), nil

--- a/pkg/pruner/queue.go
+++ b/pkg/pruner/queue.go
@@ -3,7 +3,7 @@ package pruner
 // PrunerQueue is the interface for queue implementations used by the pruner.
 // Host's only implementation is EventQueue, a FIFO queue tracking docIDs
 // arriving from P2P replication events.
-type PrunerQueue interface {
+type PrunerQueue interface { // nolint:revive // TODO: remove the double reference to
 	// Len returns the total number of entries in the queue.
 	Len() int
 

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -13,8 +13,3 @@ var SchemaGraphQL string
 func GetSchema() string {
 	return SchemaGraphQL
 }
-
-// GetSchemaForBuild returns the appropriate schema based on build tags.
-func GetSchemaForBuild() string {
-	return GetSchema()
-}

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -4,6 +4,8 @@ import (
 	_ "embed"
 )
 
+// SchemaGraphQL holds the contents of the GraphQL schema defined in `schema.graphql`.
+//
 //go:embed schema.graphql
 var SchemaGraphQL string
 

--- a/pkg/server/constants.go
+++ b/pkg/server/constants.go
@@ -1,0 +1,9 @@
+package server
+
+import "time"
+
+const (
+	healthTimeoutMultiplier = 2
+	defaultTimeout          = 5 * time.Second
+	statusUnhealthy         = "unhealthy"
+)

--- a/pkg/server/errors.go
+++ b/pkg/server/errors.go
@@ -1,0 +1,5 @@
+package server
+
+import "errors"
+
+var ErrHostNotAvailable = errors.New("host not available") //nolint:revive

--- a/pkg/server/errors_test.go
+++ b/pkg/server/errors_test.go
@@ -1,0 +1,10 @@
+package server
+
+import "errors"
+
+var (
+	errPeerInfo             = errors.New("peer info error")
+	errSigning              = errors.New("signing error")
+	errSigningNotConfigured = errors.New("signing not configured")
+	errSimulatedWrite       = errors.New("simulated write error")
+)

--- a/pkg/server/health.go
+++ b/pkg/server/health.go
@@ -18,11 +18,9 @@ import (
 //go:embed health_status_page.html
 var embeddedHealthStatusPageHTML string
 
-var (
-	healthStatusPagePath = filepath.Join("pkg", "server", "health_status_page.html")
-)
+var healthStatusPagePath = filepath.Join("pkg", "server", "health_status_page.html") //nolint:gochecknoglobals
 
-// HealthServer provides HTTP endpoints for health checks and metrics
+// HealthServer provides HTTP endpoints for health checks and metrics.
 type HealthServer struct {
 	server      *http.Server
 	host        HealthChecker
@@ -30,7 +28,7 @@ type HealthServer struct {
 	hostMetrics http.Handler
 }
 
-// HealthChecker interface for checking host health
+// HealthChecker interface for checking host health.
 type HealthChecker interface {
 	IsHealthy() bool
 	GetCurrentBlock() int64
@@ -39,42 +37,46 @@ type HealthChecker interface {
 	SignMessages(message string) (DefraPKRegistration, PeerIDRegistration, error)
 }
 
-// P2PInfo represents DefraDB P2P network information
+// P2PInfo represents DefraDB P2P network information.
 type P2PInfo struct {
 	Enabled  bool       `json:"enabled"`
 	Self     *PeerInfo  `json:"self,omitempty"`
 	PeerInfo []PeerInfo `json:"peers"`
 }
 
+// PeerInfo represents information about a P2P peer, including ID, addresses, and optional public key.
 type PeerInfo struct {
 	ID        string   `json:"id"`
 	Addresses []string `json:"addresses"`
 	PublicKey string   `json:"public_key,omitempty"`
 }
 
+// DisplayRegistration represents the registration status and signed messages for display in the health endpoint.
 type DisplayRegistration struct {
 	Enabled             bool                `json:"enabled"`
 	Message             string              `json:"message"`
-	DefraPKRegistration DefraPKRegistration `json:"defra_pk_registration,omitempty"`
-	PeerIDRegistration  PeerIDRegistration  `json:"peer_id_registration,omitempty"`
+	DefraPKRegistration DefraPKRegistration `json:"defra_pk_registration,omitzero"`
+	PeerIDRegistration  PeerIDRegistration  `json:"peer_id_registration,omitzero"`
 }
 
+// DefraPKRegistration represents the registration information for the host's DefraDB public key, including the signed message.
 type DefraPKRegistration struct {
 	PublicKey   string `json:"public_key,omitempty"`
 	SignedPKMsg string `json:"signed_pk_message,omitempty"`
 }
 
+// PeerIDRegistration represents the registration information for the host's P2P peer ID, including the signed message.
 type PeerIDRegistration struct {
 	PeerID        string `json:"peer_id,omitempty"`
 	SignedPeerMsg string `json:"signed_peer_message,omitempty"`
 }
 
-// HealthResponse represents the health check response
+// HealthResponse represents the health check response.
 type HealthResponse struct {
 	Status           string               `json:"status"`
 	Timestamp        time.Time            `json:"timestamp"`
 	CurrentBlock     int64                `json:"current_block,omitempty"`
-	LastProcessed    time.Time            `json:"last_processed,omitempty"`
+	LastProcessed    time.Time            `json:"last_processed,omitzero"`
 	DefraDBConnected bool                 `json:"defradb_connected"`
 	Uptime           string               `json:"uptime"`
 	UptimeSeconds    float64              `json:"uptime_seconds"`
@@ -82,7 +84,7 @@ type HealthResponse struct {
 	Registration     *DisplayRegistration `json:"registration,omitempty"`
 }
 
-// MetricsResponse represents basic metrics
+// MetricsResponse represents basic metrics.
 type MetricsResponse struct {
 	BlocksProcessed   int64     `json:"blocks_processed"`
 	CurrentBlock      int64     `json:"current_block"`
@@ -90,9 +92,9 @@ type MetricsResponse struct {
 	Uptime            string    `json:"uptime"`
 }
 
-var startTime = time.Now()
+var startTime = time.Now() // nolint:gochecknoglobals
 
-// NewHealthServer creates a new health server
+// NewHealthServer creates a new health server.
 func NewHealthServer(port int, host HealthChecker, defraURL string, metricsHandler http.Handler) *HealthServer {
 	mux := http.NewServeMux()
 
@@ -100,8 +102,8 @@ func NewHealthServer(port int, host HealthChecker, defraURL string, metricsHandl
 		server: &http.Server{
 			Addr:         fmt.Sprintf(":%d", port),
 			Handler:      mux,
-			ReadTimeout:  10 * time.Second,
-			WriteTimeout: 10 * time.Second,
+			ReadTimeout:  defaultHTTPClientTimeout * healthTimeoutMultiplier,
+			WriteTimeout: defaultHTTPClientTimeout * healthTimeoutMultiplier,
 		},
 		host:        host,
 		defraURL:    defraURL,
@@ -123,20 +125,20 @@ func NewHealthServer(port int, host HealthChecker, defraURL string, metricsHandl
 	return hs
 }
 
-// Start starts the health server
+// Start starts the health server.
 func (hs *HealthServer) Start() error {
 	logger.Sugar.Infof("Starting health server on %s", hs.server.Addr)
 	return hs.server.ListenAndServe()
 }
 
-// Stop gracefully stops the health server
+// Stop gracefully stops the health server.
 func (hs *HealthServer) Stop(ctx context.Context) error {
 	logger.Sugar.Info("Stopping health server...")
 	return hs.server.Shutdown(ctx)
 }
 
 // healthHandler handles liveness probe requests
-// Supports content negotiation: returns HTML if Accept header includes text/html, otherwise JSON
+// Supports content negotiation: returns HTML if Accept header includes text/html, otherwise JSON.
 func (hs *HealthServer) healthHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -155,7 +157,7 @@ func (hs *HealthServer) healthHandler(w http.ResponseWriter, r *http.Request) {
 		htmlContent := hs.getHealthStatusPageHTML()
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
-		w.Write(htmlContent)
+		_, _ = w.Write(htmlContent)
 		return
 	}
 
@@ -175,21 +177,21 @@ func (hs *HealthServer) healthHandler(w http.ResponseWriter, r *http.Request) {
 		response.P2P = p2p
 
 		if !hs.host.IsHealthy() {
-			response.Status = "unhealthy"
+			response.Status = statusUnhealthy
 		}
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	if response.Status == "unhealthy" {
+	if response.Status == statusUnhealthy {
 		w.WriteHeader(http.StatusServiceUnavailable)
 	}
-	json.NewEncoder(w).Encode(response)
+	_ = json.NewEncoder(w).Encode(response)
 }
 
-// getRegistrationData returns the signed registration data for the indexer
+// getRegistrationData returns the signed registration data for the indexer.
 func (hs *HealthServer) getRegistrationData() (*DisplayRegistration, error) {
 	if hs.host == nil {
-		return nil, fmt.Errorf("host not available")
+		return nil, ErrHostNotAvailable
 	}
 
 	const registrationMessage = "Shinzo Network host registration"
@@ -215,7 +217,7 @@ func (hs *HealthServer) getRegistrationData() (*DisplayRegistration, error) {
 	return registration, nil
 }
 
-// registrationHandler handles readiness probe requests
+// registrationHandler handles readiness probe requests.
 func (hs *HealthServer) registrationHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -251,7 +253,7 @@ func (hs *HealthServer) registrationHandler(w http.ResponseWriter, r *http.Reque
 		p2p, err := hs.host.GetPeerInfo()
 		response.P2P = p2p
 		if err != nil {
-			response.Status = "unhealthy"
+			response.Status = statusUnhealthy
 			w.WriteHeader(http.StatusServiceUnavailable)
 			return
 		}
@@ -266,10 +268,10 @@ func (hs *HealthServer) registrationHandler(w http.ResponseWriter, r *http.Reque
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(response)
+	_ = json.NewEncoder(w).Encode(response)
 }
 
-// registrationAppHandler redirects to the registration app with registration data as query params
+// registrationAppHandler redirects to the registration app with registration data as query params.
 func (hs *HealthServer) registrationAppHandler(w http.ResponseWriter, r *http.Request) {
 	registration, err := hs.getRegistrationData()
 	if err != nil || registration == nil || !registration.Enabled {
@@ -289,7 +291,7 @@ func (hs *HealthServer) registrationAppHandler(w http.ResponseWriter, r *http.Re
 	http.Redirect(w, r, redirectURL, http.StatusTemporaryRedirect)
 }
 
-// metricsHandler provides basic metrics in JSON format
+// metricsHandler provides basic metrics in JSON format.
 func (hs *HealthServer) metricsHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -307,17 +309,17 @@ func (hs *HealthServer) metricsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(metrics)
+	_ = json.NewEncoder(w).Encode(metrics)
 }
 
-// rootHandler handles root requests
+// rootHandler handles root requests.
 func (hs *HealthServer) rootHandler(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path != "/" {
 		http.NotFound(w, r)
 		return
 	}
 
-	response := map[string]interface{}{
+	response := map[string]any{
 		"service":   "Shinzo Network Host",
 		"version":   "1.0.0",
 		"status":    "running",
@@ -332,10 +334,13 @@ func (hs *HealthServer) rootHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(response)
+	_ = json.NewEncoder(w).Encode(response)
 }
 
-// checkDefraDB checks if DefraDB is accessible
+// defaultHTTPClientTimeout is the default timeout for HTTP client requests in health checks and registration data fetching.
+const defaultHTTPClientTimeout = 5 * time.Second
+
+// checkDefraDB checks if DefraDB is accessible.
 func (hs *HealthServer) checkDefraDB() bool {
 	if hs.defraURL == "" {
 		return true // Embedded mode, assume healthy
@@ -346,18 +351,18 @@ func (hs *HealthServer) checkDefraDB() bool {
 		return true
 	}
 
-	client := &http.Client{Timeout: 5 * time.Second}
+	client := &http.Client{Timeout: defaultHTTPClientTimeout}
 	resp, err := client.Get(hs.defraURL + "/api/v0/graphql")
 	if err != nil {
 		return false
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	return resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusBadRequest // GraphQL endpoint returns 400 for GET
 }
 
 // getHealthStatusPageHTML reads the HTML file from disk at runtime, falling back to embedded version
-// This allows hot-reloading during development without rebuilding
+// This allows hot-reloading during development without rebuilding.
 func (hs *HealthServer) getHealthStatusPageHTML() []byte {
 	// Try to read from disk first (for development hot-reload)
 	// Check multiple possible paths relative to where the binary might be running
@@ -367,7 +372,7 @@ func (hs *HealthServer) getHealthStatusPageHTML() []byte {
 	}
 
 	for _, path := range possiblePaths {
-		if data, err := os.ReadFile(path); err == nil {
+		if data, err := os.ReadFile(filepath.Clean(path)); err == nil {
 			logger.Sugar.Debugf("Loaded health status page from: %s", path)
 			return data
 		}

--- a/pkg/server/health_test.go
+++ b/pkg/server/health_test.go
@@ -216,7 +216,7 @@ func TestRegistrationHandler_PeerInfoError(t *testing.T) {
 		currentBlock:  200,
 		lastProcessed: time.Now(),
 		peerInfo:      nil,
-		peerInfoErr:   fmt.Errorf("peer info error"),
+		peerInfoErr:   errPeerInfo,
 	}
 	hs := newHS(mock, "")
 
@@ -265,7 +265,7 @@ func TestRegistrationAppHandler_NilHost(t *testing.T) {
 func TestRegistrationAppHandler_SignError(t *testing.T) {
 	mock := &mockHealthChecker{
 		healthy: true,
-		signErr: fmt.Errorf("signing error"),
+		signErr: errSigning,
 	}
 	hs := newHS(mock, "")
 
@@ -343,7 +343,7 @@ func TestRootHandler_RootPath(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code)
 	require.Contains(t, w.Header().Get("Content-Type"), "application/json")
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	require.Equal(t, "Shinzo Network Host", resp["service"])
 	require.Equal(t, "running", resp["status"])
@@ -380,7 +380,7 @@ func TestCheckDefraDB_Localhost127(t *testing.T) {
 }
 
 func TestCheckDefraDB_ExternalURL_Success(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer ts.Close()
@@ -390,7 +390,7 @@ func TestCheckDefraDB_ExternalURL_Success(t *testing.T) {
 }
 
 func TestCheckDefraDB_ExternalURL_BadRequest(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusBadRequest) // GraphQL endpoint returns 400 for GET
 	}))
 	defer ts.Close()
@@ -400,7 +400,7 @@ func TestCheckDefraDB_ExternalURL_BadRequest(t *testing.T) {
 }
 
 func TestCheckDefraDB_ExternalURL_ServerError(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer ts.Close()
@@ -505,7 +505,7 @@ func TestGetRegistrationData_WithHost(t *testing.T) {
 
 func TestGetRegistrationData_SignError(t *testing.T) {
 	mock := &mockHealthChecker{
-		signErr: fmt.Errorf("signing error"),
+		signErr: errSigning,
 	}
 	hs := newHS(mock, "")
 
@@ -628,7 +628,7 @@ func TestHealthServer_StartStop(t *testing.T) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	port := listener.Addr().(*net.TCPAddr).Port
-	listener.Close() // free the port for the server to use
+	_ = listener.Close() // free the port for the server to use
 
 	hs := NewHealthServer(port, nil, "", nil)
 
@@ -644,7 +644,7 @@ func TestHealthServer_StartStop(t *testing.T) {
 	// Verify the server is serving by making a request
 	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/", port))
 	require.NoError(t, err)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
 	// Stop the server gracefully
@@ -664,22 +664,25 @@ func TestHealthServer_StartStop(t *testing.T) {
 
 func TestCheckDefraDB_ExternalURL_ServerError_CustomListener(t *testing.T) {
 	// Create a test server that returns 500
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer ts.Close()
 
 	// httptest URLs use 127.0.0.1 which checkDefraDB short-circuits as localhost.
 	// Use a custom listener on 0.0.0.0 to exercise the HTTP request path.
-	_ = ts // ts is not used since its URL contains 127.0.0.1
-	listener, err := net.Listen("tcp", "0.0.0.0:0")
+	_ = ts                                          // ts is not used since its URL contains 127.0.0.1
+	listener, err := net.Listen("tcp", "0.0.0.0:0") // nolint:gosec
 	require.NoError(t, err)
 
-	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-	})}
-	go srv.Serve(listener)
-	defer srv.Close()
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}),
+		ReadHeaderTimeout: defaultTimeout,
+	}
+	go func() { _ = srv.Serve(listener) }()
+	defer func() { _ = srv.Close() }()
 
 	// Get the port and construct a URL without localhost/127.0.0.1
 	port := listener.Addr().(*net.TCPAddr).Port
@@ -690,14 +693,17 @@ func TestCheckDefraDB_ExternalURL_ServerError_CustomListener(t *testing.T) {
 }
 
 func TestCheckDefraDB_ExternalURL_200_CustomListener(t *testing.T) {
-	listener, err := net.Listen("tcp", "0.0.0.0:0")
+	listener, err := net.Listen("tcp", "0.0.0.0:0") //nolint:gosec // test server, binding to all interfaces is intentional
 	require.NoError(t, err)
 
-	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})}
-	go srv.Serve(listener)
-	defer srv.Close()
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+		ReadHeaderTimeout: defaultTimeout,
+	}
+	go func() { _ = srv.Serve(listener) }()
+	defer func() { _ = srv.Close() }()
 
 	port := listener.Addr().(*net.TCPAddr).Port
 	url := fmt.Sprintf("http://0.0.0.0:%d", port)
@@ -706,14 +712,17 @@ func TestCheckDefraDB_ExternalURL_200_CustomListener(t *testing.T) {
 }
 
 func TestCheckDefraDB_ExternalURL_400_CustomListener(t *testing.T) {
-	listener, err := net.Listen("tcp", "0.0.0.0:0")
+	listener, err := net.Listen("tcp", "0.0.0.0:0") // nolint:gosec
 	require.NoError(t, err)
 
-	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusBadRequest)
-	})}
-	go srv.Serve(listener)
-	defer srv.Close()
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+		}),
+		ReadHeaderTimeout: defaultTimeout,
+	}
+	go func() { _ = srv.Serve(listener) }()
+	defer func() { _ = srv.Close() }()
 
 	port := listener.Addr().(*net.TCPAddr).Port
 	url := fmt.Sprintf("http://0.0.0.0:%d", port)
@@ -732,7 +741,7 @@ func TestRegistrationHandler_SignError_PeerInfoOK(t *testing.T) {
 		lastProcessed: time.Now(),
 		peerInfo:      &P2PInfo{Enabled: true},
 		peerInfoErr:   nil,
-		signErr:       fmt.Errorf("signing not configured"),
+		signErr:       errSigningNotConfigured,
 	}
 	hs := newHS(mock, "")
 
@@ -764,7 +773,7 @@ func TestGetHealthStatusPageHTML_DiskReadPath(t *testing.T) {
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "health_status_page.html")
 	testContent := "<html><body>test health page</body></html>"
-	err := os.WriteFile(tmpFile, []byte(testContent), 0644)
+	err := os.WriteFile(tmpFile, []byte(testContent), 0o600)
 	require.NoError(t, err)
 
 	// Override the package-level path to point to our temp file

--- a/pkg/server/metrics.go
+++ b/pkg/server/metrics.go
@@ -18,11 +18,9 @@ import (
 //go:embed metrics_client_page.html
 var embeddedMetricsClientPageHTML string
 
-var (
-	metricsClientPagePath = filepath.Join("pkg", "server", "metrics_client_page.html")
-)
+var metricsClientPagePath = filepath.Join("pkg", "server", "metrics_client_page.html") //nolint:gochecknoglobals
 
-// HostMetrics tracks various metrics for the host
+// HostMetrics tracks various metrics for the host.
 type HostMetrics struct {
 	// Attestation metrics
 	AttestationsCreated    int64 `json:"attestations_created"`
@@ -44,7 +42,7 @@ type HostMetrics struct {
 	ViewsActive     int64 `json:"views_active"`
 
 	// Internal fields for atomic float64 operations
-	lastProcessingTimeBits uint64 `json:"-"`
+	lastProcessingTimeBits atomic.Uint64 `json:"-"`
 
 	// Performance metrics
 	LastProcessingTime float64 `json:"last_processing_time_ms"`
@@ -59,7 +57,7 @@ type HostMetrics struct {
 	SchemaType string `json:"schema_type"`
 }
 
-// NewHostMetrics creates a new metrics instance
+// NewHostMetrics creates a new metrics instance.
 func NewHostMetrics() *HostMetrics {
 	buildTags := "standard"
 	schemaType := "non-branchable"
@@ -71,38 +69,38 @@ func NewHostMetrics() *HostMetrics {
 	}
 }
 
-// IncrementAttestationsCreated atomically increments the attestations created counter
+// IncrementAttestationsCreated atomically increments the attestations created counter.
 func (m *HostMetrics) IncrementAttestationsCreated() {
 	atomic.AddInt64(&m.AttestationsCreated, 1)
 }
 
-// IncrementAttestationErrors atomically increments the attestation errors counter
+// IncrementAttestationErrors atomically increments the attestation errors counter.
 func (m *HostMetrics) IncrementAttestationErrors() {
 	atomic.AddInt64(&m.AttestationErrors, 1)
 }
 
-// IncrementSignatureVerifications atomically increments the signature verifications counter
+// IncrementSignatureVerifications atomically increments the signature verifications counter.
 func (m *HostMetrics) IncrementSignatureVerifications() {
 	atomic.AddInt64(&m.SignatureVerifications, 1)
 }
 
-// IncrementSignatureFailures atomically increments the signature failures counter
+// IncrementSignatureFailures atomically increments the signature failures counter.
 func (m *HostMetrics) IncrementSignatureFailures() {
 	atomic.AddInt64(&m.SignatureFailures, 1)
 }
 
-// IncrementBlockSigEventsReceived atomically increments the block sig events received counter
+// IncrementBlockSigEventsReceived atomically increments the block sig events received counter.
 func (m *HostMetrics) IncrementBlockSigEventsReceived() {
 	atomic.AddInt64(&m.BlockSigEventsReceived, 1)
 }
 
-// IncrementDocumentsReceived atomically increments the documents received counter
+// IncrementDocumentsReceived atomically increments the documents received counter.
 func (m *HostMetrics) IncrementDocumentsReceived() {
 	atomic.AddInt64(&m.DocumentsReceived, 1)
 	m.LastDocumentTime = time.Now()
 }
 
-// IncrementDocumentByType atomically increments the counter for a specific document type
+// IncrementDocumentByType atomically increments the counter for a specific document type.
 func (m *HostMetrics) IncrementDocumentByType(docType string) {
 	switch docType {
 	case constants.CollectionBlock:
@@ -118,24 +116,24 @@ func (m *HostMetrics) IncrementDocumentByType(docType string) {
 	}
 }
 
-// IncrementViewsRegistered atomically increments the views registered counter
+// IncrementViewsRegistered atomically increments the views registered counter.
 func (m *HostMetrics) IncrementViewsRegistered() {
 	atomic.AddInt64(&m.ViewsRegistered, 1)
 }
 
-// SetViewsActive sets the number of active views
+// SetViewsActive sets the number of active views.
 func (m *HostMetrics) SetViewsActive(count int64) {
 	atomic.StoreInt64(&m.ViewsActive, count)
 }
 
-// UpdateLastProcessingTime updates the last processing time in milliseconds
+// UpdateLastProcessingTime updates the last processing time in milliseconds.
 func (m *HostMetrics) UpdateLastProcessingTime(avgMs float64) {
 	// For float64, we need to use atomic operations with bits
-	bits := *(*uint64)(unsafe.Pointer(&avgMs))
-	atomic.StoreUint64(&m.lastProcessingTimeBits, bits)
+	bits := *(*uint64)(unsafe.Pointer(&avgMs)) //nolint:gosec // unsafe pointer used for float64 to uint64 bit conversion
+	m.lastProcessingTimeBits.Store(bits)
 }
 
-// UpdateMostRecentBlock updates the most recent block number
+// UpdateMostRecentBlock updates the most recent block number.
 func (m *HostMetrics) UpdateMostRecentBlock(blockNumber uint64) {
 	for {
 		current := atomic.LoadUint64(&m.MostRecentBlock)
@@ -148,10 +146,11 @@ func (m *HostMetrics) UpdateMostRecentBlock(blockNumber uint64) {
 	}
 }
 
+// GetSnapshot returns a snapshot of the current metrics, loading atomic values safely.
 func (m *HostMetrics) GetSnapshot() *HostMetrics {
 	// Load float64 values from atomic storage
-	lastProcessingTimeBits := atomic.LoadUint64(&m.lastProcessingTimeBits)
-	lastProcessingTime := *(*float64)(unsafe.Pointer(&lastProcessingTimeBits))
+	lastProcessingTimeBits := m.lastProcessingTimeBits.Load()
+	lastProcessingTime := *(*float64)(unsafe.Pointer(&lastProcessingTimeBits)) // nolint:gosec // unsafe pointer used for float64 to uint64 bit conversion
 
 	return &HostMetrics{
 		AttestationsCreated:      atomic.LoadInt64(&m.AttestationsCreated),
@@ -177,7 +176,7 @@ func (m *HostMetrics) GetSnapshot() *HostMetrics {
 	}
 }
 
-// ServeHTTP implements http.Handler for the metrics endpoint
+// ServeHTTP implements http.Handler for the metrics endpoint.
 func (m *HostMetrics) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Content negotiation: Default to HTML for browsers, only serve JSON if explicitly requested
 	accept := r.Header.Get("Accept")
@@ -190,7 +189,7 @@ func (m *HostMetrics) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		htmlContent := m.getMetricsClientPageHTML()
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(htmlContent))
+		_, _ = w.Write(htmlContent)
 		return
 	}
 
@@ -202,7 +201,7 @@ func (m *HostMetrics) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Add computed metrics
 	uptime := time.Since(snapshot.StartTime)
 
-	response := map[string]interface{}{
+	response := map[string]any{
 		"metrics":        snapshot,
 		"current_block":  snapshot.MostRecentBlock,
 		"timestamp":      time.Now().Unix(),
@@ -217,8 +216,8 @@ func (m *HostMetrics) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // getMetricsClientPageHTML reads the HTML file from disk at runtime, falling back to embedded version
-// This allows hot-reloading during development without rebuilding
-func (ms *HostMetrics) getMetricsClientPageHTML() []byte {
+// This allows hot-reloading during development without rebuilding.
+func (m *HostMetrics) getMetricsClientPageHTML() []byte {
 	// Try to read from disk first (for development hot-reload)
 	// Check multiple possible paths relative to where the binary might be running
 	possiblePaths := []string{
@@ -227,7 +226,7 @@ func (ms *HostMetrics) getMetricsClientPageHTML() []byte {
 	}
 
 	for _, path := range possiblePaths {
-		if data, err := os.ReadFile(path); err == nil {
+		if data, err := os.ReadFile(filepath.Clean(path)); err == nil {
 			logger.Sugar.Debugf("Loaded metrics client page from: %s", path)
 			return data
 		}

--- a/pkg/server/metrics.go
+++ b/pkg/server/metrics.go
@@ -11,8 +11,8 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/constants"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
 )
 
 //go:embed metrics_client_page.html

--- a/pkg/server/metrics_test.go
+++ b/pkg/server/metrics_test.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"encoding/json"
-	"fmt"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -80,7 +79,6 @@ func TestIncrementBlockSigEventsReceived(t *testing.T) {
 	require.Equal(t, int64(1), atomic.LoadInt64(&m.BlockSigEventsReceived))
 }
 
-
 func TestIncrementDocumentsReceived(t *testing.T) {
 	m := NewHostMetrics()
 	m.IncrementDocumentsReceived()
@@ -95,14 +93,14 @@ func TestIncrementViewsRegistered(t *testing.T) {
 	require.Equal(t, int64(2), atomic.LoadInt64(&m.ViewsRegistered))
 }
 
-// Test atomic behaviour under concurrency
+// Test atomic behavior under concurrency.
 func TestIncrementConcurrent(t *testing.T) {
 	m := NewHostMetrics()
 	const goroutines = 100
 
 	var wg sync.WaitGroup
 	wg.Add(goroutines)
-	for i := 0; i < goroutines; i++ {
+	for range goroutines {
 		go func() {
 			defer wg.Done()
 			m.IncrementAttestationsCreated()
@@ -162,7 +160,6 @@ func TestIncrementDocumentByType(t *testing.T) {
 		require.Equal(t, int64(0), atomic.LoadInt64(&m.BlockSignaturesProcessed))
 	})
 }
-
 
 // ---------------------------------------------------------------------------
 // SetViewsActive
@@ -233,7 +230,7 @@ func TestUpdateMostRecentBlock_CASRetry(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(goroutines)
-	for i := 0; i < goroutines; i++ {
+	for i := range goroutines {
 		go func(n uint64) {
 			defer wg.Done()
 			m.UpdateMostRecentBlock(n)
@@ -310,7 +307,7 @@ func TestServeHTTP_JSON(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code)
 	require.Contains(t, w.Header().Get("Content-Type"), "application/json")
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 
 	require.Contains(t, resp, "metrics")
@@ -389,15 +386,15 @@ func newFailWriter() *failWriter {
 	return &failWriter{header: make(http.Header)}
 }
 
-func (w *failWriter) Header() http.Header         { return w.header }
-func (w *failWriter) WriteHeader(statusCode int)   { w.statusCode = statusCode }
-func (w *failWriter) Write(b []byte) (int, error) {
+func (w *failWriter) Header() http.Header        { return w.header }
+func (w *failWriter) WriteHeader(statusCode int) { w.statusCode = statusCode }
+func (w *failWriter) Write(_ []byte) (int, error) {
 	if !w.written {
 		// Let the first write through (for the Content-Type / status), then fail
 		w.written = true
-		return 0, fmt.Errorf("simulated write error")
+		return 0, errSimulatedWrite
 	}
-	return 0, fmt.Errorf("simulated write error")
+	return 0, errSimulatedWrite
 }
 
 func TestServeHTTP_JSONEncodeError(t *testing.T) {
@@ -428,7 +425,7 @@ func TestGetMetricsClientPageHTML_DiskReadPath(t *testing.T) {
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "metrics_client_page.html")
 	testContent := "<html><body>test metrics page</body></html>"
-	err := os.WriteFile(tmpFile, []byte(testContent), 0644)
+	err := os.WriteFile(filepath.Clean(tmpFile), []byte(testContent), 0o600)
 	require.NoError(t, err)
 
 	// Override the package-level path to point to our temp file

--- a/pkg/shinzohub/constants.go
+++ b/pkg/shinzohub/constants.go
@@ -1,0 +1,10 @@
+package shinzohub
+
+import "time"
+
+const (
+	pingIntervalSecs = 15
+	pingMessageID    = 999
+	defaultPageSize  = 5
+	defaultTimeout   = 5 * time.Second
+)

--- a/pkg/shinzohub/entityRegistered_test.go
+++ b/pkg/shinzohub/entityRegistered_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestHostRegisteredEventSubscription tests the subscription to HostRegistered events via WebSocket
+// TestHostRegisteredEventSubscription tests the subscription to HostRegistered events via WebSocket.
 func TestHostRegisteredEventSubscription(t *testing.T) {
 	mockServer := NewMockWebSocketServer()
 	defer mockServer.Close()
@@ -20,7 +20,7 @@ func TestHostRegisteredEventSubscription(t *testing.T) {
 	defer cancel()
 
 	mockEvent := RPCResponse{
-		JsonRpcVersion: "2.0",
+		JSONRPCVersion: "2.0",
 		ID:             2,
 		Result: RPCResult{
 			Query: "tm.event='Tx' AND HostRegistered.owner EXISTS",
@@ -77,10 +77,10 @@ func TestHostRegisteredEventSubscription(t *testing.T) {
 	}
 }
 
-// TestExtractHostAndIndexerRegisteredEvents tests the extraction function directly
+// TestExtractHostAndIndexerRegisteredEvents tests the extraction function directly.
 func TestExtractHostAndIndexerRegisteredEvents(t *testing.T) {
 	testMsg := RPCResponse{
-		JsonRpcVersion: "2.0",
+		JSONRPCVersion: "2.0",
 		ID:             1,
 		Result: RPCResult{
 			Data: RPCData{
@@ -151,7 +151,7 @@ func TestExtractHostAndIndexerRegisteredEvents(t *testing.T) {
 	require.Equal(t, "1", indexerEvent.SourceChainID)
 }
 
-// TestMixedEventSubscription tests receiving ViewRegistered and HostRegistered events together
+// TestMixedEventSubscription tests receiving ViewRegistered and HostRegistered events together.
 func TestMixedEventSubscription(t *testing.T) {
 	mockServer := NewMockWebSocketServer()
 	defer mockServer.Close()
@@ -184,7 +184,7 @@ func TestMixedEventSubscription(t *testing.T) {
 
 	// Send a mixed event with ViewRegistered and HostRegistered
 	mixedEvent := RPCResponse{
-		JsonRpcVersion: "2.0",
+		JSONRPCVersion: "2.0",
 		ID:             1,
 		Result: RPCResult{
 			Data: RPCData{
@@ -266,7 +266,7 @@ func TestMixedEventSubscription(t *testing.T) {
 	}
 }
 
-// TestHostRegisteredEventToString tests the string representation
+// TestHostRegisteredEventToString tests the string representation.
 func TestHostRegisteredEventToString(t *testing.T) {
 	event := HostRegisteredEvent{
 		Owner:            "shinzo1k2e3g3696x7ycdz5tlqslplpgyh3dwy7e7jarm",
@@ -278,7 +278,7 @@ func TestHostRegisteredEventToString(t *testing.T) {
 	require.Equal(t, expected, event.ToString())
 }
 
-// TestIndexerRegisteredEventToString tests the string representation
+// TestIndexerRegisteredEventToString tests the string representation.
 func TestIndexerRegisteredEventToString(t *testing.T) {
 	event := IndexerRegisteredEvent{
 		Owner:            "shinzo1k2e3g3696x7ycdz5tlqslplpgyh3dwy7e7jarm",

--- a/pkg/shinzohub/errors.go
+++ b/pkg/shinzohub/errors.go
@@ -1,0 +1,9 @@
+package shinzohub
+
+import "errors"
+
+var ( //nolint:revive
+	ErrTendermintConnection = errors.New("tenderMint connection failure") //nolint:revive
+	ErrHTTPErrorResponse    = errors.New("HTTP error response")           //nolint:revive
+	ErrViewHasNoQuery       = errors.New("view has no query")             //nolint:revive
+)

--- a/pkg/shinzohub/events.go
+++ b/pkg/shinzohub/events.go
@@ -21,6 +21,7 @@ func log() *zap.SugaredLogger {
 	return zap.NewNop().Sugar()
 }
 
+// RPCResponse represents the structure of a RPCResponse.
 type RPCResponse struct {
 	JSONRPCVersion string    `json:"jsonrpc"`
 	ID             int       `json:"id"`
@@ -80,10 +81,18 @@ type ShinzoEvent interface {
 
 // subscriptionQueries are the CometBFT event queries the host subscribes to.
 // Tendermint doesn't support OR logic, so each event type gets its own subscription.
-var subscriptionQueries = []string{
-	"tm.event='Tx' AND ViewRegistered.view_address EXISTS",
-	"tm.event='Tx' AND HostRegistered.owner EXISTS",
-	"tm.event='Tx' AND IndexerRegistered.owner EXISTS",
+// var subscriptionQueries = []string{
+// 	"tm.event='Tx' AND ViewRegistered.view_address EXISTS",
+// 	"tm.event='Tx' AND HostRegistered.owner EXISTS",
+// 	"tm.event='Tx' AND IndexerRegistered.owner EXISTS",
+// }
+
+func getSubscriptionQueries() []string {
+	return []string{
+		"tm.event='Tx' AND ViewRegistered.view_address EXISTS",
+		"tm.event='Tx' AND HostRegistered.owner EXISTS",
+		"tm.event='Tx' AND IndexerRegistered.owner EXISTS",
+	}
 }
 
 // StartEventSubscription connects to the CometBFT WebSocket, subscribes to
@@ -93,7 +102,7 @@ var subscriptionQueries = []string{
 // reconnections; it is only closed when ctx is cancelled.
 func StartEventSubscription(tendermintURL string) (context.CancelFunc, <-chan ShinzoEvent, error) {
 	ctx, cancel := context.WithCancel(context.Background())
-	eventChan := make(chan ShinzoEvent, 16)
+	eventChan := make(chan ShinzoEvent, 16) //nolint:mnd
 
 	// Verify the URL is reachable before returning to the caller. This
 	// catches typos and DNS failures at startup instead of silently
@@ -112,31 +121,40 @@ func StartEventSubscription(tendermintURL string) (context.CancelFunc, <-chan Sh
 // dialAndSubscribe opens a WebSocket to the CometBFT node and sends all
 // subscription requests. Returns the live connection or an error.
 func dialAndSubscribe(url string) (*websocket.Conn, error) {
-	conn, _, err := websocket.DefaultDialer.Dial(url, nil)
+	conn, resp, err := websocket.DefaultDialer.Dial(url, nil)
+	if resp != nil {
+		if cerr := resp.Body.Close(); cerr != nil {
+			log().Warnf("failed to close dial response body: %v", cerr)
+		}
+	}
 	if err != nil {
 		return nil, fmt.Errorf("dial %s: %w", url, err)
 	}
 
-	for i, query := range subscriptionQueries {
-		msg := map[string]interface{}{
+	for i, query := range getSubscriptionQueries() {
+		msg := map[string]any{
 			"jsonrpc": "2.0",
 			"method":  "subscribe",
 			"id":      i + 1,
-			"params":  map[string]interface{}{"query": query},
+			"params":  map[string]any{"query": query},
 		}
 		if err := conn.WriteJSON(msg); err != nil {
-			conn.Close()
+			if err := conn.Close(); err != nil {
+				log().Warnf("failed to close websocket connection: %v", err)
+			}
 			return nil, fmt.Errorf("subscribe query %d: %w", i, err)
 		}
 		_, resp, err := conn.ReadMessage()
 		if err != nil {
-			conn.Close()
+			if err := conn.Close(); err != nil {
+				log().Warnf("failed to close websocket connection: %v", err)
+			}
 			return nil, fmt.Errorf("subscribe response %d: %w", i, err)
 		}
 		log().Debugf("subscription %d accepted: %s", i+1, string(resp))
 	}
 
-	log().Infof("WebSocket connected to %s with %d subscriptions", url, len(subscriptionQueries))
+	log().Infof("WebSocket connected to %s with %d subscriptions", url, len(getSubscriptionQueries()))
 	return conn, nil
 }
 
@@ -146,74 +164,112 @@ func dialAndSubscribe(url string) (*websocket.Conn, error) {
 // resumes reading. The channel is closed only when ctx is cancelled.
 func eventLoop(ctx context.Context, url string, conn *websocket.Conn, out chan<- ShinzoEvent) {
 	defer close(out)
-	defer func() {
-		if r := recover(); r != nil {
-			log().Errorf("WebSocket event loop recovered from panic: %v", r)
-		}
-	}()
+	defer recoverPanic()
 
 	backoff := time.Second
 	const maxBackoff = 60 * time.Second
-
 	pingStop := startPing(ctx, conn)
 	connectedAt := time.Now()
 
-	// ReadMessage blocks until data arrives. A read deadline lets the loop
-	// wake up periodically to check ctx cancellation during graceful shutdown.
-	const readTimeout = 30 * time.Second
-
 	for {
 		if ctx.Err() != nil {
-			conn.Close()
+			closeConn(conn)
 			return
 		}
 
-		conn.SetReadDeadline(time.Now().Add(readTimeout))
-		_, message, err := conn.ReadMessage()
-		if err != nil {
-			if ctx.Err() != nil {
-				conn.Close()
-				return
-			}
-			if isTimeoutError(err) {
-				continue
-			}
-
-			// Connection failure (reset by peer, server close, etc). Reconnect.
-			pingStop()
-			conn.Close()
-			log().Warnf("WebSocket read failed: %v; reconnecting in ~%v", err, backoff)
-
-			conn = reconnect(ctx, url, &backoff, maxBackoff)
-			if conn == nil {
-				return
-			}
-			pingStop = startPing(ctx, conn)
-			connectedAt = time.Now()
-			continue
-		}
-
-		// Reset backoff only after the connection has been stable for a while.
-		// This prevents a flapping connection from resetting to 1s on every
-		// brief reconnect.
-		if time.Since(connectedAt) > 60*time.Second {
-			backoff = time.Second
-		}
-
-		var msg RPCResponse
-		if err := json.Unmarshal(message, &msg); err != nil {
-			continue
-		}
-
-		for _, ev := range extractShinzoEvents(msg) {
-			select {
-			case out <- ev:
-			case <-ctx.Done():
-				conn.Close()
-				return
-			}
+		conn, pingStop, connectedAt, backoff = processNextMessage(
+			ctx, url, conn, out, pingStop, connectedAt, backoff, maxBackoff,
+		)
+		if conn == nil {
+			return
 		}
 	}
+}
+
+// recoverPanic from event loop.
+func recoverPanic() {
+	if r := recover(); r != nil {
+		log().Errorf("WebSocket event loop recovered from panic: %v", r)
+	}
+}
+
+// closeConn from event loop.
+func closeConn(conn *websocket.Conn) {
+	if err := conn.Close(); err != nil {
+		log().Warnf("failed to close websocket connection: %v", err)
+	}
+}
+
+// processNextMessage in event loop.
+func processNextMessage(
+	ctx context.Context,
+	url string,
+	conn *websocket.Conn,
+	out chan<- ShinzoEvent,
+	pingStop func(),
+	connectedAt time.Time,
+	backoff, maxBackoff time.Duration,
+) (*websocket.Conn, func(), time.Time, time.Duration) {
+	const readTimeout = 30 * time.Second
+
+	if err := conn.SetReadDeadline(time.Now().Add(readTimeout)); err != nil {
+		log().Warnf("failed to set read deadline: %v", err)
+	}
+
+	_, message, err := conn.ReadMessage()
+	if err != nil {
+		return handleReadError(ctx, url, conn, pingStop, backoff, maxBackoff, err)
+	}
+
+	if time.Since(connectedAt) > 60*time.Second {
+		backoff = time.Second
+	}
+
+	conn = dispatchEvents(ctx, conn, out, message)
+	return conn, pingStop, connectedAt, backoff
+}
+
+// handleReadError in event loop.
+func handleReadError(
+	ctx context.Context,
+	url string,
+	conn *websocket.Conn,
+	pingStop func(),
+	backoff, maxBackoff time.Duration,
+	err error,
+) (*websocket.Conn, func(), time.Time, time.Duration) {
+	if ctx.Err() != nil {
+		closeConn(conn)
+		return nil, nil, time.Time{}, backoff
+	}
+	if isTimeoutError(err) {
+		return conn, pingStop, time.Now(), backoff
+	}
+	pingStop()
+	closeConn(conn)
+	log().Warnf("WebSocket read failed: %v; reconnecting in ~%v", err, backoff)
+	conn = reconnect(ctx, url, &backoff, maxBackoff)
+	if conn == nil {
+		return nil, nil, time.Time{}, backoff
+	}
+	return conn, startPing(ctx, conn), time.Now(), backoff
+}
+
+// dispatchEvents from event loop.
+func dispatchEvents(ctx context.Context, conn *websocket.Conn, out chan<- ShinzoEvent, message []byte) *websocket.Conn {
+	var msg RPCResponse
+	if err := json.Unmarshal(message, &msg); err != nil {
+		return conn
+	}
+	for _, ev := range extractShinzoEvents(msg) {
+		select {
+		case out <- ev:
+		case <-ctx.Done():
+			closeConn(conn)
+			return nil
+		}
+	}
+	return conn
 }
 
 // isTimeoutError checks whether the error is a read deadline timeout.
@@ -230,8 +286,8 @@ func isTimeoutError(err error) bool {
 func reconnect(ctx context.Context, url string, backoff *time.Duration, maxBackoff time.Duration) *websocket.Conn {
 	for {
 		// Add jitter: sleep for backoff +/- 25% to spread reconnection attempts.
-		jitter := time.Duration(rand.Int64N(int64(*backoff) / 2))
-		wait := *backoff + jitter - (*backoff / 4)
+		jitter := time.Duration(rand.Int64N(int64(*backoff) / 2)) //nolint:gosec,mnd
+		wait := *backoff + jitter - (*backoff / 4)                // nolint:mnd
 
 		select {
 		case <-ctx.Done():
@@ -260,18 +316,18 @@ func reconnect(ctx context.Context, url string, backoff *time.Duration, maxBacko
 func startPing(ctx context.Context, conn *websocket.Conn) context.CancelFunc {
 	pingCtx, pingCancel := context.WithCancel(ctx)
 	go func() {
-		ticker := time.NewTicker(15 * time.Second)
+		ticker := time.NewTicker(15 * time.Second) // nolint:mnd
 		defer ticker.Stop()
 		for {
 			select {
 			case <-pingCtx.Done():
 				return
 			case <-ticker.C:
-				msg := map[string]interface{}{
+				msg := map[string]any{
 					"jsonrpc": "2.0",
 					"method":  "status",
-					"id":      999,
-					"params":  map[string]interface{}{},
+					"id":      999, // nolint:mnd
+					"params":  map[string]any{},
 				}
 				if err := conn.WriteJSON(msg); err != nil {
 					return
@@ -285,7 +341,7 @@ func startPing(ctx context.Context, conn *websocket.Conn) context.CancelFunc {
 // extractShinzoEvents extracts typed events from an RPC response.
 func extractShinzoEvents(msg RPCResponse) []ShinzoEvent {
 	var events []ShinzoEvent
-	if msg.JsonRpcVersion != "2.0" ||
+	if msg.JSONRPCVersion != "2.0" ||
 		msg.Result.Data.Type != "tendermint/event/Tx" ||
 		msg.Result.Data.Value.TxResult.Result.Events == nil {
 		return nil
@@ -294,82 +350,94 @@ func extractShinzoEvents(msg RPCResponse) []ShinzoEvent {
 	for _, event := range msg.Result.Data.Value.TxResult.Result.Events {
 		switch event.Type {
 		case "ViewRegistered":
-			registeredEvent := ViewRegisteredEvent{}
-
-			for _, attr := range event.Attributes {
-				switch attr.Key {
-				case "view_address":
-					registeredEvent.ViewAddress = attr.Value
-				case "view_name":
-					registeredEvent.ViewName = attr.Value
-				case "creator":
-					registeredEvent.Creator = attr.Value
-				case "data":
-					newView, err := ProcessViewFromWireFormat(attr.Value)
-					if err != nil {
-						log().Warnf("failed to process view from wire: %v", err)
-						continue
-					}
-					registeredEvent.View = newView
-				}
+			if e := parseViewRegisteredEvent(event); e != nil {
+				events = append(events, e)
 			}
-
-			if registeredEvent.ViewAddress != "" && registeredEvent.Creator != "" && registeredEvent.View.Data.Query != "" {
-				log().Infof("ViewRegistered event received: %s", registeredEvent.View.Name)
-				events = append(events, &registeredEvent)
-			} else {
-				log().Debugf("incomplete ViewRegistered event: %+v", registeredEvent)
-			}
-
 		case "HostRegistered":
-			hostEvent := HostRegisteredEvent{}
-
-			for _, attr := range event.Attributes {
-				switch attr.Key {
-				case "owner":
-					hostEvent.Owner = attr.Value
-				case "did":
-					hostEvent.DID = attr.Value
-				case "connection_string":
-					hostEvent.ConnectionString = attr.Value
-				}
+			if e := parseHostRegisteredEvent(event); e != nil {
+				events = append(events, e)
 			}
-
-			if hostEvent.Owner != "" && hostEvent.DID != "" {
-				log().Infof("HostRegistered event received: owner=%s did=%s",
-					hostEvent.Owner, hostEvent.DID)
-				events = append(events, &hostEvent)
-			} else {
-				log().Debugf("incomplete HostRegistered event: %+v", hostEvent)
-			}
-
 		case "IndexerRegistered":
-			indexerEvent := IndexerRegisteredEvent{}
-
-			for _, attr := range event.Attributes {
-				switch attr.Key {
-				case "owner":
-					indexerEvent.Owner = attr.Value
-				case "did":
-					indexerEvent.DID = attr.Value
-				case "connection_string":
-					indexerEvent.ConnectionString = attr.Value
-				case "source_chain":
-					indexerEvent.SourceChain = attr.Value
-				case "source_chain_id":
-					indexerEvent.SourceChainID = attr.Value
-				}
-			}
-
-			if indexerEvent.Owner != "" && indexerEvent.DID != "" {
-				log().Infof("IndexerRegistered event received: owner=%s did=%s chain=%s/%s",
-					indexerEvent.Owner, indexerEvent.DID, indexerEvent.SourceChain, indexerEvent.SourceChainID)
-				events = append(events, &indexerEvent)
-			} else {
-				log().Debugf("incomplete IndexerRegistered event: %+v", indexerEvent)
+			if e := parseIndexerRegisteredEvent(event); e != nil {
+				events = append(events, e)
 			}
 		}
 	}
 
 	return events
+}
+
+// parseViewRegisteredEvent parses view registration events.
+func parseViewRegisteredEvent(event Event) ShinzoEvent {
+	e := ViewRegisteredEvent{}
+	for _, attr := range event.Attributes {
+		switch attr.Key {
+		case "view_address":
+			e.ViewAddress = attr.Value
+		case "view_name":
+			e.ViewName = attr.Value
+		case "creator":
+			e.Creator = attr.Value
+		case "data":
+			newView, err := ProcessViewFromWireFormat(attr.Value)
+			if err != nil {
+				log().Warnf("failed to process view from wire: %v", err)
+				continue
+			}
+			e.View = newView
+		}
+	}
+	if e.ViewAddress != "" && e.Creator != "" && e.View.Data.Query != "" {
+		log().Infof("ViewRegistered event received: %s", e.View.Name)
+		return &e
+	}
+	log().Debugf("incomplete ViewRegistered event: %+v", e)
+	return nil
+}
+
+// parseHostRegisteredEvent parse host registration events.
+func parseHostRegisteredEvent(event Event) ShinzoEvent {
+	e := HostRegisteredEvent{}
+	for _, attr := range event.Attributes {
+		switch attr.Key {
+		case "owner":
+			e.Owner = attr.Value
+		case "did":
+			e.DID = attr.Value
+		case "connection_string":
+			e.ConnectionString = attr.Value
+		}
+	}
+	if e.Owner != "" && e.DID != "" {
+		log().Infof("HostRegistered event received: owner=%s did=%s", e.Owner, e.DID)
+		return &e
+	}
+	log().Debugf("incomplete HostRegistered event: %+v", e)
+	return nil
+}
+
+// parseIndexerRegisteredEvent parse indexer registration events.
+func parseIndexerRegisteredEvent(event Event) ShinzoEvent {
+	e := IndexerRegisteredEvent{}
+	for _, attr := range event.Attributes {
+		switch attr.Key {
+		case "owner":
+			e.Owner = attr.Value
+		case "did":
+			e.DID = attr.Value
+		case "connection_string":
+			e.ConnectionString = attr.Value
+		case "source_chain":
+			e.SourceChain = attr.Value
+		case "source_chain_id":
+			e.SourceChainID = attr.Value
+		}
+	}
+	if e.Owner != "" && e.DID != "" {
+		log().Infof("IndexerRegistered event received: owner=%s did=%s chain=%s/%s",
+			e.Owner, e.DID, e.SourceChain, e.SourceChainID)
+		return &e
+	}
+	log().Debugf("incomplete IndexerRegistered event: %+v", e)
+	return nil
 }

--- a/pkg/shinzohub/events.go
+++ b/pkg/shinzohub/events.go
@@ -22,25 +22,29 @@ func log() *zap.SugaredLogger {
 }
 
 type RPCResponse struct {
-	JsonRpcVersion string    `json:"jsonrpc"`
+	JSONRPCVersion string    `json:"jsonrpc"`
 	ID             int       `json:"id"`
 	Result         RPCResult `json:"result"`
 }
 
+// RPCResult represents the structure of a Tendermint event received from the WebSocket.
 type RPCResult struct {
 	Query string  `json:"query"`
 	Data  RPCData `json:"data"`
 }
 
+// RPCData represents the data structure of a Tendermint event received from the WebSocket.
 type RPCData struct {
 	Type  string   `json:"type"`
 	Value TxResult `json:"value"`
 }
 
+// TxResult represents the structure of a transaction result received from Tendermint.
 type TxResult struct {
 	TxResult TxResultData `json:"TxResult"`
 }
 
+// TxResultData represents the data structure of a transaction result in Tendermint.
 type TxResultData struct {
 	Height string         `json:"height"`
 	Tx     string         `json:"tx"`
@@ -48,6 +52,7 @@ type TxResultData struct {
 	Events []Event        `json:"events"`
 }
 
+// TxResultResult represents the result of a transaction execution in Tendermint.
 type TxResultResult struct {
 	Data      string  `json:"data"`
 	Events    []Event `json:"events"`
@@ -55,17 +60,20 @@ type TxResultResult struct {
 	GasWanted string  `json:"gas_wanted"`
 }
 
+// Event represents a Tendermint event with a type and attributes.
 type Event struct {
 	Type       string           `json:"type"`
 	Attributes []EventAttribute `json:"attributes"`
 }
 
+// EventAttribute represents a key-value pair attribute of a Tendermint event, with an index flag.
 type EventAttribute struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`
 	Index bool   `json:"index"`
 }
 
+// ShinzoEvent is an interface that all Shinzo events implement, allowing them to be processed uniformly.
 type ShinzoEvent interface {
 	ToString() string
 }
@@ -274,13 +282,13 @@ func startPing(ctx context.Context, conn *websocket.Conn) context.CancelFunc {
 	return pingCancel
 }
 
-// extractShinzoEvents extracts ViewRegistered, HostRegistered, and IndexerRegistered events from an RPC message.
+// extractShinzoEvents extracts typed events from an RPC response.
 func extractShinzoEvents(msg RPCResponse) []ShinzoEvent {
 	var events []ShinzoEvent
 	if msg.JsonRpcVersion != "2.0" ||
 		msg.Result.Data.Type != "tendermint/event/Tx" ||
 		msg.Result.Data.Value.TxResult.Result.Events == nil {
-		return events
+		return nil
 	}
 
 	for _, event := range msg.Result.Data.Value.TxResult.Result.Events {

--- a/pkg/shinzohub/events_essential_test.go
+++ b/pkg/shinzohub/events_essential_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Real devnet values used across tests
+// Real devnet values used across tests.
 const (
 	testHostAddress    = "shinzo1k2e3g3696x7ycdz5tlqslplpgyh3dwy7e7jarm"
 	testHostDID        = "did:key:z7r8orQ6nZti55L4MsGEfJcpMBpjFAHResJ2wscTo77VFAdot5JNZ8Bz87hCMZ8XLwgA6YYMyQ521AXaEGYb9BSYfKf7i"
@@ -155,7 +155,7 @@ func TestEventInterface(t *testing.T) {
 
 func TestExtractShinzoEvents_ViewRegistered(t *testing.T) {
 	msg := RPCResponse{
-		JsonRpcVersion: "2.0",
+		JSONRPCVersion: "2.0",
 		ID:             1,
 		Result: RPCResult{
 			Data: RPCData{
@@ -187,7 +187,7 @@ func TestExtractShinzoEvents_ViewRegistered(t *testing.T) {
 
 func TestExtractShinzoEvents_HostRegistered(t *testing.T) {
 	msg := RPCResponse{
-		JsonRpcVersion: "2.0",
+		JSONRPCVersion: "2.0",
 		ID:             2,
 		Result: RPCResult{
 			Data: RPCData{
@@ -224,7 +224,7 @@ func TestExtractShinzoEvents_HostRegistered(t *testing.T) {
 
 func TestExtractShinzoEvents_IndexerRegistered(t *testing.T) {
 	msg := RPCResponse{
-		JsonRpcVersion: "2.0",
+		JSONRPCVersion: "2.0",
 		ID:             3,
 		Result: RPCResult{
 			Data: RPCData{
@@ -265,7 +265,7 @@ func TestExtractShinzoEvents_IndexerRegistered(t *testing.T) {
 
 func TestExtractShinzoEvents_IncompleteHost(t *testing.T) {
 	msg := RPCResponse{
-		JsonRpcVersion: "2.0",
+		JSONRPCVersion: "2.0",
 		ID:             2,
 		Result: RPCResult{
 			Data: RPCData{
@@ -295,7 +295,7 @@ func TestExtractShinzoEvents_IncompleteHost(t *testing.T) {
 
 func TestExtractShinzoEvents_IgnoresUnknownEvents(t *testing.T) {
 	msg := RPCResponse{
-		JsonRpcVersion: "2.0",
+		JSONRPCVersion: "2.0",
 		ID:             1,
 		Result: RPCResult{
 			Data: RPCData{

--- a/pkg/shinzohub/indexer_manager.go
+++ b/pkg/shinzohub/indexer_manager.go
@@ -15,7 +15,7 @@ type IndexerManager interface {
 	RemoveIndexer(owner string) error
 }
 
-// Indexer represents a blockchain indexer
+// Indexer represents a blockchain indexer.
 type Indexer struct {
 	Owner            string
 	DID              string
@@ -25,19 +25,19 @@ type Indexer struct {
 	Active           bool
 }
 
-// RegistrationHandler manages indexer registration from IndexerRegistered events
+// RegistrationHandler manages indexer registration from IndexerRegistered events.
 type RegistrationHandler struct {
 	indexerManager IndexerManager
 }
 
-// NewRegistrationHandler creates a new registration handler
+// NewRegistrationHandler creates a new registration handler.
 func NewRegistrationHandler(indexerManager IndexerManager) *RegistrationHandler {
 	return &RegistrationHandler{
 		indexerManager: indexerManager,
 	}
 }
 
-// ProcessIndexerRegisteredEvent handles an IndexerRegistered event from ShinzoHub
+// ProcessIndexerRegisteredEvent handles an IndexerRegistered event from ShinzoHub.
 func (rh *RegistrationHandler) ProcessIndexerRegisteredEvent(ctx context.Context, event IndexerRegisteredEvent) error {
 	fmt.Printf("Processing IndexerRegistered event for indexer: %s\n", event.Owner)
 
@@ -58,20 +58,21 @@ func (rh *RegistrationHandler) ProcessIndexerRegisteredEvent(ctx context.Context
 	return nil
 }
 
-// MockIndexerManager is a mock implementation of IndexerManager for testing
+// MockIndexerManager is a mock implementation of IndexerManager for testing.
 type MockIndexerManager struct {
 	indexers map[string]Indexer
 }
 
-// NewMockIndexerManager creates a new mock indexer manager
+// NewMockIndexerManager creates a new mock indexer manager.
 func NewMockIndexerManager() *MockIndexerManager {
 	return &MockIndexerManager{
 		indexers: make(map[string]Indexer),
 	}
 }
 
-// AddIndexer adds a new indexer
-func (mim *MockIndexerManager) AddIndexer(ctx context.Context, owner string, did string, connectionString string, sourceChain string, sourceChainID string) error {
+// AddIndexer adds a new indexer.
+// replaced ctx with _ since it's not used in this mock implementation.
+func (mim *MockIndexerManager) AddIndexer(_ context.Context, owner string, did string, connectionString string, sourceChain string, sourceChainID string) error {
 	mim.indexers[owner] = Indexer{
 		Owner:            owner,
 		DID:              did,
@@ -83,24 +84,24 @@ func (mim *MockIndexerManager) AddIndexer(ctx context.Context, owner string, did
 	return nil
 }
 
-// GetIndexer retrieves an indexer by owner address
+// GetIndexer retrieves an indexer by owner address.
 func (mim *MockIndexerManager) GetIndexer(owner string) (Indexer, bool) {
 	indexer, exists := mim.indexers[owner]
 	return indexer, exists
 }
 
-// RemoveIndexer removes an indexer by owner address
+// RemoveIndexer removes an indexer by owner address.
 func (mim *MockIndexerManager) RemoveIndexer(owner string) error {
 	delete(mim.indexers, owner)
 	return nil
 }
 
-// GetIndexerCount returns the number of indexers
+// GetIndexerCount returns the number of indexers.
 func (mim *MockIndexerManager) GetIndexerCount() int {
 	return len(mim.indexers)
 }
 
-// ListIndexers returns all indexers
+// ListIndexers returns all indexers.
 func (mim *MockIndexerManager) ListIndexers() []Indexer {
 	indexers := make([]Indexer, 0, len(mim.indexers))
 	for _, indexer := range mim.indexers {

--- a/pkg/shinzohub/integration_test.go
+++ b/pkg/shinzohub/integration_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestIndexerRegisteredToIntegrationFlow tests the complete flow from IndexerRegistered event to indexer addition
+// TestIndexerRegisteredToIntegrationFlow tests the complete flow from IndexerRegistered event to indexer addition.
 func TestIndexerRegisteredToIntegrationFlow(t *testing.T) {
 	indexerManager := NewMockIndexerManager()
 	handler := NewRegistrationHandler(indexerManager)
@@ -21,7 +21,7 @@ func TestIndexerRegisteredToIntegrationFlow(t *testing.T) {
 	defer cancel()
 
 	testEvent := RPCResponse{
-		JsonRpcVersion: "2.0",
+		JSONRPCVersion: "2.0",
 		ID:             3,
 		Result: RPCResult{
 			Query: "tm.event='Tx' AND IndexerRegistered.owner EXISTS",
@@ -95,7 +95,7 @@ func TestIndexerRegisteredToIntegrationFlow(t *testing.T) {
 	require.Equal(t, 1, indexerManager.GetIndexerCount())
 }
 
-// TestMultipleIndexerRegisteredEvents tests handling multiple IndexerRegistered events
+// TestMultipleIndexerRegisteredEvents tests handling multiple IndexerRegistered events.
 func TestMultipleIndexerRegisteredEvents(t *testing.T) {
 	indexerManager := NewMockIndexerManager()
 	handler := NewRegistrationHandler(indexerManager)
@@ -109,7 +109,7 @@ func TestMultipleIndexerRegisteredEvents(t *testing.T) {
 
 	testEvents := []RPCResponse{
 		{
-			JsonRpcVersion: "2.0",
+			JSONRPCVersion: "2.0",
 			ID:             3,
 			Result: RPCResult{
 				Query: "tm.event='Tx' AND IndexerRegistered.owner EXISTS",
@@ -138,7 +138,7 @@ func TestMultipleIndexerRegisteredEvents(t *testing.T) {
 			},
 		},
 		{
-			JsonRpcVersion: "2.0",
+			JSONRPCVersion: "2.0",
 			ID:             3,
 			Result: RPCResult{
 				Query: "tm.event='Tx' AND IndexerRegistered.owner EXISTS",
@@ -212,7 +212,7 @@ func TestMultipleIndexerRegisteredEvents(t *testing.T) {
 	require.Equal(t, "polygon", indexer2.SourceChain)
 }
 
-// TestIndexerManagerFunctionality tests the indexer manager directly
+// TestIndexerManagerFunctionality tests the indexer manager directly.
 func TestIndexerManagerFunctionality(t *testing.T) {
 	manager := NewMockIndexerManager()
 

--- a/pkg/shinzohub/mock_websocket_test.go
+++ b/pkg/shinzohub/mock_websocket_test.go
@@ -1,6 +1,7 @@
 package shinzohub
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -10,7 +11,7 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-// MockWebSocketServer simulates a ShinzoHub WebSocket server for testing
+// MockWebSocketServer simulates a ShinzoHub WebSocket server for testing.
 type MockWebSocketServer struct {
 	server   *http.Server
 	upgrader websocket.Upgrader
@@ -21,7 +22,7 @@ type MockWebSocketServer struct {
 	ready    chan struct{} // signals when all subscriptions have been processed
 }
 
-// NewMockWebSocketServer creates a new mock WebSocket server
+// NewMockWebSocketServer creates a new mock WebSocket server.
 func NewMockWebSocketServer() *MockWebSocketServer {
 	mux := http.NewServeMux()
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
@@ -29,12 +30,15 @@ func NewMockWebSocketServer() *MockWebSocketServer {
 		panic(fmt.Sprintf("Failed to create listener: %v", err))
 	}
 
-	server := &http.Server{Handler: mux}
+	server := &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: defaultTimeout,
+	}
 
 	mock := &MockWebSocketServer{
 		server: server,
 		upgrader: websocket.Upgrader{
-			CheckOrigin: func(r *http.Request) bool {
+			CheckOrigin: func(_ *http.Request) bool {
 				return true
 			},
 		},
@@ -46,7 +50,7 @@ func NewMockWebSocketServer() *MockWebSocketServer {
 	mux.HandleFunc("/websocket", mock.handleWebSocket)
 
 	go func() {
-		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
+		if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			fmt.Printf("Mock WebSocket server error: %v\n", err)
 		}
 	}()
@@ -54,20 +58,20 @@ func NewMockWebSocketServer() *MockWebSocketServer {
 	return mock
 }
 
-// WebsocketURL returns the WebSocket URL for the mock server
+// WebsocketURL returns the WebSocket URL for the mock server.
 func (m *MockWebSocketServer) WebsocketURL() string {
 	return fmt.Sprintf("ws://127.0.0.1:%d/websocket", m.port)
 }
 
-// Close shuts down the mock server
+// Close shuts down the mock server.
 func (m *MockWebSocketServer) Close() {
 	close(m.done)
 	if m.server != nil {
-		m.server.Close()
+		defer func() { _ = m.server.Close() }()
 	}
 	m.connMu.Lock()
 	if m.conn != nil {
-		m.conn.Close()
+		_ = m.conn.Close()
 	}
 	m.connMu.Unlock()
 }
@@ -94,7 +98,7 @@ func (m *MockWebSocketServer) SendEvent(event RPCResponse) {
 	}
 }
 
-// handleWebSocket handles WebSocket connections
+// handleWebSocket handles WebSocket connections.
 func (m *MockWebSocketServer) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	conn, err := m.upgrader.Upgrade(w, r, nil)
 	if err != nil {
@@ -105,7 +109,7 @@ func (m *MockWebSocketServer) handleWebSocket(w http.ResponseWriter, r *http.Req
 	m.connMu.Lock()
 	m.conn = conn
 	m.connMu.Unlock()
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	subscriptionCount := 0
 
@@ -114,7 +118,7 @@ func (m *MockWebSocketServer) handleWebSocket(w http.ResponseWriter, r *http.Req
 		case <-m.done:
 			return
 		default:
-			var msg map[string]interface{}
+			var msg map[string]any
 			if err := conn.ReadJSON(&msg); err != nil {
 				if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
 					fmt.Printf("WebSocket error: %v\n", err)
@@ -124,10 +128,10 @@ func (m *MockWebSocketServer) handleWebSocket(w http.ResponseWriter, r *http.Req
 
 			if method, ok := msg["method"].(string); ok && method == "subscribe" {
 				m.connMu.Lock()
-				response := map[string]interface{}{
+				response := map[string]any{
 					"jsonrpc": "2.0",
 					"id":      msg["id"],
-					"result": map[string]interface{}{
+					"result": map[string]any{
 						"query": "tm.event='Tx' AND (Registered.key EXISTS OR EntityRegistered.key EXISTS)",
 					},
 				}

--- a/pkg/shinzohub/query.go
+++ b/pkg/shinzohub/query.go
@@ -21,6 +21,9 @@ type RPCClient struct {
 	httpClient *http.Client
 }
 
+// defaultHTTPClientTimeout is the default timeout for HTTP client requests.
+const defaultHTTPClientTimeout = 30 * time.Second
+
 // NewRPCClient creates a new RPC client for querying Shinzo Hub.
 // defraNode is used to persist the last processed page number.
 func NewRPCClient(rpcURL string, defraNode *node.Node) *RPCClient {
@@ -28,59 +31,59 @@ func NewRPCClient(rpcURL string, defraNode *node.Node) *RPCClient {
 		rpcURL:    rpcURL,
 		defraNode: defraNode,
 		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
+			Timeout: defaultHTTPClientTimeout,
 		},
 	}
 }
 
-// queryResult wraps the GraphQL response for JSON unmarshaling
+// queryResult wraps the GraphQL response for JSON unmarshaling.
 type queryResult struct {
-	Config__LastProcessedPage []struct {
+	ConfigLastProcessedPage []struct {
 		Page     int `json:"page"`
 		PageSize int `json:"pageSize"`
-	} `json:"Config__LastProcessedPage"`
+	} `json:"ConfigLastProcessedPage"`
 }
 
 // getLastProcessedPage reads the last processed page from DefraDB.
 func (c *RPCClient) getLastProcessedPage(ctx context.Context) (int, int) {
 	if c.defraNode == nil {
-		return 0, 5
+		return 0, defaultPageSize
 	}
 
 	query := `query { Config__LastProcessedPage { page pageSize } }`
 	result := c.defraNode.DB.ExecRequest(ctx, query)
 	if result.GQL.Errors != nil {
 		logger.Sugar.Debugf("📡 getLastProcessedPage error: %v", result.GQL.Errors)
-		return 0, 5
+		return 0, defaultPageSize
 	}
 
 	// Marshal to JSON then unmarshal to struct
 	jsonBytes, err := json.Marshal(result.GQL.Data)
 	if err != nil {
 		logger.Sugar.Debugf("📡 getLastProcessedPage marshal error: %v", err)
-		return 0, 5
+		return 0, defaultPageSize
 	}
 
 	var qr queryResult
 	if err := json.Unmarshal(jsonBytes, &qr); err != nil {
 		logger.Sugar.Debugf("📡 getLastProcessedPage unmarshal error: %v", err)
-		return 0, 5
+		return 0, defaultPageSize
 	}
 
-	if len(qr.Config__LastProcessedPage) == 0 {
+	if len(qr.ConfigLastProcessedPage) == 0 {
 		logger.Sugar.Debugf("📡 getLastProcessedPage: no records")
-		return 0, 5
+		return 0, defaultPageSize
 	}
 
 	// Find max page
 	maxPage := 0
-	for _, rec := range qr.Config__LastProcessedPage {
+	for _, rec := range qr.ConfigLastProcessedPage {
 		if rec.Page > maxPage {
 			maxPage = rec.Page
 		}
 	}
 	maxPageSize := 0
-	for _, rec := range qr.Config__LastProcessedPage {
+	for _, rec := range qr.ConfigLastProcessedPage {
 		if rec.PageSize > maxPageSize {
 			maxPageSize = rec.PageSize
 		}
@@ -202,20 +205,31 @@ func (c *RPCClient) FetchAllRegisteredViews(ctx context.Context) ([]view.View, i
 
 // fetchRegisteredViewsPage fetches a single page of Registered events with retry logic.
 func (c *RPCClient) fetchRegisteredViewsPage(ctx context.Context, page, perPage int) ([]view.View, int, error) {
-	// Build the query URL
-	// Query: ViewRegistered.view_address EXISTS
 	query := url.QueryEscape(`ViewRegistered.view_address EXISTS`)
 	endpoint := fmt.Sprintf("%s/tx_search?query=\"%s\"&page=%d&per_page=%d&order_by=\"asc\"",
 		c.rpcURL, query, page, perPage)
 
-	var body []byte
+	body, err := c.fetchWithRetry(ctx, endpoint)
+	if err != nil {
+		return []view.View{}, 0, err
+	}
+
+	var txResp TxSearchResponse
+	if err := json.Unmarshal(body, &txResp); err != nil {
+		logger.Sugar.Warnf("📡 Failed to parse response: %v", err)
+		return []view.View{}, 0, nil
+	}
+
+	return parseViewsFromTxResponse(txResp)
+}
+
+func (c *RPCClient) fetchWithRetry(ctx context.Context, endpoint string) ([]byte, error) {
 	var lastErr error
 
-	// Retry up to 3 times for transient errors like EOF
-	for attempt := 0; attempt < 3; attempt++ {
+	for attempt := range 3 {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 		if err != nil {
-			return nil, 0, err
+			return nil, err
 		}
 
 		resp, err := c.httpClient.Do(req)
@@ -227,57 +241,51 @@ func (c *RPCClient) fetchRegisteredViewsPage(ctx context.Context, page, perPage 
 
 		if resp.StatusCode != http.StatusOK {
 			respBody, _ := io.ReadAll(resp.Body)
-			resp.Body.Close()
-			return nil, 0, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(respBody))
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf("HTTP %d %s: %w", resp.StatusCode, string(respBody), ErrHTTPErrorResponse)
 		}
 
-		body, err = io.ReadAll(resp.Body)
-		resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
 		if err != nil {
 			lastErr = err
 			time.Sleep(time.Duration(attempt+1) * 500 * time.Millisecond)
 			continue
 		}
 
-		// Success
-		lastErr = nil
-		break
+		return body, nil
 	}
 
-	if lastErr != nil {
-		// Return empty results instead of failing completely
-		return []view.View{}, 0, nil
-	}
+	return nil, lastErr
+}
 
-	var txResp TxSearchResponse
-	if err := json.Unmarshal(body, &txResp); err != nil {
-		logger.Sugar.Warnf("📡 Failed to parse response: %v", err)
-		return []view.View{}, 0, nil
-	}
-
-	// Extract views from events
+// parseViewsFromTxResponse is self explainatory.
+func parseViewsFromTxResponse(txResp TxSearchResponse) ([]view.View, int, error) {
 	var views []view.View
-	var skippedNoLenses int
-	var skippedMalformed int
+	var skippedNoLenses, skippedMalformed int
+
 	logger.Sugar.Debugf("📡 Processing %d transactions", len(txResp.Result.Txs))
 
 	for _, tx := range txResp.Result.Txs {
 		for _, event := range tx.TxResult.Events {
-			if event.Type == "ViewRegistered" {
-				v, err := extractViewFromEvent(event)
-				if err != nil {
-					skippedMalformed++
-					logger.Sugar.Debugf("📡 Skipping malformed event: %v", err)
-					continue
-				}
-				logger.Sugar.Debugf("📡 Found view with lenses: %s", v.Name)
-				views = append(views, v)
+			if event.Type != "ViewRegistered" {
+				continue
 			}
+			v, err := extractViewFromEvent(event)
+			if err != nil {
+				skippedMalformed++
+				logger.Sugar.Debugf("📡 Skipping malformed event: %v", err)
+				continue
+			}
+			logger.Sugar.Debugf("📡 Found view with lenses: %s", v.Name)
+			views = append(views, v)
 		}
 	}
 
 	var total int
-	fmt.Sscanf(txResp.Result.TotalCount, "%d", &total)
+	if _, err := fmt.Sscanf(txResp.Result.TotalCount, "%d", &total); err != nil {
+		return nil, 0, fmt.Errorf("failed to parse total count %q: %w", txResp.Result.TotalCount, err)
+	}
 
 	logger.Sugar.Debugf("📡 Page results: %d views with lenses, %d skipped (no lenses), %d malformed, total_count=%d",
 		len(views), skippedNoLenses, skippedMalformed, total)
@@ -290,14 +298,11 @@ func extractViewFromEvent(event Event) (view.View, error) {
 	var v view.View
 
 	for _, attr := range event.Attributes {
-		switch attr.Key {
-		case "data":
-			// Process view from wire format
+		if attr.Key == "data" {
 			newView, err := ProcessViewFromWireFormat(attr.Value)
 			if err != nil {
 				return v, fmt.Errorf("failed to process view from wire: %w", err)
 			}
-
 			v = newView
 		}
 	}
@@ -308,7 +313,7 @@ func extractViewFromEvent(event Event) (view.View, error) {
 	}
 
 	if v.Data.Query == "" {
-		return v, fmt.Errorf("view has no query")
+		return v, ErrViewHasNoQuery
 	}
 
 	return v, nil

--- a/pkg/shinzohub/view.go
+++ b/pkg/shinzohub/view.go
@@ -33,16 +33,19 @@ type IndexerRegisteredEvent struct {
 	SourceChainID    string // attr "source_chain_id": chain ID as string (e.g., "1")
 }
 
+// ToString returns a human-readable string representation of the ViewRegisteredEvent.
 func (vre *ViewRegisteredEvent) ToString() string {
 	return fmt.Sprintf("ViewRegistered: address=%s, name=%s, creator=%s",
 		vre.ViewAddress, vre.ViewName, vre.Creator)
 }
 
+// ToString returns a human-readable string representation of the HostRegisteredEvent.
 func (hre *HostRegisteredEvent) ToString() string {
 	return fmt.Sprintf("HostRegistered: owner=%s, did=%s, conn=%s",
 		hre.Owner, hre.DID, hre.ConnectionString)
 }
 
+// ToString returns a human-readable string representation of the IndexerRegisteredEvent.
 func (ire *IndexerRegisteredEvent) ToString() string {
 	return fmt.Sprintf("IndexerRegistered: owner=%s, did=%s, conn=%s, chain=%s/%s",
 		ire.Owner, ire.DID, ire.ConnectionString, ire.SourceChain, ire.SourceChainID)

--- a/pkg/shinzohub/view.go
+++ b/pkg/shinzohub/view.go
@@ -9,28 +9,28 @@ import (
 // ViewRegisteredEvent represents a view registration event from ShinzoHub.
 // Emitted by ViewRegistry precompile (0x210) as Cosmos SDK event "ViewRegistered".
 type ViewRegisteredEvent struct {
-	ViewAddress string    // attr "view_address": hex EVM contract address of deployed View.sol
-	ViewName    string    // attr "view_name": SDL resource name extracted from viewbundle
-	Creator     string    // attr "creator": bech32 address of the view creator
-	View        view.View // attr "data": decoded from base64 viewbundle wire format
+	ViewAddress string
+	ViewName    string
+	Creator     string
+	View        view.View
 }
 
 // HostRegisteredEvent represents a host registration event from ShinzoHub.
 // Emitted by HostRegistry precompile (0x211) as Cosmos SDK event "HostRegistered".
 type HostRegisteredEvent struct {
-	Owner            string // attr "owner": bech32 address of host operator
-	DID              string // attr "did": decentralized identifier derived from registration pubkey
-	ConnectionString string // attr "connection_string": network address (multiaddr or ip:port)
+	Owner            string
+	DID              string
+	ConnectionString string
 }
 
 // IndexerRegisteredEvent represents an indexer registration event from ShinzoHub.
 // Emitted by IndexerRegistry precompile (0x212) as Cosmos SDK event "IndexerRegistered".
 type IndexerRegisteredEvent struct {
-	Owner            string // attr "owner": bech32 address of indexer operator
-	DID              string // attr "did": decentralized identifier derived from registration pubkey
-	ConnectionString string // attr "connection_string": network address (multiaddr or ip:port)
-	SourceChain      string // attr "source_chain": name of indexed chain (e.g., "ethereum")
-	SourceChainID    string // attr "source_chain_id": chain ID as string (e.g., "1")
+	Owner            string
+	DID              string
+	ConnectionString string
+	SourceChain      string
+	SourceChainID    string
 }
 
 // ToString returns a human-readable string representation of the ViewRegisteredEvent.

--- a/pkg/shinzohub/view_processor.go
+++ b/pkg/shinzohub/view_processor.go
@@ -10,13 +10,13 @@ import (
 )
 
 // ViewProcessor orchestrates DefraDB setup for views (lens, migration, configuration)
-// For viewbundle operations (decode, validate), use the view package directly
+// For viewbundle operations (decode, validate), use the view package directly.
 type ViewProcessor struct {
 	defraNode     *node.Node
 	schemaService *view.SchemaService
 }
 
-// NewViewProcessor creates a new ViewProcessor for setting up views in DefraDB
+// NewViewProcessor creates a new ViewProcessor for setting up views in DefraDB.
 func NewViewProcessor(defraNode *node.Node) *ViewProcessor {
 	return &ViewProcessor{
 		defraNode:     defraNode,
@@ -24,7 +24,7 @@ func NewViewProcessor(defraNode *node.Node) *ViewProcessor {
 	}
 }
 
-// ProcessViewFromWireFormat decodes, unbundles, and validates a view from base64 wire format
+// ProcessViewFromWireFormat decodes, unbundles, and validates a view from base64 wire format.
 func ProcessViewFromWireFormat(wireBase64 string) (view.View, error) {
 	// Decode base64 wire format
 	wire, err := base64.StdEncoding.DecodeString(wireBase64)
@@ -46,7 +46,7 @@ func ProcessViewFromWireFormat(wireBase64 string) (view.View, error) {
 	return *newView, nil
 }
 
-// SetupViewInDefraDB sets up the view in DefraDB
+// SetupViewInDefraDB sets up the view in DefraDB.
 func (svp *ViewProcessor) SetupViewInDefraDB(ctx context.Context, newView *view.View) error {
 	// Set up lens and migration if needed
 	lensCID, err := view.SetupLensInDefraDB(ctx, svp.defraNode, newView)
@@ -55,7 +55,7 @@ func (svp *ViewProcessor) SetupViewInDefraDB(ctx context.Context, newView *view.
 	}
 
 	// Configure the view in DefraDB with the lens transform CID
-	err = newView.ConfigureLens(ctx, svp.defraNode, svp.schemaService, lensCID)
+	err = newView.ConfigureLens(ctx, svp.defraNode, lensCID)
 	if err != nil {
 		return fmt.Errorf("failed to configure view: %w", err)
 	}

--- a/pkg/shinzohub/view_processor_test.go
+++ b/pkg/shinzohub/view_processor_test.go
@@ -11,15 +11,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestViewProcessor_ProcessViewFromWire tests wire format processing
+// TestViewProcessor_ProcessViewFromWire tests wire format processing.
 func TestViewProcessor_ProcessViewFromWire(t *testing.T) {
 	// Create test viewbundle
 	bundler := viewbundle.NewBundler()
-	
+
 	// Create valid WASM magic number + some data
 	wasmData := []byte{0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00, 0xAA, 0xBB, 0xCC, 0xDD}
 	wasmBase64 := base64.StdEncoding.EncodeToString(wasmData)
-	
+
 	testView := viewbundle.View{
 		Query: "Log { address topics }",
 		Sdl:   "type LogView { address: String }",
@@ -49,7 +49,7 @@ func TestViewProcessor_ProcessViewFromWire(t *testing.T) {
 	require.Len(t, resultView.Data.Transform.Lenses, 1)
 }
 
-// TestViewProcessor_ProcessViewFromWire_InvalidBase64 tests error handling
+// TestViewProcessor_ProcessViewFromWire_InvalidBase64 tests error handling.
 func TestViewProcessor_ProcessViewFromWire_InvalidBase64(t *testing.T) {
 	// Test with invalid base64
 	_, err := ProcessViewFromWireFormat("invalid-base64!")
@@ -57,7 +57,7 @@ func TestViewProcessor_ProcessViewFromWire_InvalidBase64(t *testing.T) {
 	require.Contains(t, err.Error(), "failed to decode base64 wire")
 }
 
-// TestViewProcessor_ProcessViewFromWire_InvalidWire tests error handling
+// TestViewProcessor_ProcessViewFromWire_InvalidWire tests error handling.
 func TestViewProcessor_ProcessViewFromWire_InvalidWire(t *testing.T) {
 	// Test with valid base64 but invalid wire data
 	invalidBase64 := "dGVzdA==" // "test" in base64
@@ -66,7 +66,7 @@ func TestViewProcessor_ProcessViewFromWire_InvalidWire(t *testing.T) {
 	require.Contains(t, err.Error(), "failed to create view from wire")
 }
 
-// TestViewProcessor_ProcessViewFromWire_InvalidView tests validation
+// TestViewProcessor_ProcessViewFromWire_InvalidView tests validation.
 func TestViewProcessor_ProcessViewFromWire_InvalidView(t *testing.T) {
 	// Create invalid view (missing query)
 	bundler := viewbundle.NewBundler()
@@ -87,13 +87,13 @@ func TestViewProcessor_ProcessViewFromWire_InvalidView(t *testing.T) {
 	require.Contains(t, err.Error(), "view query is required")
 }
 
-// TestViewProcessor_SetupViewInDefraDB tests complete DefraDB setup
+// TestViewProcessor_SetupViewInDefraDB tests complete DefraDB setup.
 func TestViewProcessor_SetupViewInDefraDB(t *testing.T) {
 	// Create temporary DefraDB instance
 	ctx := context.Background()
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	processor := NewViewProcessor(defraNode)
 
@@ -120,13 +120,13 @@ func TestViewProcessor_SetupViewInDefraDB(t *testing.T) {
 	require.Equal(t, testView.Name, collection.Name())
 }
 
-// TestViewProcessor_SetupViewInDefraDB_WithoutLenses tests basic view setup without lenses (GitHub Actions compatible)
+// TestViewProcessor_SetupViewInDefraDB_WithoutLenses tests basic view setup without lenses (GitHub Actions compatible).
 func TestViewProcessor_SetupViewInDefraDB_WithoutLenses(t *testing.T) {
 	// Create temporary DefraDB instance
 	ctx := context.Background()
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	processor := NewViewProcessor(defraNode)
 
@@ -154,13 +154,13 @@ func TestViewProcessor_SetupViewInDefraDB_WithoutLenses(t *testing.T) {
 	require.Equal(t, testView.Name, collection.Name())
 }
 
-// TestViewProcessor_SetupViewInDefraDB_InvalidView tests error handling
+// TestViewProcessor_SetupViewInDefraDB_InvalidView tests error handling.
 func TestViewProcessor_SetupViewInDefraDB_InvalidView(t *testing.T) {
 	// Create temporary DefraDB instance
 	ctx := context.Background()
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	processor := NewViewProcessor(defraNode)
 

--- a/pkg/shinzohub/view_test.go
+++ b/pkg/shinzohub/view_test.go
@@ -138,7 +138,7 @@ func TestSubscribeToViewNoViewFailure(t *testing.T) {
 	ctx := context.Background()
 	query := "Log {address topics data transactionHash blockNumber}"
 	sdl := "type FilteredAndDecodedLogs {transactionHash: String}"
-	
+
 	// Create view using viewbundle
 	bundledView := viewbundle.View{
 		Query: query,
@@ -149,7 +149,7 @@ func TestSubscribeToViewNoViewFailure(t *testing.T) {
 
 	myDefra, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer myDefra.Close(ctx)
+	defer func() { _ = myDefra.Close(ctx) }()
 
 	// SubscribeTo should fail because the collection doesn't exist yet
 	// (views must be created before they can be subscribed to)
@@ -161,7 +161,7 @@ func TestSubscribeToViewNoViewFailure(t *testing.T) {
 func TestSubscribeToInvalidViewFails(t *testing.T) {
 	query := "Log {address topics data transactionHash blockNumber}"
 	sdl := "type FilteredAndDecodedLogs @materialized(if: false) {transactionHash: String}"
-	
+
 	// Create view using viewbundle
 	bundledView := viewbundle.View{
 		Query: query,

--- a/pkg/signer/errors.go
+++ b/pkg/signer/errors.go
@@ -1,0 +1,18 @@
+package signer
+
+import "errors"
+
+var (
+	// ErrKeyFileNotFound is returned when the defra_identity.key file cannot be located in any common path.
+	ErrKeyFileNotFound = errors.New("could not find defra_identity.key in any common location, please ensure the key file exists or provide a store path in config")
+	// ErrNoPrivateKey is returned when an identity does not contain a private key.
+	ErrNoPrivateKey = errors.New("identity does not have a private key")
+	// ErrUnexpectedKeyLength is returned when an Ed25519 key is neither 32 nor 64 bytes.
+	ErrUnexpectedKeyLength = errors.New("unexpected Ed25519 key length: expected 32 or 64 bytes")
+	// ErrNoPublicKey is returned when an identity does not contain a public key.
+	ErrNoPublicKey = errors.New("identity does not have a public key")
+	// ErrSignatureVerification is returned when a signature fails to verify against the public key.
+	ErrSignatureVerification = errors.New("signature verification failed")
+	// ErrNotEd25519Key is returned when a public key is not of the Ed25519 type.
+	ErrNotEd25519Key = errors.New("public key is not Ed25519")
+)

--- a/pkg/signer/signer.go
+++ b/pkg/signer/signer.go
@@ -21,8 +21,8 @@ const keyFileName string = "defra_identity.key"
 // shims for those have been removed. The two left below cover the load-flow
 // orchestration and ed25519 public-key parsing in the verifier.
 var (
-	loadIdentityFromStoreFn   = loadIdentityFromStore
-	ed25519PubKeyFromStringFn = func(hex string) (crypto.PublicKey, error) {
+	loadIdentityFromStoreFn   = loadIdentityFromStore                        //nolint:gochecknoglobals
+	ed25519PubKeyFromStringFn = func(hex string) (crypto.PublicKey, error) { //nolint:gochecknoglobals
 		return crypto.PublicKeyFromString(crypto.KeyTypeEd25519, hex)
 	}
 )
@@ -32,7 +32,7 @@ func loadIdentityFromFile(storePath string) (identity.FullIdentity, error) {
 	keyPath := filepath.Join(storePath, keyFileName)
 
 	// Read the stored key file
-	keyHex, err := os.ReadFile(keyPath)
+	keyHex, err := os.ReadFile(filepath.Clean(keyPath))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read key file at %s: %w", keyPath, err)
 	}
@@ -93,13 +93,13 @@ func getStorePath(_ *node.Node, cfg *defradb.Config) (string, error) {
 
 	// Try each path to see if it contains the key file
 	for _, path := range possiblePaths {
-		keyPath := filepath.Join(path, keyFileName)
+		keyPath := filepath.Join(filepath.Clean(path), keyFileName)
 		if _, err := os.Stat(keyPath); err == nil {
 			return path, nil
 		}
 	}
 
-	return "", fmt.Errorf("could not find defra_identity.key in any common location. Please ensure the key file exists or provide a store path in config")
+	return "", ErrKeyFileNotFound
 }
 
 // SignWithDefraKeys signs a message using the DefraDB identity's private key (secp256k1).
@@ -121,7 +121,7 @@ func SignWithDefraKeys(message string, defraNode *node.Node, cfg *defradb.Config
 	// Get the private key
 	privateKey := fullIdentity.PrivateKey()
 	if privateKey == nil {
-		return "", fmt.Errorf("identity does not have a private key")
+		return "", ErrNoPrivateKey
 	}
 
 	// Sign the message
@@ -166,12 +166,13 @@ func SignWithP2PKeys(message string, defraNode *node.Node, cfg *defradb.Config) 
 	// Ed25519.NewKeyFromSeed expects exactly 32 bytes (the seed)
 	// If we got 64 bytes, take only the first 32 bytes (the seed portion)
 	var ed25519Seed []byte
-	if len(rawKeyBytes) == 64 {
+	switch len(rawKeyBytes) {
+	case 64: //nolint:mnd
 		ed25519Seed = rawKeyBytes[:32]
-	} else if len(rawKeyBytes) == 32 {
+	case 32: //nolint:mnd
 		ed25519Seed = rawKeyBytes
-	} else {
-		return "", fmt.Errorf("unexpected Ed25519 key length: expected 32 or 64 bytes, got %d", len(rawKeyBytes))
+	default:
+		return "", ErrUnexpectedKeyLength
 	}
 
 	// Construct full ed25519.PrivateKey from seed (64 bytes: 32-byte seed + 32-byte public key)
@@ -202,7 +203,7 @@ func GetDefraPublicKey(defraNode *node.Node, cfg *defradb.Config) (string, error
 	// Get the public key
 	publicKey := fullIdentity.PublicKey()
 	if publicKey == nil {
-		return "", fmt.Errorf("identity does not have a public key")
+		return "", ErrNoPublicKey
 	}
 
 	// Return hex-encoded public key
@@ -271,7 +272,7 @@ func VerifyDefraSignature(publicKeyHex string, message string, signatureHex stri
 	}
 
 	if !valid {
-		return fmt.Errorf("signature verification failed")
+		return ErrSignatureVerification
 	}
 
 	return nil
@@ -301,7 +302,7 @@ func VerifyP2PSignature(publicKeyHex string, message string, signatureHex string
 	// Get the underlying Ed25519 public key
 	ed25519PubKey, ok := publicKey.Underlying().(ed25519.PublicKey)
 	if !ok {
-		return fmt.Errorf("public key is not Ed25519")
+		return ErrNotEd25519Key
 	}
 
 	// Verify the signature using DefraDB's crypto package

--- a/pkg/snapshot/client.go
+++ b/pkg/snapshot/client.go
@@ -6,22 +6,23 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"time"
 )
 
-// SnapshotInfo describes a snapshot file available on the indexer.
-type SnapshotInfo struct {
-	Filename   string                 `json:"filename"`
-	StartBlock int64                  `json:"start_block"`
-	EndBlock   int64                  `json:"end_block"`
-	SizeBytes  int64                  `json:"size_bytes"`
-	CreatedAt  time.Time              `json:"created_at"`
-	Signed     bool                   `json:"signed"`
-	Signature  *SnapshotSignatureData `json:"signature,omitempty"`
+// Info describes a snapshot file available on the indexer.
+type Info struct {
+	Filename   string         `json:"filename"`
+	StartBlock int64          `json:"start_block"`
+	EndBlock   int64          `json:"end_block"`
+	SizeBytes  int64          `json:"size_bytes"`
+	CreatedAt  time.Time      `json:"created_at"`
+	Signed     bool           `json:"signed"`
+	Signature  *SignatureData `json:"signature,omitempty"`
 }
 
-// SnapshotSignatureData holds the cryptographic signature for a snapshot file.
-type SnapshotSignatureData struct {
+// SignatureData holds the cryptographic signature for a snapshot file.
+type SignatureData struct {
 	Version             int      `json:"version"`
 	SnapshotFile        string   `json:"snapshot_file"`
 	StartBlock          int64    `json:"start_block"`
@@ -46,25 +47,25 @@ func NewClient(baseURL string) *Client {
 	return &Client{
 		baseURL: baseURL,
 		httpClient: &http.Client{
-			Timeout: 5 * time.Minute, // snapshot downloads can be large
+			Timeout: httpClientTimeoutMins * time.Minute,
 		},
 	}
 }
 
 // ListSnapshots queries the indexer for available snapshots with inline signature data.
-func (c *Client) ListSnapshots() ([]SnapshotInfo, error) {
+func (c *Client) ListSnapshots() ([]Info, error) {
 	resp, err := c.httpClient.Get(c.baseURL + "/snapshots")
 	if err != nil {
 		return nil, fmt.Errorf("list snapshots: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("list snapshots: status %d", resp.StatusCode)
+		return nil, fmt.Errorf("list snapshots status %d: %w", resp.StatusCode, ErrListSnapshotsStatus)
 	}
 
 	var result struct {
-		Snapshots []SnapshotInfo `json:"snapshots"`
+		Snapshots []Info `json:"snapshots"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, fmt.Errorf("decode snapshots list: %w", err)
@@ -79,20 +80,20 @@ func (c *Client) DownloadSnapshot(filename, destPath string) error {
 	if err != nil {
 		return fmt.Errorf("download snapshot: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("download snapshot: status %d", resp.StatusCode)
+		return fmt.Errorf("download snapshot status %d: %w", resp.StatusCode, ErrDownloadSnapshotStatus)
 	}
 
-	f, err := os.Create(destPath)
+	f, err := os.Create(filepath.Clean(destPath)) //nolint:gosec
 	if err != nil {
 		return fmt.Errorf("create file: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	if _, err := io.Copy(f, resp.Body); err != nil {
-		os.Remove(destPath)
+		_ = os.Remove(destPath)
 		return fmt.Errorf("write snapshot: %w", err)
 	}
 

--- a/pkg/snapshot/client.go
+++ b/pkg/snapshot/client.go
@@ -86,7 +86,7 @@ func (c *Client) DownloadSnapshot(filename, destPath string) error {
 		return fmt.Errorf("download snapshot status %d: %w", resp.StatusCode, ErrDownloadSnapshotStatus)
 	}
 
-	f, err := os.Create(filepath.Clean(destPath)) //nolint:gosec
+	f, err := os.Create(filepath.Clean(destPath))
 	if err != nil {
 		return fmt.Errorf("create file: %w", err)
 	}

--- a/pkg/snapshot/client_test.go
+++ b/pkg/snapshot/client_test.go
@@ -30,7 +30,7 @@ func TestListSnapshots(t *testing.T) {
 		wantErr    bool
 		errContain string
 		wantLen    int
-		checkFirst func(t *testing.T, snap SnapshotInfo)
+		checkFirst func(t *testing.T, snap Info)
 	}{
 		{
 			name: "success",
@@ -39,9 +39,9 @@ func TestListSnapshots(t *testing.T) {
 				require.Equal(t, http.MethodGet, r.Method)
 
 				resp := struct {
-					Snapshots []SnapshotInfo `json:"snapshots"`
+					Snapshots []Info `json:"snapshots"`
 				}{
-					Snapshots: []SnapshotInfo{
+					Snapshots: []Info{
 						{
 							Filename:   "snapshot-0-100.gz",
 							StartBlock: 0,
@@ -49,14 +49,14 @@ func TestListSnapshots(t *testing.T) {
 							SizeBytes:  1024,
 							CreatedAt:  now,
 							Signed:     true,
-							Signature: &SnapshotSignatureData{
+							Signature: &SignatureData{
 								Version:           1,
 								SnapshotFile:      "snapshot-0-100.gz",
 								StartBlock:        0,
 								EndBlock:          100,
 								MerkleRoot:        "abcd1234",
 								BlockCount:        101,
-								SignatureType:      "Ed25519",
+								SignatureType:     "Ed25519",
 								SignatureIdentity: "pubkey123",
 								SignatureValue:    "sig456",
 								CreatedAt:         now.Format(time.RFC3339),
@@ -78,7 +78,7 @@ func TestListSnapshots(t *testing.T) {
 				require.NoError(t, err)
 			},
 			wantLen: 2,
-			checkFirst: func(t *testing.T, snap SnapshotInfo) {
+			checkFirst: func(t *testing.T, snap Info) {
 				require.Equal(t, "snapshot-0-100.gz", snap.Filename)
 				require.Equal(t, int64(0), snap.StartBlock)
 				require.Equal(t, int64(100), snap.EndBlock)
@@ -95,7 +95,7 @@ func TestListSnapshots(t *testing.T) {
 		},
 		{
 			name: "empty list",
-			handler: func(w http.ResponseWriter, r *http.Request) {
+			handler: func(w http.ResponseWriter, _ *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				_, _ = w.Write([]byte(`{"snapshots":[]}`))
 			},
@@ -103,7 +103,7 @@ func TestListSnapshots(t *testing.T) {
 		},
 		{
 			name: "HTTP error 500",
-			handler: func(w http.ResponseWriter, r *http.Request) {
+			handler: func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusInternalServerError)
 			},
 			wantErr:    true,
@@ -111,7 +111,7 @@ func TestListSnapshots(t *testing.T) {
 		},
 		{
 			name: "HTTP error 503",
-			handler: func(w http.ResponseWriter, r *http.Request) {
+			handler: func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusServiceUnavailable)
 			},
 			wantErr:    true,
@@ -119,7 +119,7 @@ func TestListSnapshots(t *testing.T) {
 		},
 		{
 			name: "JSON decode error",
-			handler: func(w http.ResponseWriter, r *http.Request) {
+			handler: func(w http.ResponseWriter, _ *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				_, _ = w.Write([]byte(`{not valid json`))
 			},
@@ -187,7 +187,7 @@ func TestDownloadSnapshot(t *testing.T) {
 		},
 		{
 			name: "HTTP error 404",
-			handler: func(w http.ResponseWriter, r *http.Request) {
+			handler: func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusNotFound)
 			},
 			destPath: func(t *testing.T) string {
@@ -198,7 +198,7 @@ func TestDownloadSnapshot(t *testing.T) {
 		},
 		{
 			name: "HTTP error 500",
-			handler: func(w http.ResponseWriter, r *http.Request) {
+			handler: func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusInternalServerError)
 			},
 			destPath: func(t *testing.T) string {
@@ -209,11 +209,11 @@ func TestDownloadSnapshot(t *testing.T) {
 		},
 		{
 			name: "file creation error invalid path",
-			handler: func(w http.ResponseWriter, r *http.Request) {
+			handler: func(w http.ResponseWriter, _ *http.Request) {
 				w.Header().Set("Content-Type", "application/octet-stream")
 				_, _ = w.Write(fileContent)
 			},
-			destPath: func(t *testing.T) string {
+			destPath: func(_ *testing.T) string {
 				// Path with a nonexistent parent directory.
 				return "/nonexistent-dir-abc123/nested/snap.gz"
 			},
@@ -240,7 +240,7 @@ func TestDownloadSnapshot(t *testing.T) {
 			require.NoError(t, err)
 
 			if tt.checkFile {
-				data, readErr := os.ReadFile(dest)
+				data, readErr := os.ReadFile(filepath.Clean(dest))
 				require.NoError(t, readErr)
 				require.Equal(t, fileContent, data)
 			}
@@ -260,7 +260,7 @@ func TestDownloadSnapshot_WriteFail(t *testing.T) {
 	// Trigger the io.Copy error path (line 94-96 in client.go) by advertising a
 	// Content-Length larger than the body actually sent, causing io.Copy to return
 	// an "unexpected EOF" error.
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		// Tell the client to expect 1 MB, but only send 10 bytes.
 		w.Header().Set("Content-Length", fmt.Sprintf("%d", 1024*1024))
 		w.WriteHeader(http.StatusOK)
@@ -288,7 +288,7 @@ func TestDownloadSnapshot_LargeFile(t *testing.T) {
 		largeContent[i] = byte(i % 256)
 	}
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/octet-stream")
 		_, _ = w.Write(largeContent)
 	}))
@@ -300,7 +300,7 @@ func TestDownloadSnapshot_LargeFile(t *testing.T) {
 	err := c.DownloadSnapshot("large.gz", dest)
 	require.NoError(t, err)
 
-	data, err := os.ReadFile(dest)
+	data, err := os.ReadFile(filepath.Clean(dest))
 	require.NoError(t, err)
 	require.Equal(t, largeContent, data)
 }

--- a/pkg/snapshot/constants.go
+++ b/pkg/snapshot/constants.go
@@ -1,0 +1,7 @@
+package snapshot
+
+const (
+	httpClientTimeoutMins  = 5
+	sha256CombinedByteSize = 64
+	merkleArity            = 2
+)

--- a/pkg/snapshot/errors.go
+++ b/pkg/snapshot/errors.go
@@ -1,0 +1,15 @@
+package snapshot
+
+import "errors"
+
+var ( //nolint:revive
+	ErrListSnapshotsStatus    = errors.New("list snapshots non-OK status")                    //nolint:revive
+	ErrDownloadSnapshotStatus = errors.New("download snapshot non-OK status")                 //nolint:revive
+	ErrInvalidSnapshotMagic   = errors.New("invalid snapshot magic")                          //nolint:revive
+	ErrNoBlockSignatures      = errors.New("no block signatures found in KV snapshot header") //nolint:revive
+	ErrMerkleRootMismatch     = errors.New("merkle root mismatch")                            //nolint:revive
+	ErrBlockSigCountMismatch  = errors.New("block sig root count mismatch")                   //nolint:revive
+	ErrBlockSigRootMismatch   = errors.New("block sig root mismatch")                         //nolint:revive
+	ErrUnsupportedSigType     = errors.New("unsupported signature type")                      //nolint:revive
+	ErrInvalidSignature       = errors.New("invalid signature")                               //nolint:revive
+)

--- a/pkg/snapshot/importer.go
+++ b/pkg/snapshot/importer.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/shinzonetwork/shinzo-app-sdk/pkg/logger"
 	"github.com/sourcenetwork/defradb/client"
@@ -37,82 +38,25 @@ type kvSnapshotHeader struct {
 // ImportWithVerification verifies the cryptographic signature and Merkle root,
 // then imports raw KV pairs into DefraDB. Does NOT rebuild indexes — the caller
 // should call RebuildAllIndexes once after all snapshots are imported.
-func ImportWithVerification(ctx context.Context, defraNode *node.Node, snapshotPath string, sig *SnapshotSignatureData) (*ImportResult, error) {
+// ImportWithVerification verifies and imports a signed KV snapshot.
+func ImportWithVerification(ctx context.Context, defraNode *node.Node, snapshotPath string, sig *SignatureData) (*ImportResult, error) {
 	if err := verifySignature(sig); err != nil {
 		return nil, fmt.Errorf("signature verification failed: %w", err)
 	}
 
-	f, err := os.Open(snapshotPath)
+	header, gr, cleanup, err := openAndReadHeader(snapshotPath)
 	if err != nil {
-		return nil, fmt.Errorf("open snapshot: %w", err)
+		return nil, err
 	}
-	defer f.Close()
+	defer cleanup()
 
-	gr, err := gzip.NewReader(f)
+	if err := verifyHeaderAgainstSig(header, sig); err != nil {
+		return nil, err
+	}
+
+	count, err := importKVs(ctx, defraNode, gr, header)
 	if err != nil {
-		return nil, fmt.Errorf("gzip reader: %w", err)
-	}
-	defer gr.Close()
-
-	var lenBuf [4]byte
-	if _, err := io.ReadFull(gr, lenBuf[:]); err != nil {
-		return nil, fmt.Errorf("read header length: %w", err)
-	}
-	headerLen := binary.BigEndian.Uint32(lenBuf[:])
-	headerBytes := make([]byte, headerLen)
-	if _, err := io.ReadFull(gr, headerBytes); err != nil {
-		return nil, fmt.Errorf("read header: %w", err)
-	}
-
-	var header kvSnapshotHeader
-	if err := json.Unmarshal(headerBytes, &header); err != nil {
-		return nil, fmt.Errorf("parse header: %w", err)
-	}
-	if header.Magic != "DFKV" {
-		return nil, fmt.Errorf("invalid snapshot magic: %q", header.Magic)
-	}
-
-	if len(header.BlockSigMerkleRoots) == 0 {
-		return nil, fmt.Errorf("no block signatures found in KV snapshot header")
-	}
-
-	roots := make([][]byte, 0, len(header.BlockSigMerkleRoots))
-	for _, rootHex := range header.BlockSigMerkleRoots {
-		rootBytes, err := hex.DecodeString(rootHex)
-		if err != nil {
-			return nil, fmt.Errorf("decode block sig root: %w", err)
-		}
-		roots = append(roots, rootBytes)
-	}
-
-	computedRoot := computeSnapshotMerkleRoot(roots)
-	computedRootHex := hex.EncodeToString(computedRoot)
-	if computedRootHex != sig.MerkleRoot {
-		return nil, fmt.Errorf("merkle root mismatch: computed %s, expected %s", computedRootHex, sig.MerkleRoot)
-	}
-
-	// If the signature carries its own block sig roots, verify they match the file header.
-	if len(sig.BlockSigMerkleRoots) > 0 {
-		if len(sig.BlockSigMerkleRoots) != len(header.BlockSigMerkleRoots) {
-			return nil, fmt.Errorf("block sig root count mismatch: signature has %d, file header has %d",
-				len(sig.BlockSigMerkleRoots), len(header.BlockSigMerkleRoots))
-		}
-		for i, sigRoot := range sig.BlockSigMerkleRoots {
-			if sigRoot != header.BlockSigMerkleRoots[i] {
-				return nil, fmt.Errorf("block sig root mismatch at index %d: signature has %s, file header has %s",
-					i, sigRoot, header.BlockSigMerkleRoots[i])
-			}
-		}
-	}
-
-	var count int
-	if len(header.FieldMappings) > 0 {
-		count, err = defraNode.DB.ImportRawKVsWithMapping(ctx, gr, header.FieldMappings)
-	} else {
-		count, err = defraNode.DB.ImportRawKVs(ctx, gr)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("import raw KVs: %w", err)
+		return nil, err
 	}
 
 	logger.Sugar.Infof("KV snapshot imported: blocks %d-%d (%d KV pairs, signer: %s)",
@@ -122,6 +66,111 @@ func ImportWithVerification(ctx context.Context, defraNode *node.Node, snapshotP
 		StartBlock: header.StartBlock,
 		EndBlock:   header.EndBlock,
 	}, nil
+}
+
+// openAndReadHeader opens the snapshot file and reads the header, returning a cleanup func.
+func openAndReadHeader(snapshotPath string) (*kvSnapshotHeader, *gzip.Reader, func(), error) {
+	f, err := os.Open(filepath.Clean(snapshotPath))
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("open snapshot: %w", err)
+	}
+
+	gr, err := gzip.NewReader(f)
+	if err != nil {
+		_ = f.Close()
+		return nil, nil, nil, fmt.Errorf("gzip reader: %w", err)
+	}
+
+	cleanup := func() {
+		_ = gr.Close()
+		_ = f.Close()
+	}
+
+	header, err := readSnapshotHeader(gr)
+	if err != nil {
+		cleanup()
+		return nil, nil, nil, err
+	}
+
+	return header, gr, cleanup, nil
+}
+
+// readSnapshotHeader reads and parses the length-prefixed JSON header from the gzip stream.
+func readSnapshotHeader(gr *gzip.Reader) (*kvSnapshotHeader, error) {
+	var lenBuf [4]byte
+	if _, err := io.ReadFull(gr, lenBuf[:]); err != nil {
+		return nil, fmt.Errorf("read header length: %w", err)
+	}
+
+	headerBytes := make([]byte, binary.BigEndian.Uint32(lenBuf[:]))
+	if _, err := io.ReadFull(gr, headerBytes); err != nil {
+		return nil, fmt.Errorf("read header: %w", err)
+	}
+
+	var header kvSnapshotHeader
+	if err := json.Unmarshal(headerBytes, &header); err != nil {
+		return nil, fmt.Errorf("parse header: %w", err)
+	}
+	if header.Magic != "DFKV" {
+		return nil, fmt.Errorf("magic %q: %w", header.Magic, ErrInvalidSnapshotMagic)
+	}
+	if len(header.BlockSigMerkleRoots) == 0 {
+		return nil, ErrNoBlockSignatures
+	}
+
+	return &header, nil
+}
+
+// verifyHeaderAgainstSig verifies the header's merkle root and block sig roots match the signature.
+func verifyHeaderAgainstSig(header *kvSnapshotHeader, sig *SignatureData) error {
+	roots := make([][]byte, 0, len(header.BlockSigMerkleRoots))
+	for _, rootHex := range header.BlockSigMerkleRoots {
+		rootBytes, err := hex.DecodeString(rootHex)
+		if err != nil {
+			return fmt.Errorf("decode block sig root: %w", err)
+		}
+		roots = append(roots, rootBytes)
+	}
+
+	computedRootHex := hex.EncodeToString(computeSnapshotMerkleRoot(roots))
+	if computedRootHex != sig.MerkleRoot {
+		return fmt.Errorf("computed %s, expected %s: %w", computedRootHex, sig.MerkleRoot, ErrMerkleRootMismatch)
+	}
+
+	if len(sig.BlockSigMerkleRoots) == 0 {
+		return nil
+	}
+
+	if len(sig.BlockSigMerkleRoots) != len(header.BlockSigMerkleRoots) {
+		return fmt.Errorf("signature has %d, file header has %d: %w",
+			len(sig.BlockSigMerkleRoots), len(header.BlockSigMerkleRoots), ErrBlockSigCountMismatch)
+	}
+
+	for i, sigRoot := range sig.BlockSigMerkleRoots {
+		if sigRoot != header.BlockSigMerkleRoots[i] {
+			return fmt.Errorf("index %d, signature %s, header %s: %w",
+				i, sigRoot, header.BlockSigMerkleRoots[i], ErrBlockSigRootMismatch)
+		}
+	}
+
+	return nil
+}
+
+// importKVs imports raw KV pairs from the gzip reader into DefraDB.
+func importKVs(ctx context.Context, defraNode *node.Node, gr *gzip.Reader, header *kvSnapshotHeader) (int, error) {
+	var count int
+	var err error
+
+	if len(header.FieldMappings) > 0 {
+		count, err = defraNode.DB.ImportRawKVsWithMapping(ctx, gr, header.FieldMappings)
+	} else {
+		count, err = defraNode.DB.ImportRawKVs(ctx, gr)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("import raw KVs: %w", err)
+	}
+
+	return count, nil
 }
 
 // RebuildAllIndexes rebuilds indexes for all collections after bulk KV import.
@@ -136,7 +185,7 @@ func RebuildAllIndexes(ctx context.Context, defraNode *node.Node, collections []
 }
 
 // verifySignature verifies the cryptographic signature on a snapshot.
-func verifySignature(sig *SnapshotSignatureData) error {
+func verifySignature(sig *SignatureData) error {
 	merkleRootBytes, err := hex.DecodeString(sig.MerkleRoot)
 	if err != nil {
 		return fmt.Errorf("decode merkle root: %w", err)
@@ -154,7 +203,7 @@ func verifySignature(sig *SnapshotSignatureData) error {
 	case "Ed25519", "ed25519":
 		keyType = crypto.KeyTypeEd25519
 	default:
-		return fmt.Errorf("unsupported signature type: %s", sig.SignatureType)
+		return fmt.Errorf("signature type %s: %w", sig.SignatureType, ErrUnsupportedSigType)
 	}
 
 	pubKey, err := crypto.PublicKeyFromString(keyType, sig.SignatureIdentity)
@@ -167,13 +216,15 @@ func verifySignature(sig *SnapshotSignatureData) error {
 		return fmt.Errorf("verify: %w", err)
 	}
 	if !valid {
-		return fmt.Errorf("invalid signature")
+		return ErrInvalidSignature
 	}
 
 	return nil
 }
 
 // computeSnapshotMerkleRoot computes a Merkle root from per-block block sig roots.
+//
+//nolint:gomnd
 func computeSnapshotMerkleRoot(blockSigMerkleRoots [][]byte) []byte {
 	if len(blockSigMerkleRoots) == 0 {
 		return nil
@@ -185,9 +236,9 @@ func computeSnapshotMerkleRoot(blockSigMerkleRoots [][]byte) []byte {
 		hashes[i] = hash[:]
 	}
 
-	combined := make([]byte, 64)
+	combined := make([]byte, sha256CombinedByteSize)
 	for len(hashes) > 1 {
-		newLen := (len(hashes) + 1) / 2
+		newLen := (len(hashes) + 1) / merkleArity
 		newHashes := make([][]byte, 0, newLen)
 		for i := 0; i < len(hashes); i += 2 {
 			if i+1 < len(hashes) {

--- a/pkg/snapshot/importer_test.go
+++ b/pkg/snapshot/importer_test.go
@@ -98,8 +98,8 @@ func TestComputeSnapshotMerkleRoot_DifferentInputs(t *testing.T) {
 }
 
 func TestVerifySignature_UnsupportedType(t *testing.T) {
-	sig := &SnapshotSignatureData{
-		MerkleRoot:    "abcd1234",
+	sig := &SignatureData{
+		MerkleRoot:     "abcd1234",
 		SignatureValue: "abcd1234",
 		SignatureType:  "RSA",
 	}
@@ -109,8 +109,8 @@ func TestVerifySignature_UnsupportedType(t *testing.T) {
 }
 
 func TestVerifySignature_InvalidMerkleRootHex(t *testing.T) {
-	sig := &SnapshotSignatureData{
-		MerkleRoot:    "not-hex!!!",
+	sig := &SignatureData{
+		MerkleRoot:     "not-hex!!!",
 		SignatureValue: "abcd",
 		SignatureType:  "Ed25519",
 	}
@@ -120,8 +120,8 @@ func TestVerifySignature_InvalidMerkleRootHex(t *testing.T) {
 }
 
 func TestVerifySignature_InvalidSignatureHex(t *testing.T) {
-	sig := &SnapshotSignatureData{
-		MerkleRoot:    "abcd1234",
+	sig := &SignatureData{
+		MerkleRoot:     "abcd1234",
 		SignatureValue: "not-hex!!!",
 		SignatureType:  "Ed25519",
 	}
@@ -131,7 +131,7 @@ func TestVerifySignature_InvalidSignatureHex(t *testing.T) {
 }
 
 func TestVerifySignature_InvalidPublicKey(t *testing.T) {
-	sig := &SnapshotSignatureData{
+	sig := &SignatureData{
 		MerkleRoot:        "abcd1234",
 		SignatureValue:    "abcd1234",
 		SignatureType:     "Ed25519",
@@ -143,7 +143,7 @@ func TestVerifySignature_InvalidPublicKey(t *testing.T) {
 }
 
 func TestVerifySignature_ES256K_InvalidPublicKey(t *testing.T) {
-	sig := &SnapshotSignatureData{
+	sig := &SignatureData{
 		MerkleRoot:        "abcd1234",
 		SignatureValue:    "abcd1234",
 		SignatureType:     "ES256K",
@@ -155,7 +155,7 @@ func TestVerifySignature_ES256K_InvalidPublicKey(t *testing.T) {
 }
 
 func TestVerifySignature_Ecdsa256k_InvalidPublicKey(t *testing.T) {
-	sig := &SnapshotSignatureData{
+	sig := &SignatureData{
 		MerkleRoot:        "abcd1234",
 		SignatureValue:    "abcd1234",
 		SignatureType:     "ecdsa-256k",
@@ -167,7 +167,7 @@ func TestVerifySignature_Ecdsa256k_InvalidPublicKey(t *testing.T) {
 }
 
 func TestVerifySignature_Ed25519Lowercase_InvalidPublicKey(t *testing.T) {
-	sig := &SnapshotSignatureData{
+	sig := &SignatureData{
 		MerkleRoot:        "abcd1234",
 		SignatureValue:    "abcd1234",
 		SignatureType:     "ed25519",
@@ -198,7 +198,7 @@ func TestVerifySignature_ValidEd25519(t *testing.T) {
 	merkleRoot := []byte("test-merkle-root-data-for-signing")
 	pubKeyStr, merkleRootHex, sigHex := generateEd25519TestSig(t, merkleRoot)
 
-	sig := &SnapshotSignatureData{
+	sig := &SignatureData{
 		MerkleRoot:        merkleRootHex,
 		SignatureValue:    sigHex,
 		SignatureType:     "Ed25519",
@@ -212,7 +212,7 @@ func TestVerifySignature_ValidEd25519Lowercase(t *testing.T) {
 	merkleRoot := []byte("test-merkle-root-lowercase")
 	pubKeyStr, merkleRootHex, sigHex := generateEd25519TestSig(t, merkleRoot)
 
-	sig := &SnapshotSignatureData{
+	sig := &SignatureData{
 		MerkleRoot:        merkleRootHex,
 		SignatureValue:    sigHex,
 		SignatureType:     "ed25519",
@@ -232,7 +232,7 @@ func TestVerifySignature_InvalidSignature_Ed25519(t *testing.T) {
 	sigBytes, err := privKey.Sign([]byte("different-data"))
 	require.NoError(t, err)
 
-	sig := &SnapshotSignatureData{
+	sig := &SignatureData{
 		MerkleRoot:        hex.EncodeToString(merkleRoot),
 		SignatureValue:    hex.EncodeToString(sigBytes),
 		SignatureType:     "Ed25519",
@@ -251,7 +251,7 @@ func TestVerifySignature_ValidSecp256k1(t *testing.T) {
 	sigBytes, err := privKey.Sign(merkleRoot)
 	require.NoError(t, err)
 
-	sig := &SnapshotSignatureData{
+	sig := &SignatureData{
 		MerkleRoot:        hex.EncodeToString(merkleRoot),
 		SignatureValue:    hex.EncodeToString(sigBytes),
 		SignatureType:     "ES256K",
@@ -269,7 +269,7 @@ func TestVerifySignature_ValidSecp256k1_EcdsaAlias(t *testing.T) {
 	sigBytes, err := privKey.Sign(merkleRoot)
 	require.NoError(t, err)
 
-	sig := &SnapshotSignatureData{
+	sig := &SignatureData{
 		MerkleRoot:        hex.EncodeToString(merkleRoot),
 		SignatureValue:    hex.EncodeToString(sigBytes),
 		SignatureType:     "ecdsa-256k",
@@ -288,7 +288,7 @@ func TestVerifySignature_InvalidSignature_Secp256k1(t *testing.T) {
 	sigBytes, err := privKey.Sign([]byte("wrong-data"))
 	require.NoError(t, err)
 
-	sig := &SnapshotSignatureData{
+	sig := &SignatureData{
 		MerkleRoot:        hex.EncodeToString(merkleRoot),
 		SignatureValue:    hex.EncodeToString(sigBytes),
 		SignatureType:     "ES256K",
@@ -311,7 +311,7 @@ func buildTestSnapshot(t *testing.T, header kvSnapshotHeader) string {
 	gw := gzip.NewWriter(&buf)
 
 	var lenBuf [4]byte
-	binary.BigEndian.PutUint32(lenBuf[:], uint32(len(headerBytes)))
+	binary.BigEndian.PutUint32(lenBuf[:], uint32(len(headerBytes))) //nolint:gosec // header length fits in uint32
 	_, err = gw.Write(lenBuf[:])
 	require.NoError(t, err)
 	_, err = gw.Write(headerBytes)
@@ -321,13 +321,13 @@ func buildTestSnapshot(t *testing.T, header kvSnapshotHeader) string {
 	require.NoError(t, gw.Close())
 
 	path := filepath.Join(t.TempDir(), "test-snapshot.gz")
-	require.NoError(t, os.WriteFile(path, buf.Bytes(), 0644))
+	require.NoError(t, os.WriteFile(path, buf.Bytes(), 0o600))
 	return path
 }
 
 // buildValidSigForBlockRoots creates a valid Ed25519 signature that signs the
 // computed merkle root of the given block sig merkle root hex strings.
-func buildValidSigForBlockRoots(t *testing.T, blockSigRootHexes []string) *SnapshotSignatureData {
+func buildValidSigForBlockRoots(t *testing.T, blockSigRootHexes []string) *SignatureData {
 	t.Helper()
 
 	roots := make([][]byte, 0, len(blockSigRootHexes))
@@ -346,7 +346,7 @@ func buildValidSigForBlockRoots(t *testing.T, blockSigRootHexes []string) *Snaps
 	sigBytes, err := privKey.Sign(computedRoot)
 	require.NoError(t, err)
 
-	return &SnapshotSignatureData{
+	return &SignatureData{
 		MerkleRoot:        merkleRootHex,
 		SignatureValue:    hex.EncodeToString(sigBytes),
 		SignatureType:     "Ed25519",
@@ -356,8 +356,8 @@ func buildValidSigForBlockRoots(t *testing.T, blockSigRootHexes []string) *Snaps
 
 func TestImportWithVerification_SignatureVerificationFail(t *testing.T) {
 	ctx := context.Background()
-	sig := &SnapshotSignatureData{
-		MerkleRoot:    "not-hex!!!",
+	sig := &SignatureData{
+		MerkleRoot:     "not-hex!!!",
 		SignatureValue: "abcd",
 		SignatureType:  "Ed25519",
 	}
@@ -372,7 +372,7 @@ func TestImportWithVerification_FileOpenError(t *testing.T) {
 	merkleRoot := []byte("some-root")
 	pubKeyStr, merkleRootHex, sigHex := generateEd25519TestSig(t, merkleRoot)
 
-	sig := &SnapshotSignatureData{
+	sig := &SignatureData{
 		MerkleRoot:        merkleRootHex,
 		SignatureValue:    sigHex,
 		SignatureType:     "Ed25519",
@@ -388,7 +388,7 @@ func TestImportWithVerification_GzipReaderError(t *testing.T) {
 	merkleRoot := []byte("some-root")
 	pubKeyStr, merkleRootHex, sigHex := generateEd25519TestSig(t, merkleRoot)
 
-	sig := &SnapshotSignatureData{
+	sig := &SignatureData{
 		MerkleRoot:        merkleRootHex,
 		SignatureValue:    sigHex,
 		SignatureType:     "Ed25519",
@@ -397,7 +397,7 @@ func TestImportWithVerification_GzipReaderError(t *testing.T) {
 
 	// Write a file that is NOT gzip compressed.
 	path := filepath.Join(t.TempDir(), "not-gzip.gz")
-	require.NoError(t, os.WriteFile(path, []byte("this is not gzip data"), 0644))
+	require.NoError(t, os.WriteFile(path, []byte("this is not gzip data"), 0o600))
 
 	_, err := ImportWithVerification(ctx, nil, path, sig)
 	require.Error(t, err)
@@ -409,7 +409,7 @@ func TestImportWithVerification_ReadHeaderLengthError(t *testing.T) {
 	merkleRoot := []byte("some-root")
 	pubKeyStr, merkleRootHex, sigHex := generateEd25519TestSig(t, merkleRoot)
 
-	sig := &SnapshotSignatureData{
+	sig := &SignatureData{
 		MerkleRoot:        merkleRootHex,
 		SignatureValue:    sigHex,
 		SignatureType:     "Ed25519",
@@ -424,7 +424,7 @@ func TestImportWithVerification_ReadHeaderLengthError(t *testing.T) {
 	require.NoError(t, gw.Close())
 
 	path := filepath.Join(t.TempDir(), "short-header.gz")
-	require.NoError(t, os.WriteFile(path, buf.Bytes(), 0644))
+	require.NoError(t, os.WriteFile(path, buf.Bytes(), 0o600))
 
 	_, err = ImportWithVerification(ctx, nil, path, sig)
 	require.Error(t, err)
@@ -436,7 +436,7 @@ func TestImportWithVerification_ReadHeaderError(t *testing.T) {
 	merkleRoot := []byte("some-root")
 	pubKeyStr, merkleRootHex, sigHex := generateEd25519TestSig(t, merkleRoot)
 
-	sig := &SnapshotSignatureData{
+	sig := &SignatureData{
 		MerkleRoot:        merkleRootHex,
 		SignatureValue:    sigHex,
 		SignatureType:     "Ed25519",
@@ -455,7 +455,7 @@ func TestImportWithVerification_ReadHeaderError(t *testing.T) {
 	require.NoError(t, gw.Close())
 
 	path := filepath.Join(t.TempDir(), "truncated-header.gz")
-	require.NoError(t, os.WriteFile(path, buf.Bytes(), 0644))
+	require.NoError(t, os.WriteFile(path, buf.Bytes(), 0o600))
 
 	_, err = ImportWithVerification(ctx, nil, path, sig)
 	require.Error(t, err)
@@ -467,7 +467,7 @@ func TestImportWithVerification_InvalidHeaderJSON(t *testing.T) {
 	merkleRoot := []byte("some-root")
 	pubKeyStr, merkleRootHex, sigHex := generateEd25519TestSig(t, merkleRoot)
 
-	sig := &SnapshotSignatureData{
+	sig := &SignatureData{
 		MerkleRoot:        merkleRootHex,
 		SignatureValue:    sigHex,
 		SignatureType:     "Ed25519",
@@ -479,7 +479,7 @@ func TestImportWithVerification_InvalidHeaderJSON(t *testing.T) {
 	var buf bytes.Buffer
 	gw := gzip.NewWriter(&buf)
 	var lenBuf [4]byte
-	binary.BigEndian.PutUint32(lenBuf[:], uint32(len(headerBytes)))
+	binary.BigEndian.PutUint32(lenBuf[:], uint32(len(headerBytes))) //nolint:gosec // header size is always small
 	_, err := gw.Write(lenBuf[:])
 	require.NoError(t, err)
 	_, err = gw.Write(headerBytes)
@@ -487,7 +487,7 @@ func TestImportWithVerification_InvalidHeaderJSON(t *testing.T) {
 	require.NoError(t, gw.Close())
 
 	path := filepath.Join(t.TempDir(), "bad-json-header.gz")
-	require.NoError(t, os.WriteFile(path, buf.Bytes(), 0644))
+	require.NoError(t, os.WriteFile(path, buf.Bytes(), 0o600))
 
 	_, err = ImportWithVerification(ctx, nil, path, sig)
 	require.Error(t, err)
@@ -499,7 +499,7 @@ func TestImportWithVerification_InvalidMagic(t *testing.T) {
 	merkleRoot := []byte("some-root")
 	pubKeyStr, merkleRootHex, sigHex := generateEd25519TestSig(t, merkleRoot)
 
-	sig := &SnapshotSignatureData{
+	sig := &SignatureData{
 		MerkleRoot:        merkleRootHex,
 		SignatureValue:    sigHex,
 		SignatureType:     "Ed25519",
@@ -523,7 +523,7 @@ func TestImportWithVerification_NoBlockSigMerkleRoots(t *testing.T) {
 	merkleRoot := []byte("some-root")
 	pubKeyStr, merkleRootHex, sigHex := generateEd25519TestSig(t, merkleRoot)
 
-	sig := &SnapshotSignatureData{
+	sig := &SignatureData{
 		MerkleRoot:        merkleRootHex,
 		SignatureValue:    sigHex,
 		SignatureType:     "Ed25519",
@@ -548,7 +548,7 @@ func TestImportWithVerification_InvalidBlockSigRootHex(t *testing.T) {
 	merkleRoot := []byte("some-root")
 	pubKeyStr, merkleRootHex, sigHex := generateEd25519TestSig(t, merkleRoot)
 
-	sig := &SnapshotSignatureData{
+	sig := &SignatureData{
 		MerkleRoot:        merkleRootHex,
 		SignatureValue:    sigHex,
 		SignatureType:     "Ed25519",
@@ -579,7 +579,7 @@ func TestImportWithVerification_MerkleRootMismatch(t *testing.T) {
 	differentRoot := []byte("completely-different-root")
 	pubKeyStr, differentRootHex, sigHex := generateEd25519TestSig(t, differentRoot)
 
-	sig := &SnapshotSignatureData{
+	sig := &SignatureData{
 		MerkleRoot:        differentRootHex,
 		SignatureValue:    sigHex,
 		SignatureType:     "Ed25519",
@@ -750,7 +750,7 @@ func TestVerifySignature_VerifyReturnsError(t *testing.T) {
 
 	merkleRoot := []byte("test-merkle-root")
 
-	sig := &SnapshotSignatureData{
+	sig := &SignatureData{
 		MerkleRoot:        hex.EncodeToString(merkleRoot),
 		SignatureValue:    hex.EncodeToString([]byte("too-short")), // wrong length for Ed25519 sig
 		SignatureType:     "Ed25519",

--- a/pkg/snapshot/importer_test.go
+++ b/pkg/snapshot/importer_test.go
@@ -647,7 +647,7 @@ func TestImportWithVerification_BlockSigRootContentMismatch(t *testing.T) {
 
 	_, err := ImportWithVerification(ctx, nil, path, sig)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "block sig root mismatch at index")
+	require.Contains(t, err.Error(), "block sig root mismatch")
 }
 
 func TestImportWithVerification_HappyPath(t *testing.T) {

--- a/pkg/view/constants.go
+++ b/pkg/view/constants.go
@@ -1,0 +1,3 @@
+package view
+
+const minRegexMatchGroups = 3

--- a/pkg/view/errors.go
+++ b/pkg/view/errors.go
@@ -1,0 +1,17 @@
+package view
+
+import "errors"
+
+var ( //nolint:revive
+	ErrViewNameRequired      = errors.New("view name is required")             //nolint:revive
+	ErrViewQueryRequired     = errors.New("view query is required")            //nolint:revive
+	ErrViewSDLRequired       = errors.New("view SDL is required")              //nolint:revive
+	ErrViewQuerySDLRequired  = errors.New("view query and SDL are required")   //nolint:revive
+	ErrLensEmptyPath         = errors.New("lens has empty path")               //nolint:revive
+	ErrLensInvalidBase64     = errors.New("lens contains invalid base64 data") //nolint:revive
+	ErrInvalidWASMFormat     = errors.New("invalid WASM file format for lens") //nolint:revive
+	ErrCollectionNotFound    = errors.New("collection does not exist")         //nolint:revive
+	ErrViewAlreadyRegistered = errors.New("view already registered")           //nolint:revive
+	ErrWASMDownloadFailed    = errors.New("failed to download WASM files")     //nolint:revive
+	ErrHTTPErrorResponse     = errors.New("HTTP error response")               //nolint:revive
+)

--- a/pkg/view/lens_functions_test.go
+++ b/pkg/view/lens_functions_test.go
@@ -13,12 +13,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestSetupLensInDefraDB_NoLenses tests when view has no lenses
+// TestSetupLensInDefraDB_NoLenses tests when view has no lenses.
 func TestSetupLensInDefraDB_NoLenses(t *testing.T) {
 	ctx := context.Background()
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	v := &View{
 		Name: "NoLensView",
@@ -36,12 +36,12 @@ func TestSetupLensInDefraDB_NoLenses(t *testing.T) {
 	require.Empty(t, lensCID)
 }
 
-// TestSetupLensInDefraDB_WithLenses tests lens setup with valid lenses
+// TestSetupLensInDefraDB_WithLenses tests lens setup with valid lenses.
 func TestSetupLensInDefraDB_WithLenses(t *testing.T) {
 	ctx := context.Background()
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	v := &View{
 		Name: "LensView",
@@ -68,7 +68,7 @@ func TestSetupLensInDefraDB_WithLenses(t *testing.T) {
 	}
 }
 
-// TestBuildLensConfig_SingleLens tests building config with one lens
+// TestBuildLensConfig_SingleLens tests building config with one lens.
 func TestBuildLensConfig_SingleLens(t *testing.T) {
 	v := &View{
 		Data: viewbundle.View{
@@ -89,12 +89,12 @@ func TestBuildLensConfig_SingleLens(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, v.Data.Query, config.SourceCollectionVersionID)
 	require.Equal(t, v.Data.Sdl, config.DestinationCollectionVersionID)
-	require.Len(t, config.Lens.Lenses, 1)
+	require.Len(t, config.Lenses, 1)
 	require.Equal(t, "file:///filter.wasm", config.Lens.Lenses[0].Path)
 	require.Equal(t, "value", config.Lens.Lenses[0].Arguments["key"])
 }
 
-// TestBuildLensConfig_MultipleLenses tests building config with multiple lenses
+// TestBuildLensConfig_MultipleLenses tests building config with multiple lenses.
 func TestBuildLensConfig_MultipleLenses(t *testing.T) {
 	v := &View{
 		Data: viewbundle.View{
@@ -121,7 +121,7 @@ func TestBuildLensConfig_MultipleLenses(t *testing.T) {
 
 	config, err := v.BuildLensConfig()
 	require.NoError(t, err)
-	require.Len(t, config.Lens.Lenses, 3)
+	require.Len(t, config.Lenses, 3)
 	require.Equal(t, "file:///filter.wasm", config.Lens.Lenses[0].Path)
 	require.Equal(t, "file:///transform.wasm", config.Lens.Lenses[1].Path)
 	require.Equal(t, "file:///decode.wasm", config.Lens.Lenses[2].Path)
@@ -130,7 +130,7 @@ func TestBuildLensConfig_MultipleLenses(t *testing.T) {
 	require.Equal(t, float64(3), config.Lens.Lenses[2].Arguments["step"])
 }
 
-// TestBuildLensConfig_EmptyArguments tests lens with empty arguments
+// TestBuildLensConfig_EmptyArguments tests lens with empty arguments.
 func TestBuildLensConfig_EmptyArguments(t *testing.T) {
 	v := &View{
 		Data: viewbundle.View{
@@ -149,11 +149,11 @@ func TestBuildLensConfig_EmptyArguments(t *testing.T) {
 
 	config, err := v.BuildLensConfig()
 	require.NoError(t, err)
-	require.Len(t, config.Lens.Lenses, 1)
+	require.Len(t, config.Lenses, 1)
 	require.Empty(t, config.Lens.Lenses[0].Arguments)
 }
 
-// TestBuildLensConfig_InvalidJSON tests lens with invalid JSON arguments
+// TestBuildLensConfig_InvalidJSON tests lens with invalid JSON arguments.
 func TestBuildLensConfig_InvalidJSON(t *testing.T) {
 	v := &View{
 		Data: viewbundle.View{
@@ -175,7 +175,7 @@ func TestBuildLensConfig_InvalidJSON(t *testing.T) {
 	require.Contains(t, err.Error(), "failed to parse lens arguments")
 }
 
-// TestHasLenses_True tests HasLenses returns true when lenses exist
+// TestHasLenses_True tests HasLenses returns true when lenses exist.
 func TestHasLenses_True(t *testing.T) {
 	v := &View{
 		Data: viewbundle.View{
@@ -190,7 +190,7 @@ func TestHasLenses_True(t *testing.T) {
 	require.True(t, v.HasLenses())
 }
 
-// TestHasLenses_False tests HasLenses returns false when no lenses
+// TestHasLenses_False tests HasLenses returns false when no lenses.
 func TestHasLenses_False(t *testing.T) {
 	v := &View{
 		Data: viewbundle.View{
@@ -203,7 +203,7 @@ func TestHasLenses_False(t *testing.T) {
 	require.False(t, v.HasLenses())
 }
 
-// TestHasLenses_Nil tests HasLenses with nil lenses
+// TestHasLenses_Nil tests HasLenses with nil lenses.
 func TestHasLenses_Nil(t *testing.T) {
 	v := &View{
 		Data: viewbundle.View{
@@ -216,7 +216,7 @@ func TestHasLenses_Nil(t *testing.T) {
 	require.False(t, v.HasLenses())
 }
 
-// TestPostWasmToFile_Base64Conversion tests converting base64 WASM to file
+// TestPostWasmToFile_Base64Conversion tests converting base64 WASM to file.
 func TestPostWasmToFile_Base64Conversion(t *testing.T) {
 	tempDir := t.TempDir()
 
@@ -235,7 +235,7 @@ func TestPostWasmToFile_Base64Conversion(t *testing.T) {
 		},
 	}
 
-	err := v.PostWasmToFile(context.Background(), tempDir)
+	err := v.PostWasmToFile(tempDir)
 	require.NoError(t, err)
 
 	// Verify path was updated to file:// URL
@@ -243,13 +243,13 @@ func TestPostWasmToFile_Base64Conversion(t *testing.T) {
 	require.Contains(t, v.Data.Transform.Lenses[0].Path, ".wasm")
 
 	// Verify file exists and has correct content
-	filePath := v.Data.Transform.Lenses[0].Path[7:] // Remove "file://"
-	data, err := os.ReadFile(filePath)
+	path := v.Data.Transform.Lenses[0].Path[7:] // Remove "file://"
+	data, err := os.ReadFile(filepath.Clean(path))
 	require.NoError(t, err)
 	require.Equal(t, wasmData, data)
 }
 
-// TestPostWasmToFile_SkipsFileURLs tests that file:// URLs are not converted
+// TestPostWasmToFile_SkipsFileURLs tests that file:// URLs are not converted.
 func TestPostWasmToFile_SkipsFileURLs(t *testing.T) {
 	tempDir := t.TempDir()
 
@@ -264,14 +264,14 @@ func TestPostWasmToFile_SkipsFileURLs(t *testing.T) {
 		},
 	}
 
-	err := v.PostWasmToFile(context.Background(), tempDir)
+	err := v.PostWasmToFile(tempDir)
 	require.NoError(t, err)
 
 	// Path should remain unchanged
 	require.Equal(t, "file:///already/a/file.wasm", v.Data.Transform.Lenses[0].Path)
 }
 
-// TestPostWasmToFile_SkipsHTTPURLs tests that HTTP URLs are not converted
+// TestPostWasmToFile_SkipsHTTPURLs tests that HTTP URLs are not converted.
 func TestPostWasmToFile_SkipsHTTPURLs(t *testing.T) {
 	tempDir := t.TempDir()
 
@@ -286,14 +286,14 @@ func TestPostWasmToFile_SkipsHTTPURLs(t *testing.T) {
 		},
 	}
 
-	err := v.PostWasmToFile(context.Background(), tempDir)
+	err := v.PostWasmToFile(tempDir)
 	require.NoError(t, err)
 
 	// Path should remain unchanged
 	require.Equal(t, "https://example.com/lens.wasm", v.Data.Transform.Lenses[0].Path)
 }
 
-// TestPostWasmToFile_InvalidWASM tests rejection of invalid WASM data
+// TestPostWasmToFile_InvalidWASM tests rejection of invalid WASM data.
 func TestPostWasmToFile_InvalidWASM(t *testing.T) {
 	tempDir := t.TempDir()
 
@@ -312,12 +312,12 @@ func TestPostWasmToFile_InvalidWASM(t *testing.T) {
 		},
 	}
 
-	err := v.PostWasmToFile(context.Background(), tempDir)
+	err := v.PostWasmToFile(tempDir)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid WASM file format")
 }
 
-// TestPostWasmToFile_TooShortWASM tests rejection of too-short WASM data
+// TestPostWasmToFile_TooShortWASM tests rejection of too-short WASM data.
 func TestPostWasmToFile_TooShortWASM(t *testing.T) {
 	tempDir := t.TempDir()
 
@@ -336,12 +336,12 @@ func TestPostWasmToFile_TooShortWASM(t *testing.T) {
 		},
 	}
 
-	err := v.PostWasmToFile(context.Background(), tempDir)
+	err := v.PostWasmToFile(tempDir)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid WASM file format")
 }
 
-// TestPostWasmToFile_MultipleBase64Lenses tests converting multiple base64 lenses
+// TestPostWasmToFile_MultipleBase64Lenses tests converting multiple base64 lenses.
 func TestPostWasmToFile_MultipleBase64Lenses(t *testing.T) {
 	tempDir := t.TempDir()
 
@@ -360,7 +360,7 @@ func TestPostWasmToFile_MultipleBase64Lenses(t *testing.T) {
 		},
 	}
 
-	err := v.PostWasmToFile(context.Background(), tempDir)
+	err := v.PostWasmToFile(tempDir)
 	require.NoError(t, err)
 
 	// Both should be converted
@@ -371,41 +371,41 @@ func TestPostWasmToFile_MultipleBase64Lenses(t *testing.T) {
 	require.NotEqual(t, v.Data.Transform.Lenses[0].Path, v.Data.Transform.Lenses[1].Path)
 }
 
-// TestIsValidBase64_Valid tests valid base64 detection
+// TestIsValidBase64_Valid tests valid base64 detection.
 func TestIsValidBase64_Valid(t *testing.T) {
 	validBase64 := base64.StdEncoding.EncodeToString([]byte("test data"))
 	require.True(t, isValidBase64(validBase64))
 }
 
-// TestIsValidBase64_Invalid tests invalid base64 detection
+// TestIsValidBase64_Invalid tests invalid base64 detection.
 func TestIsValidBase64_Invalid(t *testing.T) {
 	require.False(t, isValidBase64("not valid base64!!!"))
 }
 
-// TestIsValidWASM_Valid tests valid WASM magic number detection
+// TestIsValidWASM_Valid tests valid WASM magic number detection.
 func TestIsValidWASM_Valid(t *testing.T) {
 	validWasm := []byte{0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00}
 	require.True(t, isValidWASM(validWasm))
 }
 
-// TestIsValidWASM_Invalid tests invalid WASM magic number detection
+// TestIsValidWASM_Invalid tests invalid WASM magic number detection.
 func TestIsValidWASM_Invalid(t *testing.T) {
 	invalidWasm := []byte{0xFF, 0xFF, 0xFF, 0xFF, 0x01, 0x00, 0x00, 0x00}
 	require.False(t, isValidWASM(invalidWasm))
 }
 
-// TestIsValidWASM_TooShort tests WASM data that's too short
+// TestIsValidWASM_TooShort tests WASM data that's too short.
 func TestIsValidWASM_TooShort(t *testing.T) {
 	shortData := []byte{0x00, 0x61, 0x73}
 	require.False(t, isValidWASM(shortData))
 }
 
-// TestConfigureLens_WithoutLensCID tests view configuration without lens CID
+// TestConfigureLens_WithoutLensCID tests view configuration without lens CID.
 func TestConfigureLens_WithoutLensCID(t *testing.T) {
 	ctx := context.Background()
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	// Create source collection
 	_, err = defraNode.DB.AddSchema(ctx, "type Ethereum__Mainnet__Log { address: String }")
@@ -419,17 +419,16 @@ func TestConfigureLens_WithoutLensCID(t *testing.T) {
 		},
 	}
 
-	schemaService := NewSchemaService()
-	err = v.ConfigureLens(ctx, defraNode, schemaService, "")
+	err = v.ConfigureLens(ctx, defraNode, "")
 	require.NoError(t, err)
 }
 
-// TestConfigureLens_WithLensCID tests view configuration with lens CID
+// TestConfigureLens_WithLensCID tests view configuration with lens CID.
 func TestConfigureLens_WithLensCID(t *testing.T) {
 	ctx := context.Background()
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	// Create source collection
 	_, err = defraNode.DB.AddSchema(ctx, "type Ethereum__Mainnet__Transaction { hash: String }")
@@ -443,30 +442,29 @@ func TestConfigureLens_WithLensCID(t *testing.T) {
 		},
 	}
 
-	schemaService := NewSchemaService()
 	// Use a fake lens CID - AddView will handle it
-	err = v.ConfigureLens(ctx, defraNode, schemaService, "bafyreifake123")
+	err = v.ConfigureLens(ctx, defraNode, "bafyreifake123")
 	// May fail if lens CID doesn't exist, but we test the code path
 	if err != nil && !contains(err.Error(), "already exists") {
 		require.Contains(t, err.Error(), "failed to create view")
 	}
 }
 
-// TestBuildLensConfig_ComplexArguments tests lens with complex JSON arguments
+// TestBuildLensConfig_ComplexArguments tests lens with complex JSON arguments.
 func TestBuildLensConfig_ComplexArguments(t *testing.T) {
-	complexArgs := map[string]interface{}{
-		"events": []interface{}{
-			map[string]interface{}{
+	complexArgs := map[string]any{
+		"events": []any{
+			map[string]any{
 				"name": "Transfer",
-				"inputs": []interface{}{
-					map[string]interface{}{"type": "address", "name": "from"},
-					map[string]interface{}{"type": "address", "name": "to"},
-					map[string]interface{}{"type": "uint256", "name": "value"},
+				"inputs": []any{
+					map[string]any{"type": "address", "name": "from"},
+					map[string]any{"type": "address", "name": "to"},
+					map[string]any{"type": "uint256", "name": "value"},
 				},
 			},
 		},
-		"config": map[string]interface{}{
-			"strict": true,
+		"config": map[string]any{
+			"strict":  true,
 			"version": 2,
 		},
 	}
@@ -491,19 +489,19 @@ func TestBuildLensConfig_ComplexArguments(t *testing.T) {
 
 	config, err := v.BuildLensConfig()
 	require.NoError(t, err)
-	require.Len(t, config.Lens.Lenses, 1)
+	require.Len(t, config.Lenses, 1)
 
 	// Verify complex arguments were parsed correctly
 	args := config.Lens.Lenses[0].Arguments
 	require.Contains(t, args, "events")
 	require.Contains(t, args, "config")
 
-	configMap := args["config"].(map[string]interface{})
+	configMap := args["config"].(map[string]any)
 	require.Equal(t, true, configMap["strict"])
 	require.Equal(t, float64(2), configMap["version"])
 }
 
-// TestSaveViewToRegistry tests saving view to registry file
+// TestSaveViewToRegistry tests saving view to registry file.
 func TestSaveViewToRegistry(t *testing.T) {
 	tempDir := t.TempDir()
 
@@ -524,7 +522,7 @@ func TestSaveViewToRegistry(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify content
-	data, err := os.ReadFile(viewsFile)
+	data, err := os.ReadFile(filepath.Clean(viewsFile))
 	require.NoError(t, err)
 
 	var views []View
@@ -534,7 +532,7 @@ func TestSaveViewToRegistry(t *testing.T) {
 	require.Equal(t, "TestView", views[0].Name)
 }
 
-// TestAddViewsFromLensRegistry tests loading views from registry
+// TestAddViewsFromLensRegistry tests loading views from registry.
 func TestAddViewsFromLensRegistry(t *testing.T) {
 	tempDir := t.TempDir()
 
@@ -560,7 +558,7 @@ func TestAddViewsFromLensRegistry(t *testing.T) {
 	require.NoError(t, err)
 
 	viewsFile := filepath.Join(tempDir, "views.json")
-	err = os.WriteFile(viewsFile, data, 0644)
+	err = os.WriteFile(viewsFile, data, 0o600)
 	require.NoError(t, err)
 
 	// Load views
@@ -571,7 +569,7 @@ func TestAddViewsFromLensRegistry(t *testing.T) {
 	require.Equal(t, "View2", loadedViews[1].Name)
 }
 
-// TestAddViewsFromLensRegistry_NoFile tests loading when file doesn't exist
+// TestAddViewsFromLensRegistry_NoFile tests loading when file doesn't exist.
 func TestAddViewsFromLensRegistry_NoFile(t *testing.T) {
 	tempDir := t.TempDir()
 

--- a/pkg/view/schemaService.go
+++ b/pkg/view/schemaService.go
@@ -1,4 +1,3 @@
-// pkg/view/schema_service.go
 package view
 
 import (
@@ -7,13 +6,15 @@ import (
 	"strings"
 )
 
+// SchemaService provides utilities for normalizing and parsing SDL schemas for Shinzo views.
 type SchemaService struct{}
 
+// NewSchemaService creates a new instance of SchemaService.
 func NewSchemaService() *SchemaService {
 	return &SchemaService{}
 }
 
-// NormalizeSDL applies standard transformations to an SDL schema
+// NormalizeSDL applies standard transformations to an SDL schema.
 func (ss *SchemaService) NormalizeSDL(sdl string, typeName string, options SDLOptions) string {
 	// Replace type name if provided
 	if typeName != "" {
@@ -32,11 +33,13 @@ func (ss *SchemaService) NormalizeSDL(sdl string, typeName string, options SDLOp
 	return sdl
 }
 
+// SDLOptions defines options for SDLs within views.
 type SDLOptions struct {
 	Materialized   bool
 	RequiredFields []FieldDef
 }
 
+// FieldDef represents a field definition with a name and type.
 type FieldDef struct {
 	Name string
 	Type string

--- a/pkg/view/view.go
+++ b/pkg/view/view.go
@@ -20,17 +20,19 @@ import (
 	"github.com/sourcenetwork/lens/host-go/config/model"
 )
 
-// Type aliases for viewbundle types
+// Transform is a type alias for viewbundle.Transform.
 type Transform = viewbundle.Transform
+
+// Lens is a type alias for viewbundle.Lens.
 type Lens = viewbundle.Lens
 
-// View represents a Shinzo view with viewbundle integration
+// View represents a Shinzo view with viewbundle integration.
 type View struct {
 	Name string          `json:"name"`
 	Data viewbundle.View `json:"data"`
 }
 
-// NewViewFromWire creates a new View from a viewbundle wire format
+// NewViewFromWire creates a new View from a viewbundle wire format.
 func NewViewFromWire(wire []byte) (*View, error) {
 	bundler := viewbundle.NewBundler()
 	bundledView, err := bundler.UnbundleView(wire)
@@ -49,7 +51,7 @@ func NewViewFromWire(wire []byte) (*View, error) {
 	return view, nil
 }
 
-// NewViewFromBundle creates a new View from a viewbundle.View
+// NewViewFromBundle creates a new View from a viewbundle.View.
 func NewViewFromBundle(bundledView viewbundle.View) (*View, error) {
 	view := &View{
 		Name: "", // Will be extracted from SDL
@@ -62,7 +64,7 @@ func NewViewFromBundle(bundledView viewbundle.View) (*View, error) {
 	return view, nil
 }
 
-// ExtractNameFromSDL extracts the type name from the SDL string
+// ExtractNameFromSDL extracts the type name from the SDL string.
 func (v *View) ExtractNameFromSDL() {
 	if v.Data.Sdl == "" {
 		v.Name = ""
@@ -84,28 +86,28 @@ func (v *View) ExtractNameFromSDL() {
 	}
 }
 
-// Validate validates the view configuration
+// Validate validates the view configuration.
 func (v *View) Validate() error {
 	if v.Name == "" {
-		return fmt.Errorf("view name is required")
+		return ErrViewNameRequired
 	}
 	if v.Data.Query == "" {
-		return fmt.Errorf("view query is required")
+		return ErrViewQueryRequired
 	}
 	if v.Data.Sdl == "" {
-		return fmt.Errorf("view SDL is required")
+		return ErrViewSDLRequired
 	}
 
 	// Validate lenses
 	for i, lens := range v.Data.Transform.Lenses {
 		if lens.Path == "" {
-			return fmt.Errorf("lens %d has empty path", i)
+			return fmt.Errorf("lens %d: %w", i, ErrLensEmptyPath)
 		}
 
 		// Additional validation for base64 WASM
 		if !strings.HasPrefix(lens.Path, "file://") && !strings.HasPrefix(lens.Path, "http") {
 			if !isValidBase64(lens.Path) {
-				return fmt.Errorf("lens %d contains invalid base64 data", i)
+				return fmt.Errorf("lens %d: %w", i, ErrLensInvalidBase64)
 			}
 		}
 	}
@@ -113,23 +115,23 @@ func (v *View) Validate() error {
 	return nil
 }
 
-// SubscribeTo subscribes to the view collection for real-time updates
-func (view *View) SubscribeTo(ctx context.Context, defraNode *node.Node) error {
-	_, err := defraNode.DB.GetCollectionByName(ctx, view.Name)
+// SubscribeTo subscribes to the view collection for real-time updates.
+func (v *View) SubscribeTo(ctx context.Context, defraNode *node.Node) error {
+	_, err := defraNode.DB.GetCollectionByName(ctx, v.Name)
 	if err != nil {
-		return fmt.Errorf("cannot subscribe to view %s: collection does not exist", view.Name)
+		return fmt.Errorf("view %s: %w", v.Name, ErrCollectionNotFound)
 	}
 
-	err = defraNode.DB.CreateP2PCollections(ctx, []string{view.Name})
+	err = defraNode.DB.CreateP2PCollections(ctx, []string{v.Name})
 	if err != nil {
-		return fmt.Errorf("error subscribing to collection %s: %v", view.Name, err)
+		return fmt.Errorf("error subscribing to collection %s: %w", v.Name, err)
 	}
 
 	return nil
 }
 
-// PostWasmToFile writes base64 WASM data to files and updates lens paths
-func (v *View) PostWasmToFile(ctx context.Context, lensRegistryPath string) error {
+// PostWasmToFile writes base64 WASM data to files and updates lens paths.
+func (v *View) PostWasmToFile(lensRegistryPath string) error {
 	registryDir, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("failed to get working directory: %w", err)
@@ -137,7 +139,7 @@ func (v *View) PostWasmToFile(ctx context.Context, lensRegistryPath string) erro
 	registryDir = filepath.Join(registryDir, lensRegistryPath)
 
 	// Create registry directory if it doesn't exist
-	if err := os.MkdirAll(registryDir, 0755); err != nil {
+	if err := os.MkdirAll(registryDir, 0o750); err != nil { // nolint:mnd
 		return fmt.Errorf("failed to create registry directory: %w", err)
 	}
 
@@ -149,7 +151,7 @@ func (v *View) PostWasmToFile(ctx context.Context, lensRegistryPath string) erro
 
 		// Validate base64 WASM data before attempting to decode
 		if !isValidBase64(lense.Path) {
-			return fmt.Errorf("lens %d contains invalid base64 data", i)
+			return fmt.Errorf("lens %d: %w", i, ErrLensInvalidBase64)
 		}
 
 		// Decode base64 WASM
@@ -160,7 +162,7 @@ func (v *View) PostWasmToFile(ctx context.Context, lensRegistryPath string) erro
 
 		// Validate WASM file integrity (check for WASM magic number)
 		if len(wasmDecoded) < 8 || !isValidWASM(wasmDecoded) {
-			return fmt.Errorf("invalid WASM file format for lens %d", i)
+			return fmt.Errorf("lens %d: %w", i, ErrInvalidWASMFormat)
 		}
 
 		// Generate short filename
@@ -170,7 +172,7 @@ func (v *View) PostWasmToFile(ctx context.Context, lensRegistryPath string) erro
 		wasmFilePath := filepath.Join(registryDir, wasmFileName)
 
 		// Write WASM file
-		err = os.WriteFile(wasmFilePath, wasmDecoded, 0644)
+		err = os.WriteFile(wasmFilePath, wasmDecoded, 0o600) //nolint:mnd
 		if err != nil {
 			return fmt.Errorf("failed to write WASM file: %w", err)
 		}
@@ -186,10 +188,10 @@ func (v *View) PostWasmToFile(ctx context.Context, lensRegistryPath string) erro
 	return nil
 }
 
-// ConfigureLens creates the view in DefraDB with the lens transform CID
-func (v *View) ConfigureLens(ctx context.Context, defraNode *node.Node, schemaService *SchemaService, lensCID string) error {
+// ConfigureLens creates the view in DefraDB with the lens transform CID.
+func (v *View) ConfigureLens(ctx context.Context, defraNode *node.Node, lensCID string) error {
 	if v.Data.Query == "" || v.Data.Sdl == "" {
-		return fmt.Errorf("view query and SDL are required")
+		return ErrViewQuerySDLRequired
 	}
 
 	var err error
@@ -228,23 +230,22 @@ func (v *View) ConfigureLens(ctx context.Context, defraNode *node.Node, schemaSe
 				}
 				fmt.Printf("✅ Query auto-corrected successfully for view %s\n", v.Name)
 				return nil
-			} else {
-				fmt.Printf("⚠️ Auto-correction produced same query for view %s\n", v.Name)
 			}
 		}
+		fmt.Printf("⚠️ Auto-correction produced same query for view %s\n", v.Name)
 		return fmt.Errorf("failed to create view: %w", err)
 	}
 
 	return nil
 }
 
-// attemptQueryCorrection tries to fix common field name issues based on error message
+// attemptQueryCorrection tries to fix common field name issues based on error message.
 func (v *View) attemptQueryCorrection(errMsg string) string {
 	// Error format: Cannot query field "inputData" on type "X". Did you mean "input"?
 	re := regexp.MustCompile(`Cannot query field "([^"]+)".*Did you mean "([^"]+)"`)
 	matches := re.FindStringSubmatch(errMsg)
 
-	if len(matches) == 3 {
+	if len(matches) == minRegexMatchGroups {
 		incorrectField := matches[1]
 		suggestedField := matches[2]
 		// Whole-word match so substrings inside other identifiers are not touched.
@@ -257,7 +258,7 @@ func (v *View) attemptQueryCorrection(errMsg string) string {
 
 // SetupLensInDefraDB stores the lens WASM in DefraDB and returns the lens CID
 // Note: SetMigration is NOT called here - it's only needed when using PatchCollection
-// to transform data between collection versions, which we don't do for view lenses
+// to transform data between collection versions, which we don't do for view lenses.
 func SetupLensInDefraDB(ctx context.Context, defraNode *node.Node, v *View) (string, error) {
 	if !v.HasLenses() {
 		return "", nil
@@ -278,7 +279,7 @@ func SetupLensInDefraDB(ctx context.Context, defraNode *node.Node, v *View) (str
 	return lensCID, nil
 }
 
-// BuildLensConfig creates the lens configuration for DefraDB SetMigration
+// BuildLensConfig creates the lens configuration for DefraDB SetMigration.
 func (v *View) BuildLensConfig() (client.LensConfig, error) {
 	lensModules := make([]model.LensModule, 0, len(v.Data.Transform.Lenses))
 
@@ -305,12 +306,12 @@ func (v *View) BuildLensConfig() (client.LensConfig, error) {
 	}, nil
 }
 
-// HasLenses returns true if the view has lens transformations
+// HasLenses returns true if the view has lens transformations.
 func (v *View) HasLenses() bool {
 	return len(v.Data.Transform.Lenses) > 0
 }
 
-// needsWasmConversion returns true if any lens path contains base64 data instead of a file path
+// needsWasmConversion returns true if any lens path contains base64 data instead of a file path.
 func (v *View) needsWasmConversion() bool {
 	for _, lens := range v.Data.Transform.Lenses {
 		// If path doesn't start with file:// or http(s)://, it's likely base64 data
@@ -321,7 +322,7 @@ func (v *View) needsWasmConversion() bool {
 	return false
 }
 
-// Helper function to check if error contains substring
+// Helper function to check if error contains substring.
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr ||
 		(len(s) > len(substr) &&
@@ -339,15 +340,18 @@ func indexOf(s, substr string) int {
 	return -1
 }
 
-// isValidBase64 checks if a string is valid base64
+// isValidBase64 checks if a string is valid base64.
 func isValidBase64(s string) bool {
 	_, err := base64.StdEncoding.DecodeString(s)
 	return err == nil
 }
 
-// isValidWASM checks if the byte slice has a valid WASM magic number
+// defaultWASMLength is the minimum length for a valid WASM file.
+const defaultWASMLength = 8
+
+// isValidWASM checks if the byte slice has a valid WASM magic number.
 func isValidWASM(data []byte) bool {
-	if len(data) < 8 {
+	if len(data) < defaultWASMLength {
 		return false
 	}
 	// WASM magic number: 0x00 0x61 0x73 0x6D (WebAssembly)

--- a/pkg/view/viewManager.go
+++ b/pkg/view/viewManager.go
@@ -14,55 +14,47 @@ import (
 	"go.uber.org/zap"
 )
 
-// ViewRegistrar defines the contract for view registration operations
-type ViewRegistrar interface {
+// Registrar defines the contract for view registration operations.
+type Registrar interface {
 	RegisterView(ctx context.Context, v View) error
 }
 
-type ViewQueueItem struct {
-	viewName      string
-	activeViewKey string
-	lensConfig    *client.LensConfig
-}
-
-// ViewManager orchestrates the complete lifecycle of Shinzo views including:
+// Manager orchestrates the complete lifecycle of Shinzo views including:
 // - Loading views from local storage and external sources
 // - Managing WASM lens files and migrations
 // - Registering views with DefraDB (SetMigration + AddView)
 // - Setting up P2P subscriptions for real-time updates
-// - Tracking active views and metrics
-type ViewManager struct {
+// - Tracking active views and metrics.
+type Manager struct {
 	activeViews     map[string]*client.LensConfig
 	defraNode       *node.Node
 	mutex           sync.RWMutex
 	schemaService   *SchemaService
 	wasmRegistry    *WASMRegistry
 	registryPath    string
-	processingQueue chan ViewQueueItem
 	metricsCallback func() *server.HostMetrics
 }
 
-// NewViewManager creates a new ViewManager with the given DefraDB node and registry path
-// It initializes all required services and sets up the processing queue for async operations
-func NewViewManager(defraNode *node.Node, registryPath string) *ViewManager {
+// NewManager creates a new Manager with the given DefraDB node and registry path
+// It initializes all required services and sets up the processing queue for async operations.
+func NewManager(defraNode *node.Node, registryPath string) *Manager {
 	wasmRegistry, _ := NewWASMRegistry(registryPath, zap.L().Sugar())
-	return &ViewManager{
-		activeViews:     make(map[string]*client.LensConfig),
-		defraNode:       defraNode,
-		schemaService:   NewSchemaService(),
-		wasmRegistry:    wasmRegistry,
-		registryPath:    registryPath,
-		processingQueue: make(chan ViewQueueItem, 100),
+	return &Manager{
+		activeViews:   make(map[string]*client.LensConfig),
+		defraNode:     defraNode,
+		schemaService: NewSchemaService(),
+		wasmRegistry:  wasmRegistry,
+		registryPath:  registryPath,
 	}
 }
 
-// SetMetricsCallback sets the callback function to get metrics for tracking view operations
-func (vm *ViewManager) SetMetricsCallback(callback func() *server.HostMetrics) {
-	vm.metricsCallback = callback
+// SetMetricsCallback sets the callback function to get metrics for tracking view operations.
+func (m *Manager) SetMetricsCallback(callback func() *server.HostMetrics) {
+	m.metricsCallback = callback
 }
 
 // LoadAndRegisterViews loads views from local registry and external sources, ensures WASM files exist, and registers them.
-func (vm *ViewManager) LoadAndRegisterViews(ctx context.Context, externalViews []View) error {
+func (m *Manager) LoadAndRegisterViews(ctx context.Context, externalViews []View) error {
 	var allViews []View
 
 	if len(externalViews) > 0 {
@@ -70,7 +62,7 @@ func (vm *ViewManager) LoadAndRegisterViews(ctx context.Context, externalViews [
 		allViews = append(allViews, externalViews...)
 	}
 
-	localViews, err := AddViewsFromLensRegistry(vm.registryPath)
+	localViews, err := AddViewsFromLensRegistry(m.registryPath)
 	if err != nil {
 		logger.Sugar.Warnf("⚠️ Failed to load local views: %v", err)
 	} else if len(localViews) > 0 {
@@ -88,9 +80,9 @@ func (vm *ViewManager) LoadAndRegisterViews(ctx context.Context, externalViews [
 	logger.Sugar.Infof("📋 Total unique views to register: %d", len(allViews))
 
 	wasmURLs := extractWasmURLsFromViews(allViews)
-	if len(wasmURLs) > 0 && vm.wasmRegistry != nil {
+	if len(wasmURLs) > 0 && m.wasmRegistry != nil {
 		logger.Sugar.Infof("📥 Downloading %d WASM files...", len(wasmURLs))
-		downloaded, err := vm.wasmRegistry.EnsureAllWASM(ctx, wasmURLs)
+		downloaded, err := m.wasmRegistry.EnsureAllWASM(ctx, wasmURLs)
 		if err != nil {
 			logger.Sugar.Warnf("⚠️ Some WASM files failed to download: %v", err)
 		} else {
@@ -99,14 +91,14 @@ func (vm *ViewManager) LoadAndRegisterViews(ctx context.Context, externalViews [
 	}
 
 	for i := range allViews {
-		if err := vm.RegisterView(ctx, &allViews[i]); err != nil {
+		if err := m.RegisterView(ctx, &allViews[i]); err != nil {
 			logger.Sugar.Warnf("⚠️ Failed to register view %s: %v", allViews[i].Name, err)
 			continue
 		}
 		logger.Sugar.Infof("✅ Registered view: %s", allViews[i].Name)
 
 		// Persist view to local registry for next startup (with any auto-corrections applied)
-		if err := SaveViewToRegistry(vm.registryPath, allViews[i]); err != nil {
+		if err := SaveViewToRegistry(m.registryPath, allViews[i]); err != nil {
 			logger.Sugar.Warnf("⚠️ Failed to persist view %s: %v", allViews[i].Name, err)
 		}
 	}
@@ -114,7 +106,7 @@ func (vm *ViewManager) LoadAndRegisterViews(ctx context.Context, externalViews [
 	return nil
 }
 
-// deduplicateViews removes duplicate views by name, keeping the first occurrence
+// deduplicateViews removes duplicate views by name, keeping the first occurrence.
 func deduplicateViews(views []View) []View {
 	seen := make(map[string]bool)
 	result := make([]View, 0, len(views))
@@ -127,7 +119,7 @@ func deduplicateViews(views []View) []View {
 	return result
 }
 
-// extractWasmURLsFromViews extracts HTTP/HTTPS WASM URLs from views
+// extractWasmURLsFromViews extracts HTTP/HTTPS WASM URLs from views.
 func extractWasmURLsFromViews(views []View) []string {
 	var urls []string
 	for _, v := range views {
@@ -140,141 +132,75 @@ func extractWasmURLsFromViews(views []View) []string {
 	return urls
 }
 
-// GetActiveViewNames returns names of all active views
-func (vm *ViewManager) GetActiveViewNames() []string {
-	vm.mutex.RLock()
-	defer vm.mutex.RUnlock()
+// GetActiveViewNames returns names of all active views.
+func (m *Manager) GetActiveViewNames() []string {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
 
-	names := make([]string, 0, len(vm.activeViews))
-	for name := range vm.activeViews {
+	names := make([]string, 0, len(m.activeViews))
+	for name := range m.activeViews {
 		names = append(names, name)
 	}
 	return names
 }
 
-// GetActiveViewDetails returns names + sdl of all active views as [name, sdl] pairs
-func (vm *ViewManager) GetActiveViewDetails() [][]string {
-	vm.mutex.RLock()
-	defer vm.mutex.RUnlock()
+// GetActiveViewDetails returns names + sdl of all active views as [name, sdl] pairs.
+func (m *Manager) GetActiveViewDetails() [][]string {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
 
-	details := make([][]string, 0, len(vm.activeViews))
-	for name, lensConfig := range vm.activeViews {
+	details := make([][]string, 0, len(m.activeViews))
+	for name, lensConfig := range m.activeViews {
 		details = append(details, []string{name, lensConfig.DestinationCollectionVersionID})
 	}
 	return details
 }
 
-// GetViewCount returns the number of active views
-func (vm *ViewManager) GetViewCount() int {
-	vm.mutex.RLock()
-	defer vm.mutex.RUnlock()
-	return len(vm.activeViews)
+// GetViewCount returns the number of active views.
+func (m *Manager) GetViewCount() int {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+	return len(m.activeViews)
 }
 
-// QueueView adds a view to the processing queue
-func (vm *ViewManager) QueueView(v View) {
-	item := ViewQueueItem{
-		viewName:      v.Name,
-		activeViewKey: v.Name,
-	}
-	vm.processingQueue <- item
-}
-
-// RegisterView runs the full view registration flow with validation.
-// A panic from any step (commonly malformed lens WASM at instantiation)
-// is recovered and returned as an error so one bad view does not take
-// down the host.
-func (vm *ViewManager) RegisterView(ctx context.Context, v *View) (err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			err = fmt.Errorf("panic registering view %s: %v", v.Name, r)
-		}
-	}()
-
-	// Debug log the SDL schema when registering
+// RegisterView implements the full view registration flow with validation.
+// RegisterView registers a view with DefraDB and sets up all required infrastructure.
+func (m *Manager) RegisterView(ctx context.Context, v *View) error {
 	logger.Sugar.Debugf("🔍 Registering view: %s", v.Name)
 	logger.Sugar.Debugf("📄 SDL for %s:\n%s", v.Name, v.Data.Sdl)
 	logger.Sugar.Debugf("🎯 Query for %s:\n%s", v.Name, v.Data.Query)
 
-	// Pre-validate view before any operations
 	if err := v.Validate(); err != nil {
 		return fmt.Errorf("view validation failed for %s: %w", v.Name, err)
 	}
 
-	// Pre-emptively fix common query issues (inputData -> input)
-	// This ensures the corrected query is used everywhere, not just in DefraDB
-	if strings.Contains(v.Data.Query, "inputData") {
-		logger.Sugar.Infof("🔧 Pre-correcting query for view %s: replacing 'inputData' with 'input'", v.Name)
-		v.Data.Query = strings.ReplaceAll(v.Data.Query, "inputData", "input")
+	fixQueryInputData(v)
+
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	if _, exists := m.activeViews[v.Name]; exists {
+		return fmt.Errorf("view %s: %w", v.Name, ErrViewAlreadyRegistered)
 	}
 
-	vm.mutex.Lock()
-	defer vm.mutex.Unlock()
-
-	// Check if already registered
-	if _, exists := vm.activeViews[v.Name]; exists {
-		return fmt.Errorf("view %s already registered", v.Name)
+	if err := m.prepareWasm(v); err != nil {
+		return err
 	}
 
-	// Step 0: Convert base64 WASM to files if needed
-	if v.HasLenses() && v.needsWasmConversion() {
-		if err := v.PostWasmToFile(ctx, vm.registryPath); err != nil {
-			return fmt.Errorf("failed to write WASM files for view %s: %w", v.Name, err)
-		}
-	}
-
-	// Step 1: Set up lens and migration if needed
-	logger.Sugar.Infof("Storing lens for view %s", v.Name)
-	lensCID, err := SetupLensInDefraDB(ctx, vm.defraNode, v)
+	lensCID, err := m.setupLens(ctx, v)
 	if err != nil {
-		return fmt.Errorf("failed to setup lens for view %s: %w", v.Name, err)
-	}
-	if lensCID != "" {
-		logger.Sugar.Infof("Lens CID for view %s: %s", v.Name, lensCID)
+		return err
 	}
 
-	// Step 2: Auto-fix collection name if needed and create view in DefraDB.
-	// Skip when the extracted name is empty; strings.Replace with an empty
-	// old string would otherwise insert the prefix at byte 0.
-	sourceCollection := extractCollectionFromQuery(v.Data.Query)
-	if sourceCollection != "" && !strings.HasPrefix(sourceCollection, constants.CollectionChain+"__") {
-		v.Data.Query = strings.Replace(v.Data.Query, sourceCollection, constants.CollectionChain+"__"+sourceCollection, 1)
-		logger.Sugar.Debugf("Fixed collection name: %s → %s__%s", sourceCollection, constants.CollectionChain, sourceCollection)
+	fixCollectionName(v)
+
+	if err := m.configureLensAndSubscribe(ctx, v, lensCID); err != nil {
+		return err
 	}
 
-	err = v.ConfigureLens(ctx, vm.defraNode, vm.schemaService, lensCID)
-	if err != nil {
-		return fmt.Errorf("failed to configure lens for view %s: %w", v.Name, err)
-	}
+	m.updateMetrics()
 
-	// Step 3: Subscribe to view collection for P2P replication
-	err = v.SubscribeTo(ctx, vm.defraNode)
-	if err != nil {
-		logger.Sugar.Warnf("Failed to subscribe to view %s: %v", v.Name, err)
-		// Non-fatal - view can still work
-	}
-
-	// Step 4: Subscribe to source collection for real-time updates
-	if v.Data.Query != "" {
-		sourceCollection := extractCollectionFromQuery(v.Data.Query)
-		if sourceCollection != "" {
-			err = vm.subscribeToSourceCollection(ctx, sourceCollection, v.Name)
-			if err != nil {
-				logger.Sugar.Warnf("Failed to subscribe to source collection %s: %v", sourceCollection, err)
-			}
-		}
-	}
-
-	// Update metrics
-	if vm.metricsCallback != nil {
-		if metrics := vm.metricsCallback(); metrics != nil {
-			metrics.IncrementViewsRegistered()
-			metrics.SetViewsActive(int64(len(vm.activeViews)))
-		}
-	}
-
-	// Step 5: Add view to active views registry
-	vm.activeViews[v.Name] = &client.LensConfig{
+	m.activeViews[v.Name] = &client.LensConfig{
 		SourceCollectionVersionID:      v.Data.Query,
 		DestinationCollectionVersionID: v.Data.Sdl,
 	}
@@ -282,8 +208,81 @@ func (vm *ViewManager) RegisterView(ctx context.Context, v *View) (err error) {
 	return nil
 }
 
-// subscribeToSourceCollection subscribes to a source collection for real-time document updates
-func (vm *ViewManager) subscribeToSourceCollection(ctx context.Context, collectionName, viewName string) error {
+// fixQueryInputData replaces legacy 'inputData' with 'input' in the query.
+func fixQueryInputData(v *View) {
+	if strings.Contains(v.Data.Query, "inputData") {
+		logger.Sugar.Infof("🔧 Pre-correcting query for view %s: replacing 'inputData' with 'input'", v.Name)
+		v.Data.Query = strings.ReplaceAll(v.Data.Query, "inputData", "input")
+	}
+}
+
+// prepareWasm converts base64 WASM to files if needed.
+func (m *Manager) prepareWasm(v *View) error {
+	if v.HasLenses() && v.needsWasmConversion() {
+		if err := v.PostWasmToFile(m.registryPath); err != nil {
+			return fmt.Errorf("failed to write WASM files for view %s: %w", v.Name, err)
+		}
+	}
+	return nil
+}
+
+// setupLens sets up the lens and migration in DefraDB.
+func (m *Manager) setupLens(ctx context.Context, v *View) (string, error) {
+	logger.Sugar.Infof("Storing lens for view %s", v.Name)
+	lensCID, err := SetupLensInDefraDB(ctx, m.defraNode, v)
+	if err != nil {
+		return "", fmt.Errorf("failed to setup lens for view %s: %w", v.Name, err)
+	}
+	if lensCID != "" {
+		logger.Sugar.Infof("Lens CID for view %s: %s", v.Name, lensCID)
+	}
+	return lensCID, nil
+}
+
+// fixCollectionName auto-fixes the collection name in the query if needed.
+func fixCollectionName(v *View) {
+	sourceCollection := extractCollectionFromQuery(v.Data.Query)
+	if sourceCollection != "" && !strings.HasPrefix(sourceCollection, constants.CollectionChain+"__") {
+		v.Data.Query = strings.Replace(v.Data.Query, sourceCollection, constants.CollectionChain+"__"+sourceCollection, 1)
+		logger.Sugar.Debugf("Fixed collection name: %s → %s__%s", sourceCollection, constants.CollectionChain, sourceCollection)
+	}
+}
+
+// configureLensAndSubscribe configures the lens and subscribes to relevant collections.
+func (m *Manager) configureLensAndSubscribe(ctx context.Context, v *View, lensCID string) error {
+	if err := v.ConfigureLens(ctx, m.defraNode, lensCID); err != nil {
+		return fmt.Errorf("failed to configure lens for view %s: %w", v.Name, err)
+	}
+
+	if err := v.SubscribeTo(ctx, m.defraNode); err != nil {
+		logger.Sugar.Warnf("Failed to subscribe to view %s: %v", v.Name, err)
+	}
+
+	if v.Data.Query != "" {
+		sourceCollection := extractCollectionFromQuery(v.Data.Query)
+		if sourceCollection != "" {
+			if err := m.subscribeToSourceCollection(ctx, sourceCollection, v.Name); err != nil {
+				logger.Sugar.Warnf("Failed to subscribe to source collection %s: %v", sourceCollection, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// updateMetrics increments view registration metrics.
+func (m *Manager) updateMetrics() {
+	if m.metricsCallback != nil {
+		if metrics := m.metricsCallback(); metrics != nil {
+			metrics.IncrementViewsRegistered()
+			metrics.SetViewsActive(int64(len(m.activeViews)))
+		}
+	}
+}
+
+// subscribeToSourceCollection subscribes to a source collection for real-time document updates.
+// ctx was replaced with _ because the current implementation is a stub and does not use the context, but it may be needed for future implementations that involve long-running subscriptions or need to handle cancellation.
+func (m *Manager) subscribeToSourceCollection(_ context.Context, collectionName, viewName string) error {
 	// Implementation would use defra.Subscribe to listen for new documents
 	// and trigger view processing when source documents arrive
 	logger.Sugar.Infof("View %s subscribed to source collection %s", viewName, collectionName)
@@ -302,8 +301,8 @@ func extractCollectionFromQuery(query string) string {
 	return query
 }
 
-// suggestCorrectCollection suggests the correct collection name based on available collections
-func (vm *ViewManager) suggestCorrectCollection(invalidCollection string) string {
+// suggestCorrectCollection suggests the correct collection name based on available collections.
+func (m *Manager) suggestCorrectCollection(invalidCollection string) string {
 	// If the collection already starts with a chain network prefix, return as-is
 	if strings.HasPrefix(invalidCollection, constants.CollectionChain+"__") ||
 		strings.Contains(invalidCollection, "__") {

--- a/pkg/view/viewManager.go
+++ b/pkg/view/viewManager.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/constants"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/server"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/node"

--- a/pkg/view/viewManager_test.go
+++ b/pkg/view/viewManager_test.go
@@ -16,10 +16,10 @@ func TestNewViewManager(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	registryPath := t.TempDir()
-	vm := NewViewManager(defraNode, registryPath)
+	vm := NewManager(defraNode, registryPath)
 
 	require.NotNil(t, vm)
 	require.NotNil(t, vm.activeViews)
@@ -33,9 +33,9 @@ func TestViewManager_GetActiveViewNames_Empty(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
-	vm := NewViewManager(defraNode, t.TempDir())
+	vm := NewManager(defraNode, t.TempDir())
 	names := vm.GetActiveViewNames()
 
 	require.Empty(t, names)
@@ -46,9 +46,9 @@ func TestViewManager_GetViewCount_Empty(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
-	vm := NewViewManager(defraNode, t.TempDir())
+	vm := NewManager(defraNode, t.TempDir())
 	count := vm.GetViewCount()
 
 	require.Equal(t, 0, count)
@@ -59,9 +59,9 @@ func TestViewManager_LoadAndRegisterViews_NoViews(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
-	vm := NewViewManager(defraNode, t.TempDir())
+	vm := NewManager(defraNode, t.TempDir())
 	err = vm.LoadAndRegisterViews(ctx, nil)
 
 	require.NoError(t, err)
@@ -176,7 +176,7 @@ func TestView_BuildLensConfig(t *testing.T) {
 
 	require.Equal(t, query, config.SourceCollectionVersionID)
 	require.Equal(t, sdl, config.DestinationCollectionVersionID)
-	require.Len(t, config.Lens.Lenses, 1)
+	require.Len(t, config.Lenses, 1)
 	require.Equal(t, "file://"+"filter_transaction.wasm", config.Lens.Lenses[0].Path)
 	require.Equal(t, map[string]any{}, config.Lens.Lenses[0].Arguments) // Arguments are empty
 }
@@ -186,9 +186,9 @@ func TestViewManager_RegisterView_AlreadyExists(t *testing.T) {
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
-	vm := NewViewManager(defraNode, t.TempDir())
+	vm := NewManager(defraNode, t.TempDir())
 
 	// Manually add a view to activeViews
 	vm.activeViews["TestView"] = nil
@@ -207,7 +207,7 @@ func TestViewManager_RegisterView_AlreadyExists(t *testing.T) {
 	require.Contains(t, err.Error(), "already registered")
 }
 
-// MockWASMRegistry provides a mock implementation for testing
+// MockWASMRegistry provides a mock implementation for testing.
 type MockWASMRegistry struct {
 	downloadedFiles map[string]string
 	downloadError   error
@@ -219,7 +219,7 @@ func NewMockWASMRegistry() *MockWASMRegistry {
 	}
 }
 
-func (m *MockWASMRegistry) EnsureAllWASM(ctx context.Context, urls []string) ([]string, error) {
+func (m *MockWASMRegistry) EnsureAllWASM(_ context.Context, urls []string) ([]string, error) {
 	if m.downloadError != nil {
 		return nil, m.downloadError
 	}
@@ -239,23 +239,23 @@ func (m *MockWASMRegistry) SetDownloadError(err error) {
 	m.downloadError = err
 }
 
-// MockViewManager creates a ViewManager with mocked dependencies to avoid WASM operations
-func MockViewManager(defraNode *node.Node, registryPath string) *ViewManager {
-	vm := NewViewManager(defraNode, registryPath)
+// MockViewManager creates a ViewManager with mocked dependencies to avoid WASM operations.
+func MockViewManager(defraNode *node.Node, registryPath string) *Manager {
+	vm := NewManager(defraNode, registryPath)
 	// Replace WASM registry with mock to avoid any downloads
 	vm.wasmRegistry = nil
 	return vm
 }
 
-// TestViewManager_SetMetricsCallback tests setting metrics callback
+// TestViewManager_SetMetricsCallback tests setting metrics callback.
 func TestViewManager_SetMetricsCallback(t *testing.T) {
 	ctx := context.Background()
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
-	vm := NewViewManager(defraNode, t.TempDir())
+	vm := NewManager(defraNode, t.TempDir())
 
 	// Initially nil
 	require.Nil(t, vm.metricsCallback)
@@ -276,46 +276,15 @@ func TestViewManager_SetMetricsCallback(t *testing.T) {
 	require.True(t, callbackCalled)
 }
 
-// TestViewManager_QueueView tests queuing views for processing
-func TestViewManager_QueueView(t *testing.T) {
-	ctx := context.Background()
-
-	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
-	require.NoError(t, err)
-	defer defraNode.Close(ctx)
-
-	vm := NewViewManager(defraNode, t.TempDir())
-
-	v := View{
-		Name: "TestView",
-		Data: viewbundle.View{
-			Query: "Log { address }",
-			Sdl:   "type TestView { address: String }",
-		},
-	}
-
-	// Queue the view
-	vm.QueueView(v)
-
-	// Check that item was added to queue
-	select {
-	case item := <-vm.processingQueue:
-		require.Equal(t, "TestView", item.viewName)
-		require.Equal(t, "TestView", item.activeViewKey)
-	default:
-		t.Fatal("Expected item in processing queue")
-	}
-}
-
-// TestViewManager_LoadAndRegisterViews_ExternalViews tests loading external views
+// TestViewManager_LoadAndRegisterViews_ExternalViews tests loading external views.
 func TestViewManager_LoadAndRegisterViews_ExternalViews(t *testing.T) {
 	ctx := context.Background()
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
-	vm := NewViewManager(defraNode, t.TempDir())
+	vm := NewManager(defraNode, t.TempDir())
 
 	// Create source collections first
 	_, err = defraNode.DB.AddSchema(ctx, "type Ethereum__Mainnet__Log { address: String }")
@@ -351,15 +320,15 @@ func TestViewManager_LoadAndRegisterViews_ExternalViews(t *testing.T) {
 	require.Contains(t, names, "ExternalView2")
 }
 
-// TestViewManager_LoadAndRegisterViews_ViewWithoutLenses tests loading views without lenses (GitHub Actions compatible)
+// TestViewManager_LoadAndRegisterViews_ViewWithoutLenses tests loading views without lenses (GitHub Actions compatible).
 func TestViewManager_LoadAndRegisterViews_ViewWithoutLenses(t *testing.T) {
 	ctx := context.Background()
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
-	vm := NewViewManager(defraNode, t.TempDir())
+	vm := NewManager(defraNode, t.TempDir())
 
 	// Disable WASM registry completely to avoid any downloads
 	vm.wasmRegistry = nil
@@ -386,15 +355,15 @@ func TestViewManager_LoadAndRegisterViews_ViewWithoutLenses(t *testing.T) {
 	require.Equal(t, 1, vm.GetViewCount())
 }
 
-// TestViewManager_RegisterView_ValidationFailure tests view validation
+// TestViewManager_RegisterView_ValidationFailure tests view validation.
 func TestViewManager_RegisterView_ValidationFailure(t *testing.T) {
 	ctx := context.Background()
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
-	vm := NewViewManager(defraNode, t.TempDir())
+	vm := NewManager(defraNode, t.TempDir())
 
 	// Test invalid view (missing name)
 	v := View{
@@ -410,15 +379,15 @@ func TestViewManager_RegisterView_ValidationFailure(t *testing.T) {
 	require.Contains(t, err.Error(), "view validation failed")
 }
 
-// TestViewManager_RegisterView_QueryCorrection tests inputData -> input correction
+// TestViewManager_RegisterView_QueryCorrection tests inputData -> input correction.
 func TestViewManager_RegisterView_QueryCorrection(t *testing.T) {
 	ctx := context.Background()
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
-	vm := NewViewManager(defraNode, t.TempDir())
+	vm := NewManager(defraNode, t.TempDir())
 
 	v := &View{
 		Name: "CorrectionView",
@@ -440,7 +409,7 @@ func TestViewManager_RegisterView_QueryCorrection(t *testing.T) {
 	require.Contains(t, v.Data.Query, "input")
 }
 
-// TestSuggestCorrectCollection tests collection name correction
+// TestSuggestCorrectCollection tests collection name correction.
 func TestSuggestCorrectCollection(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -471,28 +440,28 @@ func TestSuggestCorrectCollection(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			vm := &ViewManager{}
+			vm := &Manager{}
 			result := vm.suggestCorrectCollection(tt.input)
 			require.Equal(t, tt.expected, result)
 		})
 	}
 }
 
-// TestViewManager_SubscribeToSourceCollection tests subscription functionality
+// TestViewManager_SubscribeToSourceCollection tests subscription functionality.
 func TestViewManager_SubscribeToSourceCollection(t *testing.T) {
 	ctx := context.Background()
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
-	vm := NewViewManager(defraNode, t.TempDir())
+	vm := NewManager(defraNode, t.TempDir())
 
 	err = vm.subscribeToSourceCollection(ctx, "Ethereum__Mainnet__Log", "TestView")
 	require.NoError(t, err)
 }
 
-// TestExtractWasmURLsFromViews_MixedURLs tests extracting HTTP URLs from mixed lens paths
+// TestExtractWasmURLsFromViews_MixedURLs tests extracting HTTP URLs from mixed lens paths.
 func TestExtractWasmURLsFromViews_MixedURLs(t *testing.T) {
 	views := []View{
 		{
@@ -517,15 +486,15 @@ func TestExtractWasmURLsFromViews_MixedURLs(t *testing.T) {
 	require.Contains(t, urls, "http://example.com/lens2.wasm")
 }
 
-// TestViewManager_LoadAndRegisterViews_Deduplication tests view deduplication
+// TestViewManager_LoadAndRegisterViews_Deduplication tests view deduplication.
 func TestViewManager_LoadAndRegisterViews_Deduplication(t *testing.T) {
 	ctx := context.Background()
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
-	vm := NewViewManager(defraNode, t.TempDir())
+	vm := NewManager(defraNode, t.TempDir())
 
 	// Create source collections first
 	_, err = defraNode.DB.AddSchema(ctx, "type Ethereum__Mainnet__Log { address: String }")
@@ -570,16 +539,16 @@ func TestViewManager_LoadAndRegisterViews_Deduplication(t *testing.T) {
 	require.Contains(t, names, "UniqueView")
 }
 
-// TestViewManager_RegisterView_WithBase64WASM tests registration with base64 WASM (completely mocked)
+// TestViewManager_RegisterView_WithBase64WASM tests registration with base64 WASM (completely mocked).
 func TestViewManager_RegisterView_WithBase64WASM(t *testing.T) {
 	ctx := context.Background()
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	// Use regular view manager but disable WASM registry to avoid downloads
-	vm := NewViewManager(defraNode, t.TempDir())
+	vm := NewManager(defraNode, t.TempDir())
 	vm.wasmRegistry = nil
 
 	// Test with a view that has no lenses to avoid WASM complications
@@ -602,15 +571,15 @@ func TestViewManager_RegisterView_WithBase64WASM(t *testing.T) {
 	require.Equal(t, 1, vm.GetViewCount())
 }
 
-// TestViewManager_RegisterView_CollectionNameCorrection tests automatic collection name fixing
+// TestViewManager_RegisterView_CollectionNameCorrection tests automatic collection name fixing.
 func TestViewManager_RegisterView_CollectionNameCorrection(t *testing.T) {
 	ctx := context.Background()
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
-	vm := NewViewManager(defraNode, t.TempDir())
+	vm := NewManager(defraNode, t.TempDir())
 
 	v := &View{
 		Name: "CollectionTestView",
@@ -632,15 +601,15 @@ func TestViewManager_RegisterView_CollectionNameCorrection(t *testing.T) {
 	require.NotEqual(t, "Log { address }", v.Data.Query) // Should not be the original uncorrected form
 }
 
-// TestViewManager_Integration_CompleteFlow tests a complete view registration flow without WASM
+// TestViewManager_Integration_CompleteFlow tests a complete view registration flow without WASM.
 func TestViewManager_Integration_CompleteFlow(t *testing.T) {
 	ctx := context.Background()
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
-	vm := NewViewManager(defraNode, t.TempDir())
+	vm := NewManager(defraNode, t.TempDir())
 
 	// Set up metrics callback
 	metricsCallCount := 0
@@ -674,7 +643,7 @@ func TestViewManager_Integration_CompleteFlow(t *testing.T) {
 	require.Greater(t, metricsCallCount, 0)
 }
 
-// TestExtractCollectionFromQuery_ComplexQueries tests collection extraction from various query formats
+// TestExtractCollectionFromQuery_ComplexQueries tests collection extraction from various query formats.
 func TestExtractCollectionFromQuery_ComplexQueries(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -726,15 +695,15 @@ func TestExtractCollectionFromQuery_ComplexQueries(t *testing.T) {
 	}
 }
 
-// TestViewManager_RegisterView_NoLenses tests view registration without any lenses
+// TestViewManager_RegisterView_NoLenses tests view registration without any lenses.
 func TestViewManager_RegisterView_NoLenses(t *testing.T) {
 	ctx := context.Background()
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
-	vm := NewViewManager(defraNode, t.TempDir())
+	vm := NewManager(defraNode, t.TempDir())
 
 	v := &View{
 		Name: "NoLensesView",
@@ -759,15 +728,15 @@ func TestViewManager_RegisterView_NoLenses(t *testing.T) {
 	require.Contains(t, vm.GetActiveViewNames(), "NoLensesView")
 }
 
-// TestViewManager_RegisterView_WithFileURLs tests view registration with file:// URLs (no downloads)
+// TestViewManager_RegisterView_WithFileURLs tests view registration with file:// URLs (no downloads).
 func TestViewManager_RegisterView_WithFileURLs(t *testing.T) {
 	ctx := context.Background()
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
-	vm := NewViewManager(defraNode, t.TempDir())
+	vm := NewManager(defraNode, t.TempDir())
 
 	v := &View{
 		Name: "FileURLView",
@@ -788,15 +757,15 @@ func TestViewManager_RegisterView_WithFileURLs(t *testing.T) {
 	require.Equal(t, 1, vm.GetViewCount())
 }
 
-// TestViewManager_LoadAndRegisterViews_LocalRegistryError tests handling of local registry errors
+// TestViewManager_LoadAndRegisterViews_LocalRegistryError tests handling of local registry errors.
 func TestViewManager_LoadAndRegisterViews_LocalRegistryError(t *testing.T) {
 	ctx := context.Background()
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
-	vm := NewViewManager(defraNode, t.TempDir())
+	vm := NewManager(defraNode, t.TempDir())
 
 	// Use an invalid registry path that should cause loading to fail
 	vm.registryPath = "/invalid/path/that/does/not/exist"
@@ -807,19 +776,19 @@ func TestViewManager_LoadAndRegisterViews_LocalRegistryError(t *testing.T) {
 	require.Equal(t, 0, vm.GetViewCount())
 }
 
-// TestViewManager_ConcurrentAccess tests thread safety of view manager operations
+// TestViewManager_ConcurrentAccess tests thread safety of view manager operations.
 func TestViewManager_ConcurrentAccess(t *testing.T) {
 	ctx := context.Background()
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
-	vm := NewViewManager(defraNode, t.TempDir())
+	vm := NewManager(defraNode, t.TempDir())
 
 	// Test concurrent access to getters
 	done := make(chan bool, 10)
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		go func() {
 			// These should be thread-safe
 			_ = vm.GetViewCount()
@@ -829,7 +798,7 @@ func TestViewManager_ConcurrentAccess(t *testing.T) {
 	}
 
 	// Wait for all goroutines to complete
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		select {
 		case <-done:
 		case <-ctx.Done():
@@ -838,15 +807,15 @@ func TestViewManager_ConcurrentAccess(t *testing.T) {
 	}
 }
 
-// TestViewManager_MetricsCallbackError tests metrics callback error handling
+// TestViewManager_MetricsCallbackError tests metrics callback error handling.
 func TestViewManager_MetricsCallbackError(t *testing.T) {
 	ctx := context.Background()
 
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
-	vm := NewViewManager(defraNode, t.TempDir())
+	vm := NewManager(defraNode, t.TempDir())
 
 	// Set a callback that returns nil (error case)
 	vm.SetMetricsCallback(func() *server.HostMetrics {
@@ -870,7 +839,7 @@ func TestViewManager_MetricsCallbackError(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// TestDeduplicateViews_ComplexScenarios tests deduplication with edge cases
+// TestDeduplicateViews_ComplexScenarios tests deduplication with edge cases.
 func TestDeduplicateViews_ComplexScenarios(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/view/viewManager_test.go
+++ b/pkg/view/viewManager_test.go
@@ -276,38 +276,7 @@ func TestViewManager_SetMetricsCallback(t *testing.T) {
 	require.True(t, callbackCalled)
 }
 
-// TestViewManager_QueueView tests queuing views for processing
-func TestViewManager_QueueView(t *testing.T) {
-	ctx := context.Background()
-
-	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
-	require.NoError(t, err)
-	defer defraNode.Close(ctx)
-
-	vm := NewViewManager(defraNode, t.TempDir())
-
-	v := View{
-		Name: "TestView",
-		Data: viewbundle.View{
-			Query: "Log { address }",
-			Sdl:   "type TestView { address: String }",
-		},
-	}
-
-	// Queue the view
-	vm.QueueView(v)
-
-	// Check that item was added to queue
-	select {
-	case item := <-vm.processingQueue:
-		require.Equal(t, "TestView", item.viewName)
-		require.Equal(t, "TestView", item.activeViewKey)
-	default:
-		t.Fatal("Expected item in processing queue")
-	}
-}
-
-// TestViewManager_LoadAndRegisterViews_ExternalViews tests loading external views
+// TestViewManager_LoadAndRegisterViews_ExternalViews tests loading external views.
 func TestViewManager_LoadAndRegisterViews_ExternalViews(t *testing.T) {
 	ctx := context.Background()
 

--- a/pkg/view/view_test.go
+++ b/pkg/view/view_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestView_SubscribeTo tests basic view subscription functionality
+// TestView_SubscribeTo tests basic view subscription functionality.
 func TestView_SubscribeTo(t *testing.T) {
 	ctx := context.Background()
 
@@ -27,7 +27,7 @@ func TestView_SubscribeTo(t *testing.T) {
 	// Create a mock DefraDB node
 	defraNode, err := defra.StartDefraInstanceWithTestConfig(t, defra.DefaultConfig, &defra.MockSchemaApplierThatSucceeds{})
 	require.NoError(t, err)
-	defer defraNode.Close(ctx)
+	defer func() { _ = defraNode.Close(ctx) }()
 
 	// SubscribeTo should fail because the collection doesn't exist yet
 	err = testView.SubscribeTo(ctx, defraNode)
@@ -35,7 +35,7 @@ func TestView_SubscribeTo(t *testing.T) {
 	require.Contains(t, err.Error(), "collection does not exist")
 }
 
-// TestView_HasLenses tests lens detection
+// TestView_HasLenses tests lens detection.
 func TestView_HasLenses(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -79,7 +79,7 @@ func TestView_HasLenses(t *testing.T) {
 	}
 }
 
-// TestView_NeedsWasmConversion tests WASM conversion detection
+// TestView_NeedsWasmConversion tests WASM conversion detection.
 func TestView_NeedsWasmConversion(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -129,7 +129,7 @@ func TestView_NeedsWasmConversion(t *testing.T) {
 	}
 }
 
-// TestView_ExtractNameFromSDL tests SDL name extraction
+// TestView_ExtractNameFromSDL tests SDL name extraction.
 func TestView_ExtractNameFromSDL(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/view/wasmRegistry.go
+++ b/pkg/view/wasmRegistry.go
@@ -26,29 +26,32 @@ type WASMRegistry struct {
 	cached       map[string]string // url/hash -> local file path
 }
 
+// defaultHTTPClientTimeout is the default timeout for HTTP client requests.
+const defaultHTTPClientTimeout = 30 * time.Second
+
 // NewWASMRegistry creates a new WASM registry with the specified storage path.
 func NewWASMRegistry(registryPath string, logger *zap.SugaredLogger) (*WASMRegistry, error) {
 	// Create registry directory if it doesn't exist
-	if err := os.MkdirAll(registryPath, 0755); err != nil {
+	if err := os.MkdirAll(registryPath, 0o750); err != nil { // nolint:mnd
 		return nil, fmt.Errorf("failed to create WASM registry directory: %w", err)
 	}
 
 	return &WASMRegistry{
 		registryPath: registryPath,
 		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
+			Timeout: defaultHTTPClientTimeout,
 		},
 		logger: logger,
 		cached: make(map[string]string),
 	}, nil
 }
 
-// AddViewsFromLensRegistry loads persisted view definitions from views.json in the registry
+// AddViewsFromLensRegistry loads persisted view definitions from views.json in the registry.
 func AddViewsFromLensRegistry(registryPath string) ([]View, error) {
 	viewsFilePath := filepath.Join(registryPath, "views.json")
 
 	// Check if views.json exists
-	data, err := os.ReadFile(viewsFilePath)
+	data, err := os.ReadFile(filepath.Clean(viewsFilePath))
 	if err != nil {
 		if os.IsNotExist(err) {
 			// No persisted views - return empty slice (not an error)
@@ -66,7 +69,7 @@ func AddViewsFromLensRegistry(registryPath string) ([]View, error) {
 	return views, nil
 }
 
-// SaveViewToRegistry persists a view definition to views.json
+// SaveViewToRegistry persists a view definition to views.json.
 func SaveViewToRegistry(registryPath string, v View) error {
 	viewsFilePath := filepath.Join(registryPath, "views.json")
 
@@ -95,7 +98,7 @@ func SaveViewToRegistry(registryPath string, v View) error {
 		return fmt.Errorf("failed to marshal views: %w", err)
 	}
 
-	return os.WriteFile(viewsFilePath, data, 0644)
+	return os.WriteFile(viewsFilePath, data, 0o600) //nolint:mnd
 }
 
 // EnsureWASM checks if a WASM file exists locally, downloads it if not.
@@ -152,7 +155,7 @@ func (r *WASMRegistry) EnsureAllWASM(ctx context.Context, wasmURLs []string) (ma
 	}
 
 	if len(errors) > 0 {
-		return results, fmt.Errorf("failed to download %d WASM files", len(errors))
+		return results, fmt.Errorf("%d files: %w", len(errors), ErrWASMDownloadFailed)
 	}
 
 	return results, nil
@@ -248,23 +251,23 @@ func (r *WASMRegistry) downloadWASM(ctx context.Context, url, destPath string) e
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, resp.Status)
+		return fmt.Errorf("HTTP %d %s: %w", resp.StatusCode, resp.Status, ErrHTTPErrorResponse)
 	}
 
 	// Create temp file first, then rename for atomicity
 	tmpPath := destPath + ".tmp"
-	f, err := os.Create(tmpPath)
+	f, err := os.Create(filepath.Clean(tmpPath))
 	if err != nil {
 		return err
 	}
 
 	_, err = io.Copy(f, resp.Body)
-	f.Close()
+	_ = f.Close()
 	if err != nil {
-		os.Remove(tmpPath)
+		_ = os.Remove(tmpPath)
 		return err
 	}
 

--- a/playground/playground.go
+++ b/playground/playground.go
@@ -10,4 +10,3 @@ import (
 
 //go:embed dist
 var Dist embed.FS
-

--- a/playground/playground_windows.go
+++ b/playground/playground_windows.go
@@ -10,4 +10,3 @@ import (
 
 //go:embed dist
 var Dist embed.FS
-


### PR DESCRIPTION
# Pull Request

# Pull Request

## Description
Fixes all linter errors. This branch includes the cilint file. Will need to circle back to fix err113.

## Changes
- new lint ci file
- fixed all linter errors.
- app-sdk bump 
- attestation.attestationrecord is now attestation.record
- view.viewmanager is now view.manager
- snapshot.snapshot* is now snapshot.*

## Related Issue
#208 

## Checklist
- [x] Code compiles / runs
- [x] Tests added / updated
- [x] Documentation updated if needed
- [x] PR is self-contained and focused
- [x] Code does not break any existing features
- [x] Code passes personal internal testing

