### PR TITLE
Menna/develop

### DIFF
--- a/.github/DEPLOYMENT.md
+++ b/.github/DEPLOYMENT.md
@@ -68,7 +68,7 @@ docker run -d \
   -p 9181:9181 \
   -p 9182:9182 \
   -p 9171:9171 \
-  -v $(pwd)/data/defradb:/app/.defra/data \
+  -v $(pwd)/data/defradb:/app/.defra \
   -v $(pwd)/data/lens:/app/.lens \
   -v $(pwd)/config.yaml:/app/config.yaml:ro \
   -e DEFRA_URL=0.0.0.0:9181 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -134,7 +134,7 @@ ENV LOG_STACKTRACE=false
 # 9182: GraphQL Playground (if enabled)
 EXPOSE 9181 9182 9171
 
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost:9181 || exit 1
+HEALTHCHECK --interval=15s --timeout=30s --start-period=120s --retries=10 \
+    CMD wget --no-verbose --tries=1 --spider http://localhost:8080/metrics || exit 1
 
 CMD ["./host"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -118,7 +118,7 @@ COPY --from=builder /app/config/config.yaml /app/config.yaml
 COPY --from=builder /app/playground/dist /app/playground/dist
 
 # Create directories for data persistence
-RUN mkdir -p .defra/data .lens && \
+RUN mkdir -p .defra .lens && \
     chown -R shinzo:shinzo /app
 
 # Switch to non-root user

--- a/config/config.go
+++ b/config/config.go
@@ -184,6 +184,13 @@ func LoadConfig(path string) (*Config, error) {
 		cfg.DefraDB.P2P.BootstrapPeers = strings.Split(v, ",")
 	}
 
+	// DEFRA_URL overrides defradb.url at runtime, so deployment artifacts
+	// can pick a different bind address (e.g. 0.0.0.0:9181 instead of the
+	// loopback-only default) without editing the YAML.
+	if v := os.Getenv("DEFRA_URL"); v != "" {
+		cfg.DefraDB.URL = v
+	}
+
 	return &cfg, nil
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -229,3 +229,31 @@ func TestLoadConfig_BootstrapPeersEnvOverride(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []string{"peer1", "peer2", "peer3"}, cfg.DefraDB.P2P.BootstrapPeers)
 }
+
+func TestLoadConfig_DefraURLEnvOverride(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.yaml")
+
+	err := os.WriteFile(configPath, []byte("defradb:\n  url: localhost:9181\n"), 0o600)
+	require.NoError(t, err)
+
+	t.Setenv("DEFRA_URL", "0.0.0.0:9181")
+
+	cfg, err := LoadConfig(configPath)
+	require.NoError(t, err)
+	require.Equal(t, "0.0.0.0:9181", cfg.DefraDB.URL)
+}
+
+func TestLoadConfig_DefraURLEnvUnsetKeepsYAML(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.yaml")
+
+	err := os.WriteFile(configPath, []byte("defradb:\n  url: localhost:9181\n"), 0o600)
+	require.NoError(t, err)
+
+	t.Setenv("DEFRA_URL", "")
+
+	cfg, err := LoadConfig(configPath)
+	require.NoError(t, err)
+	require.Equal(t, "localhost:9181", cfg.DefraDB.URL)
+}

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -25,8 +25,7 @@ services:
     restart: unless-stopped
     container_name: shinzo-host
     volumes:
-      - ~/data/defradb:/app/.defra/data
-      - ~/data/keys:/app/.defra/keys
+      - ~/data/defradb:/app/.defra
       - ~/data/lens:/app/.lens
       - ~/shinzo-host-client/config.yaml:/app/config.yaml:ro
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - "444:9182"  # GraphQL Playground 
       - "9171:9171"  # P2P networking (still needs external access)
     # volumes:
-    #   - ./data/defradb:/app/.defra/data
+    #   - ./data/defradb:/app/.defra
     #   - ./data/lens:/app/.lens
     #   - ./config.yaml:/app/config.yaml:ro
     environment:

--- a/go.mod
+++ b/go.mod
@@ -11,11 +11,14 @@ require (
 	github.com/rs/zerolog v1.34.0
 	github.com/shinzonetwork/shinzo-indexer-client v0.0.0-20251219184827-5722330739e8
 	github.com/shinzonetwork/viewbundle-go v0.1.1
+	github.com/sourcenetwork/acp_core v0.8.1
 	github.com/sourcenetwork/corelog v0.0.8
 	github.com/sourcenetwork/defradb v0.20.1-0.20260324203720-98437e4f0d60
 	github.com/sourcenetwork/immutable v0.3.0
 	github.com/sourcenetwork/lens/host-go v0.10.0
+	github.com/sourcenetwork/sourcehub v0.4.1-0.20260128164915-1bce44032618
 	github.com/stretchr/testify v1.11.1
+	github.com/vektah/gqlparser/v2 v2.5.33
 	go.uber.org/zap v1.27.1
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -316,7 +319,6 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/skip-mev/block-sdk/v2 v2.1.5 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
-	github.com/sourcenetwork/acp_core v0.8.1 // indirect
 	github.com/sourcenetwork/corekv v0.3.1 // indirect
 	github.com/sourcenetwork/corekv/badger v0.3.1 // indirect
 	github.com/sourcenetwork/corekv/blockstore v0.3.1 // indirect
@@ -331,7 +333,6 @@ require (
 	github.com/sourcenetwork/graphql-go v0.7.10-0.20251126162830-73185f9b1d45 // indirect
 	github.com/sourcenetwork/raccoondb v0.2.1-0.20240722161350-d4a78b691ec8 // indirect
 	github.com/sourcenetwork/raccoondb/v2 v2.0.0 // indirect
-	github.com/sourcenetwork/sourcehub v0.4.1-0.20260128164915-1bce44032618 // indirect
 	github.com/sourcenetwork/zanzi v0.3.1-0.20251104182341-4b1bd0f7be5a // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spf13/afero v1.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -739,6 +739,8 @@ github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b h1:mimo19zliBX/vS
 github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b/go.mod h1:fvzegU4vN3H1qMT+8wDmzjAcDONcgo2/SZ/TyfdUOFs=
 github.com/alexkohler/prealloc v1.0.0/go.mod h1:VetnK3dIgFBBKmg0YnD9F9x6Icjd+9cvfHR56wJVlKE=
 github.com/alingse/asasalint v0.0.10/go.mod h1:nCaoMhw7a9kSJObvQyVzNTPBDbNpdocqrSP7t/cW5+I=
+github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
+github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/brotli v1.0.2/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/andybalholm/brotli v1.0.3/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
@@ -2464,6 +2466,8 @@ github.com/valyala/fastjson v1.6.4 h1:uAUNq9Z6ymTgGhcm0UynUAB6tlbakBrz6CQFax3BXV
 github.com/valyala/fastjson v1.6.4/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
 github.com/valyala/quicktemplate v1.7.0/go.mod h1:sqKJnoaOF88V07vkO+9FL8fb9uZg/VPSJnLYn+LmLk8=
 github.com/valyala/tcplisten v1.0.0/go.mod h1:T0xQ8SeCZGxckz9qRXTfG43PvQ/mcWh7FwZEA7Ioqkc=
+github.com/vektah/gqlparser/v2 v2.5.33 h1:lRp8aIeNUNbimf/axZd7ETg24q06hBtPaas+TcvI/7E=
+github.com/vektah/gqlparser/v2 v2.5.33/go.mod h1:c1I28gSOVNzlfc4WuDlqU7voQnsqI6OG2amkBAFmgts=
 github.com/vektra/mockery/v2 v2.14.0/go.mod h1:bnD1T8tExSgPD1ripLkDbr60JA9VtQeu12P3wgLZd7M=
 github.com/viki-org/dnscache v0.0.0-20130720023526-c70c1f23c5d8/go.mod h1:dniwbG03GafCjFohMDmz6Zc6oCuiqgH6tGNyXTkHzXE=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=

--- a/host-prod-setup.sh
+++ b/host-prod-setup.sh
@@ -5,8 +5,9 @@ defradb:
   p2p:
     enabled: true
     bootstrap_peers:
-      - '/ip4/34.63.13.57/tcp/9171/p2p/12D3KooW9vHms1Uyzai3j8L3ZykcPhLYXoHifzrhgKP6HaTmszbV'
-      - '/ip4/35.208.241.78/tcp/9171/p2p/12D3KooWDUN4xrdREQ4qcAbRmHb1otefmwi6F3a9FTsZdconUHUZ' # IND2
+      - '/ip4/34.63.13.57/tcp/9171/p2p/12D3KooWBT2F45LH7Gy6EadTE3sm7PKofyJ3RXcCnKufdu4L5c4M' # IND1
+      - '/ip4/35.208.241.78/tcp/9171/p2p/12D3KooWDYXkjdncFL3X1SaaYBpFi4XfWskbXv4y5gYdTvmGm3bo' # IND2
+      - '/ip4/35.209.45.53/tcp/9171/p2p/12D3KooWNLCXZEVZoM6NwU1i7zAZDscEZHhynsF74M5hP99sptM9' # IND3
     listen_addr: "/ip4/0.0.0.0/tcp/9171"
     max_retries: 5                  # Number of connection attempts before marking peer as failed
     retry_base_delay_ms: 1000       # Base delay for exponential backoff (1s, 2s, 4s, 8s, 16s)
@@ -71,7 +72,7 @@ shinzo:
     # In blocklist mode a document is rejected if it matches any enabled group.
     groups:
       - name: "uniswap-v3"       # Human-readable label (for logs)
-        enabled: true             # Set to false to disable this group without removing it
+        enabled: false             # Set to false to disable this group without removing it
         # Contract filters - match documents by on-chain address.
         # "types" controls which collection types this address applies to:
         #   "transaction" - matches tx.to field
@@ -91,7 +92,7 @@ shinzo:
             # topic2: "0x..."    # Optional: filter by indexed param 2
             # topic3: "0x..."    # Optional: filter by indexed param 3
       - name: "stablecoins"
-        enabled: true
+        enabled: false
         contracts:
           - name: "USDT"
             address: "0xdAC17F958D2ee523a2206206994597C13D831ec7"
@@ -135,7 +136,7 @@ networks:
 services:
   shinzo-host:
     image: ghcr.io/shinzonetwork/shinzo-host-client:standard
-    user: "1003:1006" # update to match your user and group id.
+    user: "1001:1001" # update to match your user and group id.
     mem_limit: 16g
     mem_reservation: 13g
     restart: unless-stopped
@@ -157,6 +158,7 @@ services:
       - LOG_LEVEL=error
       - LOG_SOURCE=false
       - LOG_STACKTRACE=false
+      - ALLOWED_ORIGINS=https://*.shinzo.network
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/metrics"]
       interval: 15s
@@ -183,50 +185,107 @@ sudo tee ~/nginx.conf <<'EOF'
 events { worker_connections 1024; }
 
 http {
-  # Only allow this origin for CORS
+  resolver 127.0.0.11 valid=10s;
+
   map $http_origin $cors_origin {
     default "";
     "https://explorer.shinzo.network" $http_origin;
   }
 
   server {
-    listen 8080;
-    server_name _;
+    listen 80;
+    listen 443 ssl;
+    server_name api.shinzo.network;
 
-    # CORS headers for ALL responses from this server
-    add_header 'Access-Control-Allow-Origin' $cors_origin always;
-    add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
-    add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type, Accept, Origin' always;
-    add_header 'Access-Control-Max-Age' 3600 always;
-    add_header 'Vary' 'Origin' always;
+    ssl_certificate     /etc/nginx/ssl/nginx.crt;
+    ssl_certificate_key /etc/nginx/ssl/nginx.key;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_ciphers         HIGH:!aNULL:!MD5;
 
-    # Generic preflight handler (OPTIONS to any path)
-    location / {
-      if ($request_method = OPTIONS) {
-        return 204;
-      }
+    set $backend "shinzo-host";
 
-      proxy_pass http://shinzo-host:9181;
-      proxy_set_header Host $host;
-    }
-
-    # Metrics endpoint
     location = /metrics {
       if ($request_method = OPTIONS) {
+        add_header 'Access-Control-Allow-Origin'  $cors_origin always;
+        add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS' always;
+        add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type, Accept, Origin' always;
+        add_header 'Access-Control-Max-Age'       3600 always;
+        add_header 'Vary'                         'Origin' always;
         return 204;
       }
-
-      proxy_pass http://shinzo-host:8080/metrics;
+      add_header 'Access-Control-Allow-Origin'  $cors_origin always;
+      add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS' always;
+      add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type, Accept, Origin' always;
+      add_header 'Vary'                         'Origin' always;
+      proxy_pass http://$backend:8080/metrics;
       proxy_set_header Host $host;
     }
 
-    # GraphQL endpoint
-    location = /api/v0/graphql {
+    location = /health {
       if ($request_method = OPTIONS) {
+        add_header 'Access-Control-Allow-Origin'  $cors_origin always;
+        add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS' always;
+        add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type, Accept, Origin' always;
+        add_header 'Access-Control-Max-Age'       3600 always;
+        add_header 'Vary'                         'Origin' always;
         return 204;
       }
+      add_header 'Access-Control-Allow-Origin'  $cors_origin always;
+      add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS' always;
+      add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type, Accept, Origin' always;
+      add_header 'Vary'                         'Origin' always;
+      proxy_pass http://$backend:8080/health;
+      proxy_set_header Host $host;
+    }
 
-      proxy_pass http://shinzo-host:9181/api/v0/graphql;
+    location = /registration {
+      if ($request_method = OPTIONS) {
+        add_header 'Access-Control-Allow-Origin'  $cors_origin always;
+        add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS' always;
+        add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type, Accept, Origin' always;
+        add_header 'Access-Control-Max-Age'       3600 always;
+        add_header 'Vary'                         'Origin' always;
+        return 204;
+      }
+      add_header 'Access-Control-Allow-Origin'  $cors_origin always;
+      add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS' always;
+      add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type, Accept, Origin' always;
+      add_header 'Vary'                         'Origin' always;
+      proxy_pass http://$backend:8080/registration;
+      proxy_set_header Host $host;
+    }
+
+    location = /api/v0/graphql {
+      if ($request_method = OPTIONS) {
+        add_header 'Access-Control-Allow-Origin'  $cors_origin always;
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
+        add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type, Accept, Origin' always;
+        add_header 'Access-Control-Max-Age'       3600 always;
+        add_header 'Vary'                         'Origin' always;
+        return 204;
+      }
+      add_header 'Access-Control-Allow-Origin'  $cors_origin always;
+      add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
+      add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type, Accept, Origin' always;
+      add_header 'Vary'                         'Origin' always;
+      proxy_pass http://$backend:9181/api/v0/graphql;
+      proxy_set_header Host $host;
+    }
+
+    location / {
+      if ($request_method = OPTIONS) {
+        add_header 'Access-Control-Allow-Origin'  $cors_origin always;
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
+        add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type, Accept, Origin' always;
+        add_header 'Access-Control-Max-Age'       3600 always;
+        add_header 'Vary'                         'Origin' always;
+        return 204;
+      }
+      add_header 'Access-Control-Allow-Origin'  $cors_origin always;
+      add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
+      add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type, Accept, Origin' always;
+      add_header 'Vary'                         'Origin' always;
+      proxy_pass http://$backend:9181;
       proxy_set_header Host $host;
     }
   }

--- a/host-prod-setup.sh
+++ b/host-prod-setup.sh
@@ -148,8 +148,7 @@ services:
       - "444:9182"  # GraphQL Playground 
       - "9171:9171"  # P2P networking (still needs external access)
     volumes:
-      - ~/data/defradb:/app/.defra/data
-      - ~/data/keys:/app/.defra/keys
+      - ~/data/defradb:/app/.defra
       - ~/data/lens:/app/.lens
       - ~/config.yaml:/app/config.yaml:ro
     environment:

--- a/host-prod.sh
+++ b/host-prod.sh
@@ -10,5 +10,5 @@ sudo rm /tmp/nginx.csr
 sudo apt-get update &&
 sudo apt-get install -y docker.io docker-compose nginx &&
 sudo mkdir -p ~/data/defradb ~/data/keys ~/data/lens &&
-sudo chown -R 1003:1006 ~/data/defradb ~/data/keys ~/data/lens &&
+sudo chown -R 1001:1001 ~/data/defradb ~/data/keys ~/data/lens &&
 docker-compose up -d

--- a/host-prod.sh
+++ b/host-prod.sh
@@ -9,6 +9,6 @@ sudo rm /tmp/nginx.csr
 # Install dependencies and start the host
 sudo apt-get update &&
 sudo apt-get install -y docker.io docker-compose nginx &&
-sudo mkdir -p ~/data/defradb ~/data/keys ~/data/lens &&
-sudo chown -R 1001:1001 ~/data/defradb ~/data/keys ~/data/lens &&
+sudo mkdir -p ~/data/defradb ~/data/lens &&
+sudo chown -R 1001:1001 ~/data/defradb ~/data/lens &&
 docker-compose up -d

--- a/pkg/acp/authorizer.go
+++ b/pkg/acp/authorizer.go
@@ -1,0 +1,94 @@
+package acp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	coreTypes "github.com/sourcenetwork/acp_core/pkg/types"
+	sourcehub "github.com/sourcenetwork/sourcehub/sdk"
+	sourcehubTypes "github.com/sourcenetwork/sourcehub/x/acp/types"
+)
+
+// Sentinel errors reported by NewSourceHubAuthorizer when a required
+// configuration value is missing. Callers branch on these with errors.Is
+// rather than parsing error strings.
+var (
+	ErrGRPCAddrRequired  = errors.New("sourcehub grpc address required")
+	ErrCometAddrRequired = errors.New("sourcehub comet rpc address required")
+	ErrPolicyIDRequired  = errors.New("sourcehub policy id required")
+)
+
+// Authorizer answers: may this caller read this view? The middleware
+// holds an Authorizer rather than calling SourceHub directly so the
+// test surface can substitute a stub and stay free of any gRPC
+// dependency.
+type Authorizer interface {
+	AuthorizeView(ctx context.Context, callerDID, contractAddr string) (bool, error)
+}
+
+// Resource and permission names match the SourceHub policy expression
+// `view.read = (subscriber) - banned` registered for Shinzo. Hard-coded
+// because the middleware only gates the view resource on read; mutations
+// continue through whatever path the policy defines.
+const (
+	viewResourceName = "view"
+	readPermission   = "read"
+)
+
+// SourceHubAuthorizer evaluates view-read access by calling SourceHub's
+// VerifyAccessRequest. The call is a Cosmos read query against the ACP
+// keeper: no gas, no transaction, latency bounded by the network hop to
+// the configured gRPC endpoint.
+type SourceHubAuthorizer struct {
+	client   *sourcehub.Client
+	policyID string
+}
+
+// NewSourceHubAuthorizer dials SourceHub over gRPC and CometBFT RPC and
+// returns a ready Authorizer. The CometBFT RPC endpoint is required by
+// the SDK even when the caller only uses read queries.
+func NewSourceHubAuthorizer(grpcAddr, cometRPCAddr, policyID string) (*SourceHubAuthorizer, error) {
+	if grpcAddr == "" {
+		return nil, ErrGRPCAddrRequired
+	}
+	if cometRPCAddr == "" {
+		return nil, ErrCometAddrRequired
+	}
+	if policyID == "" {
+		return nil, ErrPolicyIDRequired
+	}
+	client, err := sourcehub.NewClient(
+		sourcehub.WithGRPCAddr(grpcAddr),
+		sourcehub.WithCometRPCAddr(cometRPCAddr),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("sourcehub client: %w", err)
+	}
+	return &SourceHubAuthorizer{
+		client:   client,
+		policyID: policyID,
+	}, nil
+}
+
+// AuthorizeView returns true if SourceHub's policy evaluation finds a
+// subscriber tuple for (contractAddr, callerDID) under the configured
+// policy. A non-nil error from the gRPC call is treated by the caller as
+// an indeterminate state, distinct from a clean "deny".
+func (a *SourceHubAuthorizer) AuthorizeView(ctx context.Context, callerDID, contractAddr string) (bool, error) {
+	resp, err := a.client.ACPQueryClient().VerifyAccessRequest(ctx,
+		&sourcehubTypes.QueryVerifyAccessRequestRequest{
+			PolicyId: a.policyID,
+			AccessRequest: &coreTypes.AccessRequest{
+				Operations: []*coreTypes.Operation{{
+					Object:     coreTypes.NewObject(viewResourceName, contractAddr),
+					Permission: readPermission,
+				}},
+				Actor: &coreTypes.Actor{Id: callerDID},
+			},
+		})
+	if err != nil {
+		return false, fmt.Errorf("verify access request: %w", err)
+	}
+	return resp.Valid, nil
+}

--- a/pkg/acp/authorizer.go
+++ b/pkg/acp/authorizer.go
@@ -24,7 +24,7 @@ var (
 // test surface can substitute a stub and stay free of any gRPC
 // dependency.
 type Authorizer interface {
-	AuthorizeView(ctx context.Context, callerDID, contractAddr string) (bool, error)
+	AuthorizeView(ctx context.Context, callerDID, viewName, contractAddr string) (bool, error)
 }
 
 // Resource and permission names match the SourceHub policy expression
@@ -72,16 +72,19 @@ func NewSourceHubAuthorizer(grpcAddr, cometRPCAddr, policyID string) (*SourceHub
 }
 
 // AuthorizeView returns true if SourceHub's policy evaluation finds a
-// subscriber tuple for (contractAddr, callerDID) under the configured
-// policy. A non-nil error from the gRPC call is treated by the caller as
-// an indeterminate state, distinct from a clean "deny".
-func (a *SourceHubAuthorizer) AuthorizeView(ctx context.Context, callerDID, contractAddr string) (bool, error) {
+// subscriber tuple for the view under the configured policy. The object
+// id is "<viewName>_<contractAddr>", matching the format ShinzoHub's
+// ViewRegistry precompile uses at registration. A non-nil error from
+// the gRPC call is treated by the caller as an indeterminate state,
+// distinct from a clean "deny".
+func (a *SourceHubAuthorizer) AuthorizeView(ctx context.Context, callerDID, viewName, contractAddr string) (bool, error) {
+	viewID := fmt.Sprintf("%s_%s", viewName, contractAddr)
 	resp, err := a.client.ACPQueryClient().VerifyAccessRequest(ctx,
 		&sourcehubTypes.QueryVerifyAccessRequestRequest{
 			PolicyId: a.policyID,
 			AccessRequest: &coreTypes.AccessRequest{
 				Operations: []*coreTypes.Operation{{
-					Object:     coreTypes.NewObject(viewResourceName, contractAddr),
+					Object:     coreTypes.NewObject(viewResourceName, viewID),
 					Permission: readPermission,
 				}},
 				Actor: &coreTypes.Actor{Id: callerDID},

--- a/pkg/acp/authorizer_test.go
+++ b/pkg/acp/authorizer_test.go
@@ -1,0 +1,45 @@
+package acp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testGRPCAddr  = "localhost:9090"
+	testCometAddr = "tcp://localhost:26657"
+	testPolicyID  = "policy-1"
+)
+
+// NewSourceHubAuthorizer must reject incomplete configuration up front; a
+// missing grpc address, comet rpc address, or policy id all leave the
+// SDK in a state where the first AuthorizeView call would silently fail
+// far from its cause.
+func TestNewSourceHubAuthorizer_RejectsMissingParams(t *testing.T) {
+	tests := []struct {
+		name      string
+		grpc      string
+		comet     string
+		policy    string
+		expectErr error
+	}{
+		{name: "missing grpc", grpc: "", comet: testCometAddr, policy: testPolicyID, expectErr: ErrGRPCAddrRequired},
+		{name: "missing comet", grpc: testGRPCAddr, comet: "", policy: testPolicyID, expectErr: ErrCometAddrRequired},
+		{name: "missing policy", grpc: testGRPCAddr, comet: testCometAddr, policy: "", expectErr: ErrPolicyIDRequired},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a, err := NewSourceHubAuthorizer(tt.grpc, tt.comet, tt.policy)
+			require.ErrorIs(t, err, tt.expectErr)
+			require.Nil(t, a)
+		})
+	}
+}
+
+// The positive-path constructor (NewSourceHubAuthorizer with valid grpc +
+// comet + policy) reaches out to CometBFT during NewClient, so it requires
+// a live SourceHub to exercise. That path is covered end-to-end by the
+// integration stages against a local or develop-devnet SourceHub; keeping
+// it out of the unit suite avoids a flaky dependency on external services.

--- a/pkg/acp/config.go
+++ b/pkg/acp/config.go
@@ -1,0 +1,84 @@
+package acp
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+)
+
+// ErrConfigIncomplete is returned by Config.Validate when the middleware
+// is enabled but a required endpoint value is missing. Callers branch on
+// it via errors.Is; the formatted error includes the offending env var
+// name for operator debugging.
+var ErrConfigIncomplete = errors.New("acp middleware enabled without required endpoint")
+
+// Environment variable names the middleware reads at startup.
+const (
+	EnvEnabled        = "ACP_MIDDLEWARE_ENABLED"
+	EnvSourceHubGRPC  = "SOURCEHUB_GRPC_ADDR"
+	EnvSourceHubComet = "SOURCEHUB_COMET_RPC"
+	EnvPolicyID       = "SHINZO_POLICY_ID"
+)
+
+// Config holds the runtime configuration for the access-control middleware.
+//
+// Enabled toggles the middleware on or off without removing it from the
+// handler chain: when false, requests pass through to defradb unchanged
+// and no SourceHub query fires. The three endpoint fields are consumed by
+// SourceHubAuthorizer when Enabled is true.
+type Config struct {
+	Enabled        bool
+	SourceHubGRPC  string
+	SourceHubComet string
+	PolicyID       string
+}
+
+// LoadConfigFromEnv reads the middleware configuration from the process
+// environment. When Enabled is true, missing endpoint values return an
+// error so the host fails to start rather than silently running ungated.
+func LoadConfigFromEnv() (Config, error) {
+	cfg := Config{
+		Enabled:        parseBool(os.Getenv(EnvEnabled)),
+		SourceHubGRPC:  os.Getenv(EnvSourceHubGRPC),
+		SourceHubComet: os.Getenv(EnvSourceHubComet),
+		PolicyID:       os.Getenv(EnvPolicyID),
+	}
+	if err := cfg.Validate(); err != nil {
+		return cfg, err
+	}
+	return cfg, nil
+}
+
+// Validate returns an error when the middleware is enabled but any of the
+// endpoint values is missing. A disabled middleware is always valid; its
+// endpoint fields may be empty and the middleware will short-circuit.
+func (c Config) Validate() error {
+	if !c.Enabled {
+		return nil
+	}
+	if c.SourceHubGRPC == "" {
+		return fmt.Errorf("%w: %s", ErrConfigIncomplete, EnvSourceHubGRPC)
+	}
+	if c.SourceHubComet == "" {
+		return fmt.Errorf("%w: %s", ErrConfigIncomplete, EnvSourceHubComet)
+	}
+	if c.PolicyID == "" {
+		return fmt.Errorf("%w: %s", ErrConfigIncomplete, EnvPolicyID)
+	}
+	return nil
+}
+
+// parseBool returns true only for explicit truthy strings ("1", "t",
+// "true", etc. per strconv.ParseBool). An unset variable or unparseable
+// value is treated as false so the middleware is opt-in.
+func parseBool(s string) bool {
+	if s == "" {
+		return false
+	}
+	b, err := strconv.ParseBool(s)
+	if err != nil {
+		return false
+	}
+	return b
+}

--- a/pkg/acp/config_test.go
+++ b/pkg/acp/config_test.go
@@ -1,0 +1,109 @@
+package acp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadConfigFromEnv_DisabledByDefault(t *testing.T) {
+	t.Setenv(EnvEnabled, "")
+	t.Setenv(EnvSourceHubGRPC, "")
+	t.Setenv(EnvSourceHubComet, "")
+	t.Setenv(EnvPolicyID, "")
+
+	cfg, err := LoadConfigFromEnv()
+	require.NoError(t, err)
+	require.False(t, cfg.Enabled)
+}
+
+// Truthy values per strconv.ParseBool ("1", "t", "true", case-insensitive)
+// all enable the middleware; anything else is treated as opt-out.
+func TestLoadConfigFromEnv_EnabledViaTruthyStrings(t *testing.T) {
+	cases := []string{"1", "t", "T", "true", "True", "TRUE"}
+	for _, val := range cases {
+		t.Run(val, func(t *testing.T) {
+			t.Setenv(EnvEnabled, val)
+			t.Setenv(EnvSourceHubGRPC, testGRPCAddr)
+			t.Setenv(EnvSourceHubComet, testCometAddr)
+			t.Setenv(EnvPolicyID, testPolicyID)
+
+			cfg, err := LoadConfigFromEnv()
+			require.NoError(t, err)
+			require.True(t, cfg.Enabled)
+		})
+	}
+}
+
+func TestLoadConfigFromEnv_UnparseableFlagDisables(t *testing.T) {
+	t.Setenv(EnvEnabled, "yesplease")
+
+	cfg, err := LoadConfigFromEnv()
+	require.NoError(t, err)
+	require.False(t, cfg.Enabled, "unparseable boolean must default to disabled, not error")
+}
+
+// When enabled, missing endpoint values must error rather than silently
+// produce a half-configured Authorizer. Each missing field is reported
+// individually so the operator can see which variable is wrong.
+func TestLoadConfigFromEnv_EnabledRequiresAllEndpoints(t *testing.T) {
+	tests := []struct {
+		name     string
+		grpc     string
+		comet    string
+		policy   string
+		expectIn string
+	}{
+		{name: "missing grpc", comet: testCometAddr, policy: testPolicyID, expectIn: EnvSourceHubGRPC},
+		{name: "missing comet", grpc: testGRPCAddr, policy: testPolicyID, expectIn: EnvSourceHubComet},
+		{name: "missing policy", grpc: testGRPCAddr, comet: testCometAddr, expectIn: EnvPolicyID},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(EnvEnabled, "true")
+			t.Setenv(EnvSourceHubGRPC, tt.grpc)
+			t.Setenv(EnvSourceHubComet, tt.comet)
+			t.Setenv(EnvPolicyID, tt.policy)
+
+			cfg, err := LoadConfigFromEnv()
+			require.ErrorIs(t, err, ErrConfigIncomplete)
+			require.Contains(t, err.Error(), tt.expectIn)
+			require.True(t, cfg.Enabled, "Enabled should still reflect the env var even when validation fails, so the operator can see what was attempted")
+		})
+	}
+}
+
+func TestLoadConfigFromEnv_EnabledWithAllParamsSucceeds(t *testing.T) {
+	const realPolicyID = "3542e098142bb863819519bf54661a1df3b6e32d5ca42b4687132c0e5b81a066"
+	t.Setenv(EnvEnabled, "true")
+	t.Setenv(EnvSourceHubGRPC, testGRPCAddr)
+	t.Setenv(EnvSourceHubComet, testCometAddr)
+	t.Setenv(EnvPolicyID, realPolicyID)
+
+	cfg, err := LoadConfigFromEnv()
+	require.NoError(t, err)
+	require.True(t, cfg.Enabled)
+	require.Equal(t, testGRPCAddr, cfg.SourceHubGRPC)
+	require.Equal(t, testCometAddr, cfg.SourceHubComet)
+	require.Equal(t, realPolicyID, cfg.PolicyID)
+}
+
+// Validate is exposed so callers that build Config programmatically
+// (not via env) can run the same check. Verify it agrees with the env
+// loader's enforcement.
+func TestConfig_Validate_AgreesWithLoader(t *testing.T) {
+	disabled := Config{Enabled: false}
+	require.NoError(t, disabled.Validate())
+
+	enabledIncomplete := Config{Enabled: true, SourceHubGRPC: testGRPCAddr}
+	require.ErrorIs(t, enabledIncomplete.Validate(), ErrConfigIncomplete)
+
+	enabledComplete := Config{
+		Enabled:        true,
+		SourceHubGRPC:  testGRPCAddr,
+		SourceHubComet: testCometAddr,
+		PolicyID:       testPolicyID,
+	}
+	require.NoError(t, enabledComplete.Validate())
+}

--- a/pkg/acp/middleware.go
+++ b/pkg/acp/middleware.go
@@ -1,0 +1,207 @@
+package acp
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
+	"go.uber.org/zap"
+)
+
+// GraphQLPath is the request path the middleware gates. Requests with any
+// other path are passed through to the wrapped handler unchanged.
+const GraphQLPath = "/api/v0/graphql"
+
+const (
+	authHeader   = "Authorization"
+	bearerPrefix = "Bearer "
+)
+
+// ErrAuthRequired is the error returned by an Authenticator when the
+// caller has not provided a valid bearer token. The middleware maps it
+// to a 403 response.
+var ErrAuthRequired = errors.New("authentication required")
+
+// Authenticator extracts and verifies the caller identity from an HTTP
+// request. The production implementation parses the bearer JWT and
+// checks the audience claim; tests may substitute a stub.
+type Authenticator interface {
+	CallerDID(r *http.Request) (string, error)
+}
+
+// Middleware applies access-control to incoming GraphQL requests.
+//
+// Decision tree for a request to GraphQLPath:
+//   - Body parse fails           -> 400 Bad Request
+//   - No view collections        -> pass through (auth optional)
+//   - View(s) but no/invalid JWT -> 403 Forbidden
+//   - Authorizer reports error   -> 503 Service Unavailable
+//   - Any view denied            -> 403 Forbidden
+//   - All views allowed          -> pass through
+//
+// Non-GraphQL paths bypass every step above.
+type Middleware struct {
+	auth     Authenticator
+	authz    Authorizer
+	registry ViewRegistry
+	log      *zap.SugaredLogger
+}
+
+// NewMiddleware returns a Middleware that uses auth to identify the
+// caller, authz for per-view permission checks, and registry to resolve
+// collection names to on-chain addresses. A nil log argument is replaced
+// with a no-op logger so callers in tests do not have to initialize the
+// package-level logger.
+func NewMiddleware(auth Authenticator, authz Authorizer, registry ViewRegistry, log *zap.SugaredLogger) *Middleware {
+	if log == nil {
+		log = zap.NewNop().Sugar()
+	}
+	return &Middleware{auth: auth, authz: authz, registry: registry, log: log}
+}
+
+// Wrap returns an http.Handler that runs the gating policy before
+// delegating to next.
+func (m *Middleware) Wrap(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != GraphQLPath {
+			next.ServeHTTP(w, r)
+			return
+		}
+		m.handleGraphQL(w, r, next)
+	})
+}
+
+// viewLookup pairs a collection name with its resolved contract address.
+type viewLookup struct {
+	Name    string
+	Address string
+}
+
+func (m *Middleware) handleGraphQL(w http.ResponseWriter, r *http.Request, next http.Handler) {
+	collections, err := ExtractCollections(r)
+	if err != nil {
+		m.log.Warnw("acp.parse_failed", "err", err, "path", r.URL.Path)
+		http.Error(w, "bad graphql request", http.StatusBadRequest)
+		return
+	}
+
+	lookups, ok := m.collectViewLookups(w, collections)
+	if !ok {
+		return
+	}
+	if len(lookups) == 0 {
+		// No view collections in this request. Authentication is the
+		// downstream handler's concern when there is nothing to gate.
+		next.ServeHTTP(w, r)
+		return
+	}
+
+	callerDID, err := m.auth.CallerDID(r)
+	if err != nil {
+		m.log.Infow("acp.deny",
+			"reason", "no_identity",
+			"err", err.Error(),
+			"path", r.URL.Path)
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+
+	for _, lookup := range lookups {
+		if !m.authorizeOne(w, r, callerDID, lookup) {
+			return
+		}
+	}
+
+	next.ServeHTTP(w, r)
+}
+
+// collectViewLookups resolves each top-level collection name through the
+// registry. Returns (lookups, true) when every view in the request has an
+// on-chain address. Returns (nil, false) after writing a 503 response
+// when a registered view is missing its address (fail-closed).
+func (m *Middleware) collectViewLookups(w http.ResponseWriter, collections []string) ([]viewLookup, bool) {
+	var lookups []viewLookup
+	for _, name := range collections {
+		if !m.registry.IsView(name) {
+			continue
+		}
+		addr, ok := m.registry.ContractAddress(name)
+		if !ok {
+			m.log.Errorw("acp.view_without_address",
+				"view", name,
+				"action", "fail_closed")
+			http.Error(w, "view metadata unavailable", http.StatusServiceUnavailable)
+			return nil, false
+		}
+		lookups = append(lookups, viewLookup{Name: name, Address: addr})
+	}
+	return lookups, true
+}
+
+// authorizeOne issues a single AuthorizeView call. Returns true on allow,
+// false after writing the appropriate error response on deny or error.
+func (m *Middleware) authorizeOne(w http.ResponseWriter, r *http.Request, callerDID string, lookup viewLookup) bool {
+	start := time.Now()
+	allowed, err := m.authz.AuthorizeView(r.Context(), callerDID, lookup.Address)
+	latencyMS := time.Since(start).Milliseconds()
+	switch {
+	case err != nil:
+		m.log.Errorw("acp.error",
+			"view", lookup.Name,
+			"address", lookup.Address,
+			"did", callerDID,
+			"latency_ms", latencyMS,
+			"err", err)
+		http.Error(w, "authorization backend unavailable", http.StatusServiceUnavailable)
+		return false
+	case !allowed:
+		m.log.Infow("acp.deny",
+			"reason", "no_subscription",
+			"view", lookup.Name,
+			"address", lookup.Address,
+			"did", callerDID,
+			"latency_ms", latencyMS)
+		http.Error(w, "forbidden: no subscription", http.StatusForbidden)
+		return false
+	default:
+		m.log.Infow("acp.allow",
+			"view", lookup.Name,
+			"address", lookup.Address,
+			"did", callerDID,
+			"latency_ms", latencyMS)
+		return true
+	}
+}
+
+// BearerJWTAuth is the production Authenticator. It parses the
+// Authorization header as a defradb-format JWT, verifies the signature
+// against the issuer DID's public key, and checks the audience matches
+// the request's Host header. The type is stateless; callers construct
+// it directly with BearerJWTAuth{}.
+type BearerJWTAuth struct{}
+
+// CallerDID returns the issuer DID from the request's bearer token after
+// verifying the signature and audience. All failure modes wrap
+// ErrAuthRequired so callers can branch on it via errors.Is.
+func (BearerJWTAuth) CallerDID(r *http.Request) (string, error) {
+	raw := r.Header.Get(authHeader)
+	if raw == "" {
+		return "", fmt.Errorf("%w: missing header", ErrAuthRequired)
+	}
+	if !strings.HasPrefix(raw, bearerPrefix) {
+		return "", fmt.Errorf("%w: missing Bearer prefix", ErrAuthRequired)
+	}
+	token := strings.TrimPrefix(raw, bearerPrefix)
+	ident, err := acpIdentity.FromToken([]byte(token))
+	if err != nil {
+		return "", fmt.Errorf("%w: parse: %w", ErrAuthRequired, err)
+	}
+	audience := strings.ToLower(r.Host)
+	if err := acpIdentity.VerifyAuthToken(ident, audience); err != nil {
+		return "", fmt.Errorf("%w: verify: %w", ErrAuthRequired, err)
+	}
+	return ident.DID(), nil
+}

--- a/pkg/acp/middleware.go
+++ b/pkg/acp/middleware.go
@@ -145,7 +145,7 @@ func (m *Middleware) collectViewLookups(w http.ResponseWriter, collections []str
 // false after writing the appropriate error response on deny or error.
 func (m *Middleware) authorizeOne(w http.ResponseWriter, r *http.Request, callerDID string, lookup viewLookup) bool {
 	start := time.Now()
-	allowed, err := m.authz.AuthorizeView(r.Context(), callerDID, lookup.Address)
+	allowed, err := m.authz.AuthorizeView(r.Context(), callerDID, lookup.Name, lookup.Address)
 	latencyMS := time.Since(start).Milliseconds()
 	switch {
 	case err != nil:

--- a/pkg/acp/middleware_test.go
+++ b/pkg/acp/middleware_test.go
@@ -1,0 +1,404 @@
+package acp
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Shared test constants used across the acp package's test suite.
+const (
+	testViewFilteredLogs = "FilteredLogs"
+	testViewFilteredTxs  = "FilteredTxs"
+	testContractA        = "0xabc"
+	testContractB        = "0xdef"
+	testDIDAlice         = "did:key:alice"
+	testDIDEve           = "did:key:eve"
+	testOpBNamed         = "Bar"
+)
+
+// errTestAuthzFail simulates a transport-level failure from the
+// authorizer (e.g., SourceHub unreachable). Declared at package scope
+// so test assertions can branch on it via errors.Is.
+var errTestAuthzFail = errors.New("test: authorizer transport failure")
+
+// Non-graphql paths must bypass the gating logic entirely. The
+// registry and request are set up so that, if the path check were
+// removed, the request would be denied: the body references a view
+// the registry knows about and the authenticator refuses every caller.
+// Passing through under that configuration proves the path check is
+// the only thing skipping the gate.
+func TestMiddleware_NonGraphQLPathPassesThrough(t *testing.T) {
+	authz := newFakeAuthorizer()
+	reg := fakeRegistry{views: map[string]string{testViewFilteredLogs: testContractA}}
+	mw := NewMiddleware(noAuth{}, authz, reg, nil)
+
+	next := &recordingNext{}
+	srv := mw.Wrap(next)
+
+	body := []byte(`{"query":"{ FilteredLogs { hash } }"}`)
+	r := httptest.NewRequest(http.MethodPost, "/api/v0/collections", bytes.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.True(t, next.called)
+	require.Empty(t, authz.calls, "non-graphql request must not invoke the authorizer")
+}
+
+// A graphql request that touches no view collections requires no
+// authentication and passes through to next.
+func TestMiddleware_NonViewQueryPassesWithoutAuth(t *testing.T) {
+	authz := newFakeAuthorizer()
+	reg := fakeRegistry{views: map[string]string{}}
+	mw := NewMiddleware(noAuth{}, authz, reg, nil)
+
+	next := &recordingNext{}
+	srv := mw.Wrap(next)
+
+	body := []byte(`{"query":"{ Block { number } }"}`)
+	r := newGraphQLPost(body)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.True(t, next.called)
+	require.Empty(t, authz.calls)
+}
+
+// A view collection without authentication is denied. The middleware
+// does not consult the authorizer because there is no caller identity
+// to evaluate.
+func TestMiddleware_ViewQueryWithoutAuthIs403(t *testing.T) {
+	authz := newFakeAuthorizer()
+	reg := fakeRegistry{views: map[string]string{testViewFilteredLogs: testContractA}}
+	mw := NewMiddleware(noAuth{}, authz, reg, nil)
+
+	next := &recordingNext{}
+	srv := mw.Wrap(next)
+
+	body := []byte(`{"query":"{ FilteredLogs { hash } }"}`)
+	r := newGraphQLPost(body)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusForbidden, w.Code)
+	require.False(t, next.called)
+	require.Empty(t, authz.calls)
+}
+
+// Happy path: the caller is authenticated and the authorizer allows.
+// Middleware forwards to next.
+func TestMiddleware_ViewQueryWithValidAuth_Allowed(t *testing.T) {
+	authz := newFakeAuthorizer()
+	authz.allow(testDIDAlice, testContractA)
+	reg := fakeRegistry{views: map[string]string{testViewFilteredLogs: testContractA}}
+	mw := NewMiddleware(stubAuth{did: testDIDAlice}, authz, reg, nil)
+
+	next := &recordingNext{}
+	srv := mw.Wrap(next)
+
+	body := []byte(`{"query":"{ FilteredLogs { hash } }"}`)
+	r := newGraphQLPost(body)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.True(t, next.called)
+	require.Equal(t, []authzCall{{testDIDAlice, testContractA}}, authz.calls)
+}
+
+// The authorizer denies the request; middleware returns 403 without
+// calling next.
+func TestMiddleware_ViewQueryDeniedByAuthorizer_403(t *testing.T) {
+	authz := newFakeAuthorizer() // default: deny everything
+	reg := fakeRegistry{views: map[string]string{testViewFilteredLogs: testContractA}}
+	mw := NewMiddleware(stubAuth{did: testDIDEve}, authz, reg, nil)
+
+	next := &recordingNext{}
+	srv := mw.Wrap(next)
+
+	body := []byte(`{"query":"{ FilteredLogs { hash } }"}`)
+	r := newGraphQLPost(body)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusForbidden, w.Code)
+	require.False(t, next.called)
+	require.Len(t, authz.calls, 1, "the authorizer must be consulted before denying")
+}
+
+// A transport-level error from the authorizer (SourceHub unreachable,
+// gRPC failure, etc.) is an indeterminate result, not a deny. The
+// middleware maps it to 503 so the caller can retry once the backend
+// recovers.
+func TestMiddleware_ViewQueryAuthorizerError_503(t *testing.T) {
+	authz := newFakeAuthorizer()
+	authz.fail(testDIDAlice, testContractA, errTestAuthzFail)
+	reg := fakeRegistry{views: map[string]string{testViewFilteredLogs: testContractA}}
+	mw := NewMiddleware(stubAuth{did: testDIDAlice}, authz, reg, nil)
+
+	next := &recordingNext{}
+	srv := mw.Wrap(next)
+
+	body := []byte(`{"query":"{ FilteredLogs { hash } }"}`)
+	r := newGraphQLPost(body)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+	require.False(t, next.called)
+}
+
+// A view that is registered but missing its contract address fails
+// closed (503). The authorizer is never consulted because we don't have
+// an object_id to look up against.
+func TestMiddleware_ViewWithoutAddressFailsClosed(t *testing.T) {
+	authz := newFakeAuthorizer()
+	reg := fakeRegistry{views: map[string]string{testViewFilteredLogs: ""}} // registered, no address
+	mw := NewMiddleware(stubAuth{did: testDIDAlice}, authz, reg, nil)
+
+	next := &recordingNext{}
+	srv := mw.Wrap(next)
+
+	body := []byte(`{"query":"{ FilteredLogs { hash } }"}`)
+	r := newGraphQLPost(body)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+	require.False(t, next.called)
+	require.Empty(t, authz.calls, "fail-closed must not consult the authorizer")
+}
+
+// When a single request selects multiple views, all must be authorized.
+// One denial fails the whole request even if other views would have
+// been allowed.
+func TestMiddleware_MultipleViewsAllMustPass(t *testing.T) {
+	authz := newFakeAuthorizer()
+	authz.allow(testDIDAlice, testContractA)
+	// 0xdef is not in the allow map, so it defaults to deny.
+	reg := fakeRegistry{
+		views: map[string]string{
+			testViewFilteredLogs: testContractA,
+			testViewFilteredTxs:  testContractB,
+		},
+	}
+	mw := NewMiddleware(stubAuth{did: testDIDAlice}, authz, reg, nil)
+
+	next := &recordingNext{}
+	srv := mw.Wrap(next)
+
+	body := []byte(`{"query":"{ FilteredLogs { hash } FilteredTxs { hash } }"}`)
+	r := newGraphQLPost(body)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusForbidden, w.Code)
+	require.False(t, next.called)
+	// The middleware short-circuits on first deny; at least one call
+	// must have happened, but the second view may not be consulted.
+	require.GreaterOrEqual(t, len(authz.calls), 1)
+}
+
+// A request mixing a view and a primitive collection is gated only on
+// the view; the primitive part passes through.
+func TestMiddleware_MixedViewAndPrimitive_AuthorizedOnViewOnly(t *testing.T) {
+	authz := newFakeAuthorizer()
+	authz.allow(testDIDAlice, testContractA)
+	reg := fakeRegistry{views: map[string]string{testViewFilteredLogs: testContractA}}
+	mw := NewMiddleware(stubAuth{did: testDIDAlice}, authz, reg, nil)
+
+	next := &recordingNext{}
+	srv := mw.Wrap(next)
+
+	body := []byte(`{"query":"{ Block { number } FilteredLogs { hash } }"}`)
+	r := newGraphQLPost(body)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.True(t, next.called)
+	require.Equal(t, []authzCall{{testDIDAlice, testContractA}}, authz.calls,
+		"the authorizer must be consulted only for view collections")
+}
+
+// Body must remain readable by the wrapped handler. The middleware
+// reads the body to parse the GraphQL operation; if it does not rewind
+// r.Body, the wrapped handler sees an empty payload.
+func TestMiddleware_BodyForwardedToNextUnchanged(t *testing.T) {
+	authz := newFakeAuthorizer()
+	authz.allow(testDIDAlice, testContractA)
+	reg := fakeRegistry{views: map[string]string{testViewFilteredLogs: testContractA}}
+	mw := NewMiddleware(stubAuth{did: testDIDAlice}, authz, reg, nil)
+
+	next := &recordingNext{}
+	srv := mw.Wrap(next)
+
+	body := []byte(`{"query":"{ FilteredLogs { hash } }"}`)
+	r := newGraphQLPost(body)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	require.Equal(t, body, next.bodyReceived, "downstream must see the original body")
+}
+
+// A malformed JSON body returns 400 immediately. The authorizer is not
+// consulted; we cannot determine what the request was asking for.
+func TestMiddleware_MalformedBodyIs400(t *testing.T) {
+	authz := newFakeAuthorizer()
+	reg := fakeRegistry{views: map[string]string{testViewFilteredLogs: testContractA}}
+	mw := NewMiddleware(stubAuth{did: testDIDAlice}, authz, reg, nil)
+
+	next := &recordingNext{}
+	srv := mw.Wrap(next)
+
+	r := newGraphQLPost([]byte(`{"query": "{ Foo`)) // truncated
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.False(t, next.called)
+	require.Empty(t, authz.calls)
+}
+
+// GET requests are gated the same as POST: a view query without auth
+// returns 403.
+func TestMiddleware_GETViewQueryWithoutAuthIs403(t *testing.T) {
+	authz := newFakeAuthorizer()
+	reg := fakeRegistry{views: map[string]string{testViewFilteredLogs: testContractA}}
+	mw := NewMiddleware(noAuth{}, authz, reg, nil)
+
+	next := &recordingNext{}
+	srv := mw.Wrap(next)
+
+	r := httptest.NewRequest(http.MethodGet, GraphQLPath+"?query=%7B+FilteredLogs+%7B+hash+%7D+%7D", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusForbidden, w.Code)
+	require.False(t, next.called)
+}
+
+// An empty POST body on the graphql path has no collections to gate;
+// the request passes through and defradb decides how to respond.
+func TestMiddleware_EmptyBodyPassesThrough(t *testing.T) {
+	authz := newFakeAuthorizer()
+	reg := fakeRegistry{views: map[string]string{testViewFilteredLogs: testContractA}}
+	mw := NewMiddleware(noAuth{}, authz, reg, nil)
+
+	next := &recordingNext{}
+	srv := mw.Wrap(next)
+
+	r := newGraphQLPost(nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.True(t, next.called)
+}
+
+// --- helpers ---
+
+func newGraphQLPost(body []byte) *http.Request {
+	r := httptest.NewRequest(http.MethodPost, GraphQLPath, bytes.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	return r
+}
+
+// noAuth fails every CallerDID request with ErrAuthRequired, modelling
+// "the caller did not send a valid bearer token".
+type noAuth struct{}
+
+func (noAuth) CallerDID(*http.Request) (string, error) {
+	return "", ErrAuthRequired
+}
+
+// stubAuth always reports the same DID; used in tests where the caller
+// identity is given.
+type stubAuth struct{ did string }
+
+func (s stubAuth) CallerDID(*http.Request) (string, error) {
+	return s.did, nil
+}
+
+type authzCall struct {
+	did  string
+	addr string
+}
+
+type authzDecision struct {
+	allow bool
+	err   error
+}
+
+// fakeAuthorizer records every AuthorizeView call and returns a
+// pre-configured decision keyed by (callerDID, contractAddr). Unknown
+// keys default to deny so a test that forgets to set an expectation
+// fails fast.
+type fakeAuthorizer struct {
+	decisions map[string]authzDecision
+	calls     []authzCall
+}
+
+func newFakeAuthorizer() *fakeAuthorizer {
+	return &fakeAuthorizer{decisions: make(map[string]authzDecision)}
+}
+
+func (f *fakeAuthorizer) allow(did, addr string) {
+	f.decisions[did+"|"+addr] = authzDecision{allow: true}
+}
+
+func (f *fakeAuthorizer) fail(did, addr string, err error) {
+	f.decisions[did+"|"+addr] = authzDecision{err: err}
+}
+
+func (f *fakeAuthorizer) AuthorizeView(_ context.Context, did, addr string) (bool, error) {
+	f.calls = append(f.calls, authzCall{did, addr})
+	d := f.decisions[did+"|"+addr]
+	return d.allow, d.err
+}
+
+// fakeRegistry treats every key in `views` as a registered view; an
+// empty-string value models "registered but no contract address" so
+// fail-closed behavior can be tested without touching view.Manager.
+type fakeRegistry struct {
+	views map[string]string
+}
+
+func (f fakeRegistry) IsView(name string) bool {
+	_, ok := f.views[name]
+	return ok
+}
+
+func (f fakeRegistry) ContractAddress(name string) (string, bool) {
+	addr, ok := f.views[name]
+	if !ok || addr == "" {
+		return "", false
+	}
+	return addr, true
+}
+
+// recordingNext is the wrapped handler; tests inspect it to verify
+// whether the middleware forwarded the request and what body the
+// downstream handler observed.
+type recordingNext struct {
+	called       bool
+	bodyReceived []byte
+}
+
+func (n *recordingNext) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	n.called = true
+	if r.Body != nil {
+		body, _ := io.ReadAll(r.Body)
+		n.bodyReceived = body
+	}
+	w.WriteHeader(http.StatusOK)
+}

--- a/pkg/acp/middleware_test.go
+++ b/pkg/acp/middleware_test.go
@@ -112,7 +112,7 @@ func TestMiddleware_ViewQueryWithValidAuth_Allowed(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, w.Code)
 	require.True(t, next.called)
-	require.Equal(t, []authzCall{{testDIDAlice, testContractA}}, authz.calls)
+	require.Equal(t, []authzCall{{testDIDAlice, testViewFilteredLogs, testContractA}}, authz.calls)
 }
 
 // The authorizer denies the request; middleware returns 403 without
@@ -226,7 +226,7 @@ func TestMiddleware_MixedViewAndPrimitive_AuthorizedOnViewOnly(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, w.Code)
 	require.True(t, next.called)
-	require.Equal(t, []authzCall{{testDIDAlice, testContractA}}, authz.calls,
+	require.Equal(t, []authzCall{{testDIDAlice, testViewFilteredLogs, testContractA}}, authz.calls,
 		"the authorizer must be consulted only for view collections")
 }
 
@@ -331,6 +331,7 @@ func (s stubAuth) CallerDID(*http.Request) (string, error) {
 
 type authzCall struct {
 	did  string
+	name string
 	addr string
 }
 
@@ -340,9 +341,10 @@ type authzDecision struct {
 }
 
 // fakeAuthorizer records every AuthorizeView call and returns a
-// pre-configured decision keyed by (callerDID, contractAddr). Unknown
-// keys default to deny so a test that forgets to set an expectation
-// fails fast.
+// pre-configured decision keyed by (callerDID, contractAddr). viewName
+// is captured in the recorded call but not part of the lookup key, so
+// tests declare expectations by (did, addr) alone. Unknown keys default
+// to deny so a test that forgets to set an expectation fails fast.
 type fakeAuthorizer struct {
 	decisions map[string]authzDecision
 	calls     []authzCall
@@ -360,8 +362,8 @@ func (f *fakeAuthorizer) fail(did, addr string, err error) {
 	f.decisions[did+"|"+addr] = authzDecision{err: err}
 }
 
-func (f *fakeAuthorizer) AuthorizeView(_ context.Context, did, addr string) (bool, error) {
-	f.calls = append(f.calls, authzCall{did, addr})
+func (f *fakeAuthorizer) AuthorizeView(_ context.Context, did, name, addr string) (bool, error) {
+	f.calls = append(f.calls, authzCall{did, name, addr})
 	d := f.decisions[did+"|"+addr]
 	return d.allow, d.err
 }

--- a/pkg/acp/parser.go
+++ b/pkg/acp/parser.go
@@ -1,0 +1,125 @@
+// Package acp implements the host-side access-control middleware. The
+// middleware authenticates each incoming GraphQL request, identifies which
+// view collections it touches, and forwards or rejects based on the
+// SourceHub subscriber tuples for the caller.
+package acp
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/parser"
+)
+
+// ErrMalformedQuery wraps any failure to parse the GraphQL operation in a
+// request. The middleware treats it as a client error (400).
+var ErrMalformedQuery = errors.New("malformed graphql query")
+
+const contentTypeGraphQL = "application/graphql"
+
+// ExtractCollections returns the top-level field names selected by the
+// GraphQL operation in r, deduplicated, with aliases resolved back to the
+// underlying field name.
+//
+// Supported transports:
+//   - GET with `query` (and optional `operationName`) URL parameters
+//   - POST with `Content-Type: application/json` body `{"query": ..., "operationName": ...}`
+//   - POST with `Content-Type: application/graphql` body (raw query string)
+//
+// For POST requests the body is read fully and reset on r so downstream
+// handlers can re-read it. An empty body or empty `query` returns nil with
+// no error so the caller can pass the request through without gating.
+// Parse failures return ErrMalformedQuery so the caller can respond 400
+// rather than silently allowing an un-gated request through.
+func ExtractCollections(r *http.Request) ([]string, error) {
+	query, operationName, err := extractGraphQLOperation(r)
+	if err != nil {
+		return nil, err
+	}
+	if query == "" {
+		return nil, nil
+	}
+
+	doc, parseErr := parser.ParseQuery(&ast.Source{Input: query})
+	if parseErr != nil {
+		return nil, fmt.Errorf("%w: %s", ErrMalformedQuery, parseErr.Error())
+	}
+
+	seen := make(map[string]struct{})
+	var names []string
+	for _, op := range doc.Operations {
+		if operationName != "" && op.Name != operationName {
+			continue
+		}
+		for _, sel := range op.SelectionSet {
+			field, ok := sel.(*ast.Field)
+			if !ok {
+				continue
+			}
+			if _, dup := seen[field.Name]; dup {
+				continue
+			}
+			seen[field.Name] = struct{}{}
+			names = append(names, field.Name)
+		}
+	}
+	return names, nil
+}
+
+// extractGraphQLOperation reads the GraphQL query and operationName from r.
+// For POST requests it reads the body into memory and rewinds r.Body so
+// downstream handlers can re-read it; for GET requests it reads URL params.
+// Unsupported methods return ("", "", nil) so the caller passes the request
+// through without parsing.
+func extractGraphQLOperation(r *http.Request) (query, operationName string, err error) {
+	switch r.Method {
+	case http.MethodGet:
+		return r.URL.Query().Get("query"), r.URL.Query().Get("operationName"), nil
+
+	case http.MethodPost:
+		if r.Body == nil {
+			return "", "", nil
+		}
+		body, readErr := io.ReadAll(r.Body)
+		if readErr != nil {
+			return "", "", fmt.Errorf("read body: %w", readErr)
+		}
+		r.Body = io.NopCloser(bytes.NewReader(body))
+		if len(body) == 0 {
+			return "", "", nil
+		}
+
+		mediaType := contentTypeOf(r)
+		if mediaType == contentTypeGraphQL {
+			return string(body), "", nil
+		}
+
+		var payload struct {
+			Query         string `json:"query"`
+			OperationName string `json:"operationName"`
+		}
+		if jsonErr := json.Unmarshal(body, &payload); jsonErr != nil {
+			return "", "", fmt.Errorf("%w: %s", ErrMalformedQuery, jsonErr.Error())
+		}
+		return payload.Query, payload.OperationName, nil
+
+	default:
+		return "", "", nil
+	}
+}
+
+// contentTypeOf returns the media type portion of the request's
+// Content-Type header, lowercased, with any parameters stripped.
+func contentTypeOf(r *http.Request) string {
+	ct := r.Header.Get("Content-Type")
+	if semi := strings.IndexByte(ct, ';'); semi >= 0 {
+		ct = ct[:semi]
+	}
+	return strings.ToLower(strings.TrimSpace(ct))
+}

--- a/pkg/acp/parser.go
+++ b/pkg/acp/parser.go
@@ -23,9 +23,19 @@ var ErrMalformedQuery = errors.New("malformed graphql query")
 
 const contentTypeGraphQL = "application/graphql"
 
+// maxFragmentDepth bounds recursion through fragment spreads and inline
+// fragments. Fragment-spread cycles are detected separately by name (see
+// visitedFrags in collectTopLevelFields); the depth bound additionally
+// caps deeply nested non-cyclic fragments and inline-fragment chains,
+// which have no name to track. Sixteen levels exceeds any reasonable
+// hand-written nesting.
+const maxFragmentDepth = 16
+
 // ExtractCollections returns the top-level field names selected by the
 // GraphQL operation in r, deduplicated, with aliases resolved back to the
-// underlying field name.
+// underlying field name. Fragment spreads and inline fragments used at
+// the operation's top level are followed, so the fields they introduce
+// are included in the result.
 //
 // Supported transports:
 //   - GET with `query` (and optional `operationName`) URL parameters
@@ -35,8 +45,10 @@ const contentTypeGraphQL = "application/graphql"
 // For POST requests the body is read fully and reset on r so downstream
 // handlers can re-read it. An empty body or empty `query` returns nil with
 // no error so the caller can pass the request through without gating.
-// Parse failures return ErrMalformedQuery so the caller can respond 400
-// rather than silently allowing an un-gated request through.
+// Parse failures, fragment cycles, undeclared fragments, and excessive
+// fragment nesting return ErrMalformedQuery so the caller can respond
+// 400 rather than forwarding a request whose top-level field set is
+// unsafe to determine.
 func ExtractCollections(r *http.Request) ([]string, error) {
 	query, operationName, err := extractGraphQLOperation(r)
 	if err != nil {
@@ -57,16 +69,73 @@ func ExtractCollections(r *http.Request) ([]string, error) {
 		if operationName != "" && op.Name != operationName {
 			continue
 		}
-		for _, sel := range op.SelectionSet {
-			field, ok := sel.(*ast.Field)
-			if !ok {
+		opNames, err := collectTopLevelFields(op.SelectionSet, doc, seen, make(map[string]struct{}), 0)
+		if err != nil {
+			return nil, err
+		}
+		names = append(names, opNames...)
+	}
+	return names, nil
+}
+
+// collectTopLevelFields walks a selection set and returns the names of
+// every top-level Field reachable from it, recursing into FragmentSpread
+// and InlineFragment along the way. seen deduplicates Field names across
+// the entire walk; visitedFrags blocks fragment-spread cycles by name.
+// depth is bounded by maxFragmentDepth.
+//
+// "Top-level" means a Field whose parent in the selection tree is either
+// the operation itself or another top-level fragment used at the
+// operation level. Selections nested inside a Field's own SelectionSet
+// describe that field's sub-shape and are not new top-level entries, so
+// they are not traversed here.
+func collectTopLevelFields(
+	sels ast.SelectionSet,
+	doc *ast.QueryDocument,
+	seen map[string]struct{},
+	visitedFrags map[string]struct{},
+	depth int,
+) ([]string, error) {
+	if depth > maxFragmentDepth {
+		return nil, fmt.Errorf("%w: fragment depth exceeded %d", ErrMalformedQuery, maxFragmentDepth)
+	}
+
+	var names []string
+	for _, sel := range sels {
+		switch s := sel.(type) {
+		case *ast.Field:
+			if _, dup := seen[s.Name]; dup {
 				continue
 			}
-			if _, dup := seen[field.Name]; dup {
-				continue
+			seen[s.Name] = struct{}{}
+			names = append(names, s.Name)
+
+		case *ast.InlineFragment:
+			nested, err := collectTopLevelFields(s.SelectionSet, doc, seen, visitedFrags, depth+1)
+			if err != nil {
+				return nil, err
 			}
-			seen[field.Name] = struct{}{}
-			names = append(names, field.Name)
+			names = append(names, nested...)
+
+		case *ast.FragmentSpread:
+			if _, cycle := visitedFrags[s.Name]; cycle {
+				return nil, fmt.Errorf("%w: fragment cycle through %q", ErrMalformedQuery, s.Name)
+			}
+			frag := doc.Fragments.ForName(s.Name)
+			if frag == nil {
+				// Undeclared fragment. ParseQuery does not run validation,
+				// so the spread can reference a name that has no
+				// definition in the document. Reject as malformed rather
+				// than forward, since the resolved field set is undefined.
+				return nil, fmt.Errorf("%w: undeclared fragment %q", ErrMalformedQuery, s.Name)
+			}
+			visitedFrags[s.Name] = struct{}{}
+			nested, err := collectTopLevelFields(frag.SelectionSet, doc, seen, visitedFrags, depth+1)
+			delete(visitedFrags, s.Name)
+			if err != nil {
+				return nil, err
+			}
+			names = append(names, nested...)
 		}
 	}
 	return names, nil

--- a/pkg/acp/parser.go
+++ b/pkg/acp/parser.go
@@ -39,12 +39,18 @@ const maxFragmentDepth = 16
 //
 // Supported transports:
 //   - GET with `query` (and optional `operationName`) URL parameters
+//   - POST with `query` (and optional `operationName`) URL parameters
 //   - POST with `Content-Type: application/json` body `{"query": ..., "operationName": ...}`
 //   - POST with `Content-Type: application/graphql` body (raw query string)
 //
-// For POST requests the body is read fully and reset on r so downstream
-// handlers can re-read it. An empty body or empty `query` returns nil with
-// no error so the caller can pass the request through without gating.
+// On POST a non-empty URL `query` parameter takes precedence over the
+// body. This mirrors defradb's GraphQL handler so the middleware gates
+// the same operation defradb will execute.
+//
+// For POST requests that fall through to the body, the body is read
+// fully and reset on r so downstream handlers can re-read it. An empty
+// body or empty `query` returns nil with no error so the caller can pass
+// the request through without gating.
 // Parse failures, fragment cycles, undeclared fragments, and excessive
 // fragment nesting return ErrMalformedQuery so the caller can respond
 // 400 rather than forwarding a request whose top-level field set is
@@ -142,16 +148,22 @@ func collectTopLevelFields(
 }
 
 // extractGraphQLOperation reads the GraphQL query and operationName from r.
-// For POST requests it reads the body into memory and rewinds r.Body so
-// downstream handlers can re-read it; for GET requests it reads URL params.
-// Unsupported methods return ("", "", nil) so the caller passes the request
-// through without parsing.
+// On POST a non-empty URL `query` parameter takes precedence over the
+// body, matching defradb's handler. When the body path is taken, the
+// body is read into memory and r.Body is rewound so downstream handlers
+// can re-read it. On GET it reads URL params. Unsupported methods return
+// ("", "", nil) so the caller passes the request through without parsing.
 func extractGraphQLOperation(r *http.Request) (query, operationName string, err error) {
 	switch r.Method {
 	case http.MethodGet:
 		return r.URL.Query().Get("query"), r.URL.Query().Get("operationName"), nil
 
 	case http.MethodPost:
+		// Defradb prefers URL `query` over the body on POST. Mirror that
+		// so the middleware sees the same query defradb will execute.
+		if q := r.URL.Query().Get("query"); q != "" {
+			return q, r.URL.Query().Get("operationName"), nil
+		}
 		if r.Body == nil {
 			return "", "", nil
 		}

--- a/pkg/acp/parser_test.go
+++ b/pkg/acp/parser_test.go
@@ -3,11 +3,14 @@ package acp
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"sort"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -206,6 +209,122 @@ func TestErrMalformedQuery_IsRecognizable(t *testing.T) {
 	r := newPostJSON(t, body)
 
 	_, err := ExtractCollections(r)
+	require.True(t, errors.Is(err, ErrMalformedQuery))
+}
+
+// A named fragment spread used at the top level of the operation
+// resolves to its declared selection set. Fields inside that selection
+// set are top-level fields of the operation for gating purposes.
+func TestExtractCollections_NamedFragmentSpreadAtTopLevel(t *testing.T) {
+	body := []byte(`{"query":"fragment AsQuery on Query { FilteredLogs { hash } } query { ...AsQuery }"}`)
+	r := newPostJSON(t, body)
+
+	got, err := ExtractCollections(r)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{testViewFilteredLogs}, got)
+}
+
+// An inline fragment at the top level introduces no Field of its own in
+// the AST. Its selection set carries the actual top-level fields and must
+// be traversed.
+func TestExtractCollections_InlineFragmentAtTopLevel(t *testing.T) {
+	body := []byte(`{"query":"query { ... on Query { FilteredLogs { hash } } }"}`)
+	r := newPostJSON(t, body)
+
+	got, err := ExtractCollections(r)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{testViewFilteredLogs}, got)
+}
+
+// Nested fragment chain. Spreads expand through arbitrary depth and the
+// parser must follow each link.
+func TestExtractCollections_NestedFragmentSpreads(t *testing.T) {
+	body := []byte(`{"query":"fragment Inner on Query { FilteredLogs { hash } } fragment Outer on Query { ...Inner } query { ...Outer }"}`)
+	r := newPostJSON(t, body)
+
+	got, err := ExtractCollections(r)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{testViewFilteredLogs}, got)
+}
+
+// A direct Field and an InlineFragment at the same selection level both
+// contribute their fields. The result includes the Field's name and
+// every name reachable through the fragment.
+func TestExtractCollections_MixedFieldAndInlineFragmentAtTopLevel(t *testing.T) {
+	body := []byte(`{"query":"query { Block { number } ... on Query { FilteredLogs { hash } } }"}`)
+	r := newPostJSON(t, body)
+
+	got, err := ExtractCollections(r)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"Block", testViewFilteredLogs}, got)
+}
+
+// Fragments INSIDE a Field's own selection set describe that field's
+// sub-shape and do not introduce new top-level fields. The outer Field is
+// the only entry; the inline fragment is not traversed further by this
+// gate.
+func TestExtractCollections_InlineFragmentInsideField(t *testing.T) {
+	body := []byte(`{"query":"query { FilteredLogs { ... on FilteredLogs { hash } } }"}`)
+	r := newPostJSON(t, body)
+
+	got, err := ExtractCollections(r)
+	require.NoError(t, err)
+	require.Equal(t, []string{testViewFilteredLogs}, got)
+}
+
+// A fragment spread that names a fragment not declared in the document
+// has no resolvable selection set. ParseQuery accepts the spread because
+// validation is a separate stage; the gate rejects it as malformed
+// since the resulting field set is undefined.
+func TestExtractCollections_UndeclaredFragmentReturnsErr(t *testing.T) {
+	body := []byte(`{"query":"query { ...Missing }"}`)
+	r := newPostJSON(t, body)
+
+	_, err := ExtractCollections(r)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrMalformedQuery))
+}
+
+// A fragment cycle (A spreads B, B spreads A) is illegal per the GraphQL
+// spec but expressible in raw input. The gate must detect the cycle and
+// return ErrMalformedQuery in bounded time rather than recursing
+// indefinitely or forwarding the request.
+func TestExtractCollections_FragmentCycleReturnsErr(t *testing.T) {
+	body := []byte(`{"query":"fragment A on Query { ...B } fragment B on Query { ...A } query { ...A }"}`)
+	r := newPostJSON(t, body)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := ExtractCollections(r)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrMalformedQuery))
+	case <-time.After(2 * time.Second):
+		t.Fatal("parser did not terminate on fragment cycle within 2s")
+	}
+}
+
+// Deep but acyclic fragment nesting is rejected once it exceeds the
+// configured depth bound. The user-facing impact is that hand-written
+// queries with more than maxFragmentDepth levels of fragment indirection
+// fail with a clear error. The bound is generous enough that legitimate
+// documents do not hit it.
+func TestExtractCollections_ExcessiveFragmentDepthReturnsErr(t *testing.T) {
+	var b strings.Builder
+	const depth = 32 // exceeds maxFragmentDepth
+	for i := 0; i < depth; i++ {
+		fmt.Fprintf(&b, "fragment F%d on Query { ...F%d } ", i, i+1)
+	}
+	fmt.Fprintf(&b, "fragment F%d on Query { FilteredLogs { hash } } query { ...F0 }", depth)
+
+	body := []byte(`{"query":"` + b.String() + `"}`)
+	r := newPostJSON(t, body)
+
+	_, err := ExtractCollections(r)
+	require.Error(t, err)
 	require.True(t, errors.Is(err, ErrMalformedQuery))
 }
 

--- a/pkg/acp/parser_test.go
+++ b/pkg/acp/parser_test.go
@@ -1,0 +1,217 @@
+package acp
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractCollections_PostJSONSingleField(t *testing.T) {
+	body := []byte(`{"query":"{ FilteredLogs { hash } }"}`)
+	r := newPostJSON(t, body)
+
+	got, err := ExtractCollections(r)
+	require.NoError(t, err)
+	require.Equal(t, []string{testViewFilteredLogs}, got)
+}
+
+func TestExtractCollections_PostJSONMultipleFields(t *testing.T) {
+	body := []byte(`{"query":"{ FilteredLogs { hash } Block { number } }"}`)
+	r := newPostJSON(t, body)
+
+	got, err := ExtractCollections(r)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{testViewFilteredLogs, "Block"}, got)
+}
+
+// Aliases must not mask the underlying field name: gating decisions are made
+// on the collection the operation actually selects, not on the local label.
+func TestExtractCollections_AliasResolvesToFieldName(t *testing.T) {
+	body := []byte(`{"query":"{ first: FilteredLogs { hash } }"}`)
+	r := newPostJSON(t, body)
+
+	got, err := ExtractCollections(r)
+	require.NoError(t, err)
+	require.Equal(t, []string{testViewFilteredLogs}, got)
+}
+
+func TestExtractCollections_DeduplicatesRepeatedSelections(t *testing.T) {
+	body := []byte(`{"query":"{ Logs { a } Logs { b } }"}`)
+	r := newPostJSON(t, body)
+
+	got, err := ExtractCollections(r)
+	require.NoError(t, err)
+	require.Equal(t, []string{"Logs"}, got)
+}
+
+// When operationName is set, only that operation's selections are returned.
+// This matters for clients that send multi-operation documents and pick at
+// request time; gating the unselected operations would cause false denials.
+func TestExtractCollections_OperationNameFiltersToNamedOp(t *testing.T) {
+	body := []byte(`{
+		"query": "query A { Foo { x } } query B { Bar { y } }",
+		"operationName": "B"
+	}`)
+	r := newPostJSON(t, body)
+
+	got, err := ExtractCollections(r)
+	require.NoError(t, err)
+	require.Equal(t, []string{testOpBNamed}, got)
+}
+
+func TestExtractCollections_NoOperationNameWalksAllOps(t *testing.T) {
+	body := []byte(`{"query":"query A { Foo { x } } query B { Bar { y } }"}`)
+	r := newPostJSON(t, body)
+
+	got, err := ExtractCollections(r)
+	require.NoError(t, err)
+	sort.Strings(got)
+	require.Equal(t, []string{testOpBNamed, "Foo"}, got)
+}
+
+func TestExtractCollections_MutationTopLevelFields(t *testing.T) {
+	body := []byte(`{"query":"mutation { update_FilteredLogs(input: {}) { _docID } }"}`)
+	r := newPostJSON(t, body)
+
+	got, err := ExtractCollections(r)
+	require.NoError(t, err)
+	require.Equal(t, []string{"update_FilteredLogs"}, got)
+}
+
+func TestExtractCollections_PostGraphQLContentType(t *testing.T) {
+	body := []byte(`{ FilteredLogs { hash } }`)
+	r := httptest.NewRequest(http.MethodPost, "/api/v0/graphql", bytes.NewReader(body))
+	r.Header.Set("Content-Type", "application/graphql")
+
+	got, err := ExtractCollections(r)
+	require.NoError(t, err)
+	require.Equal(t, []string{testViewFilteredLogs}, got)
+}
+
+func TestExtractCollections_GetQueryParam(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/api/v0/graphql?query=%7B+FilteredLogs+%7B+hash+%7D+%7D", nil)
+
+	got, err := ExtractCollections(r)
+	require.NoError(t, err)
+	require.Equal(t, []string{testViewFilteredLogs}, got)
+}
+
+func TestExtractCollections_GetWithOperationName(t *testing.T) {
+	r := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v0/graphql?query=query+A+%7BFoo%7Bx%7D%7D+query+B+%7BBar%7By%7D%7D&operationName=B",
+		nil,
+	)
+
+	got, err := ExtractCollections(r)
+	require.NoError(t, err)
+	require.Equal(t, []string{testOpBNamed}, got)
+}
+
+func TestExtractCollections_EmptyBody(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/api/v0/graphql", bytes.NewReader(nil))
+	r.Header.Set("Content-Type", "application/json")
+
+	got, err := ExtractCollections(r)
+	require.NoError(t, err)
+	require.Nil(t, got)
+}
+
+func TestExtractCollections_EmptyQueryField(t *testing.T) {
+	body := []byte(`{"query":""}`)
+	r := newPostJSON(t, body)
+
+	got, err := ExtractCollections(r)
+	require.NoError(t, err)
+	require.Nil(t, got)
+}
+
+func TestExtractCollections_MalformedJSONReturnsErr(t *testing.T) {
+	body := []byte(`{"query": "{ Foo { x }`) // truncated json
+	r := newPostJSON(t, body)
+
+	_, err := ExtractCollections(r)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrMalformedQuery)
+}
+
+func TestExtractCollections_MalformedGraphQLReturnsErr(t *testing.T) {
+	body := []byte(`{"query":"{ Foo { x "}`) // unterminated selection set
+	r := newPostJSON(t, body)
+
+	_, err := ExtractCollections(r)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrMalformedQuery)
+}
+
+// The middleware must hand the request body off to the downstream handler
+// unchanged; reading the body for parsing without resetting it would cause
+// defradb to receive an empty payload.
+func TestExtractCollections_BodyReadableAfterExtraction(t *testing.T) {
+	body := []byte(`{"query":"{ Foo { x } }"}`)
+	r := newPostJSON(t, body)
+
+	_, err := ExtractCollections(r)
+	require.NoError(t, err)
+
+	remaining, readErr := io.ReadAll(r.Body)
+	require.NoError(t, readErr)
+	require.Equal(t, body, remaining, "body must be re-readable for downstream handlers")
+}
+
+// Unsupported methods (DELETE, PATCH, etc.) are not gated; the middleware
+// passes them through unchanged. defradb will respond with whatever it
+// considers correct for that method.
+func TestExtractCollections_UnsupportedMethodReturnsNil(t *testing.T) {
+	r := httptest.NewRequest(http.MethodDelete, "/api/v0/graphql", nil)
+
+	got, err := ExtractCollections(r)
+	require.NoError(t, err)
+	require.Nil(t, got)
+}
+
+// Content-Type with parameters (e.g. charset) still resolves to the base
+// media type. application/json; charset=utf-8 is treated as JSON.
+func TestExtractCollections_ContentTypeWithParametersStillJSON(t *testing.T) {
+	body := []byte(`{"query":"{ Foo { x } }"}`)
+	r := httptest.NewRequest(http.MethodPost, "/api/v0/graphql", bytes.NewReader(body))
+	r.Header.Set("Content-Type", "application/json; charset=utf-8")
+
+	got, err := ExtractCollections(r)
+	require.NoError(t, err)
+	require.Equal(t, []string{"Foo"}, got)
+}
+
+// Introspection (`__schema`, `__type`) is a real top-level field. The
+// parser returns it; whether to gate is the registry's call (not a view).
+func TestExtractCollections_IntrospectionFieldReturned(t *testing.T) {
+	body := []byte(`{"query":"{ __schema { types { name } } }"}`)
+	r := newPostJSON(t, body)
+
+	got, err := ExtractCollections(r)
+	require.NoError(t, err)
+	require.Equal(t, []string{"__schema"}, got)
+}
+
+// ErrMalformedQuery must be reachable via errors.Is so middleware can
+// branch on it without string-matching.
+func TestErrMalformedQuery_IsRecognizable(t *testing.T) {
+	body := []byte(`not json at all`)
+	r := newPostJSON(t, body)
+
+	_, err := ExtractCollections(r)
+	require.True(t, errors.Is(err, ErrMalformedQuery))
+}
+
+func newPostJSON(t *testing.T, body []byte) *http.Request {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodPost, "/api/v0/graphql", bytes.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	return r
+}

--- a/pkg/acp/parser_test.go
+++ b/pkg/acp/parser_test.go
@@ -328,6 +328,77 @@ func TestExtractCollections_ExcessiveFragmentDepthReturnsErr(t *testing.T) {
 	require.True(t, errors.Is(err, ErrMalformedQuery))
 }
 
+// On POST, URL `query` takes precedence over the body, matching
+// defradb. Without this precedence the middleware would inspect the
+// body while defradb runs the URL query, leaving the URL-named
+// operation ungated.
+func TestExtractCollections_PostUrlQueryPrecedesBody(t *testing.T) {
+	body := []byte(`{"query":"{ Block { number } }"}`)
+	r := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v0/graphql?query=%7B+FilteredLogs+%7B+hash+%7D+%7D",
+		bytes.NewReader(body),
+	)
+	r.Header.Set("Content-Type", "application/json")
+
+	got, err := ExtractCollections(r)
+	require.NoError(t, err)
+	require.Equal(t, []string{testViewFilteredLogs}, got)
+}
+
+// A POST whose URL `query` carries multiple operations is filtered by
+// the URL `operationName`, again matching defradb. The body's
+// operationName is irrelevant on this path.
+func TestExtractCollections_PostUrlQueryWithUrlOperationName(t *testing.T) {
+	urlQuery := "query+A+%7BFoo%7Bx%7D%7D+query+B+%7BBar%7By%7D%7D"
+	body := []byte(`{"query":"{ Other { z } }", "operationName": "ignored"}`)
+	r := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v0/graphql?query="+urlQuery+"&operationName=B",
+		bytes.NewReader(body),
+	)
+	r.Header.Set("Content-Type", "application/json")
+
+	got, err := ExtractCollections(r)
+	require.NoError(t, err)
+	require.Equal(t, []string{testOpBNamed}, got)
+}
+
+// When the URL `query` path is taken, the body is not consumed so
+// downstream handlers can still read it.
+func TestExtractCollections_PostUrlQueryDoesNotConsumeBody(t *testing.T) {
+	body := []byte(`{"query":"{ Block { number } }"}`)
+	r := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v0/graphql?query=%7B+FilteredLogs+%7B+hash+%7D+%7D",
+		bytes.NewReader(body),
+	)
+	r.Header.Set("Content-Type", "application/json")
+
+	_, err := ExtractCollections(r)
+	require.NoError(t, err)
+
+	remaining, readErr := io.ReadAll(r.Body)
+	require.NoError(t, readErr)
+	require.Equal(t, body, remaining)
+}
+
+// When URL `query` is empty, POST still reads the body as before. Empty
+// URL query must not trigger the precedence branch.
+func TestExtractCollections_PostEmptyUrlQueryFallsBackToBody(t *testing.T) {
+	body := []byte(`{"query":"{ FilteredLogs { hash } }"}`)
+	r := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v0/graphql?query=",
+		bytes.NewReader(body),
+	)
+	r.Header.Set("Content-Type", "application/json")
+
+	got, err := ExtractCollections(r)
+	require.NoError(t, err)
+	require.Equal(t, []string{testViewFilteredLogs}, got)
+}
+
 func newPostJSON(t *testing.T, body []byte) *http.Request {
 	t.Helper()
 	r := httptest.NewRequest(http.MethodPost, "/api/v0/graphql", bytes.NewReader(body))

--- a/pkg/acp/parser_test.go
+++ b/pkg/acp/parser_test.go
@@ -315,7 +315,7 @@ func TestExtractCollections_FragmentCycleReturnsErr(t *testing.T) {
 func TestExtractCollections_ExcessiveFragmentDepthReturnsErr(t *testing.T) {
 	var b strings.Builder
 	const depth = 32 // exceeds maxFragmentDepth
-	for i := 0; i < depth; i++ {
+	for i := range depth {
 		fmt.Fprintf(&b, "fragment F%d on Query { ...F%d } ", i, i+1)
 	}
 	fmt.Fprintf(&b, "fragment F%d on Query { FilteredLogs { hash } } query { ...F0 }", depth)

--- a/pkg/acp/registry.go
+++ b/pkg/acp/registry.go
@@ -1,0 +1,35 @@
+package acp
+
+import (
+	"github.com/shinzonetwork/shinzo-host-client/pkg/view"
+)
+
+// ViewRegistry resolves a GraphQL collection name to (a) whether the
+// collection is a host-registered view that requires access-control gating
+// and (b) the on-chain contract address used as the SourceHub
+// relationship-tuple object_id. The two methods are kept separate so the
+// middleware can fail closed on a registered view without an address
+// rather than silently treat it as ungated.
+type ViewRegistry interface {
+	IsView(collectionName string) bool
+	ContractAddress(collectionName string) (string, bool)
+}
+
+// managerAdapter narrows view.Manager to the ViewRegistry shape so the
+// middleware depends only on the methods it uses.
+type managerAdapter struct {
+	m *view.Manager
+}
+
+// NewViewRegistry returns a ViewRegistry backed by the host's view.Manager.
+func NewViewRegistry(m *view.Manager) ViewRegistry {
+	return &managerAdapter{m: m}
+}
+
+func (a *managerAdapter) IsView(name string) bool {
+	return a.m.IsActive(name)
+}
+
+func (a *managerAdapter) ContractAddress(name string) (string, bool) {
+	return a.m.ContractAddress(name)
+}

--- a/pkg/defradb/lan_ip.go
+++ b/pkg/defradb/lan_ip.go
@@ -3,6 +3,7 @@ package defradb
 import (
 	"fmt"
 	"net"
+	"strings"
 )
 
 // dialFunc abstracts net.Dial for testability.
@@ -22,4 +23,22 @@ func getLANIP() (string, error) {
 	localAddr := conn.LocalAddr().(*net.UDPAddr)
 
 	return localAddr.IP.String(), nil
+}
+
+// ResolveListenAddress rewrites loopback hosts (localhost, 127.0.0.1) in the
+// given address to the local LAN IP so external peers and reverse proxies can
+// reach the bound port. Non-loopback hosts are returned unchanged. If the LAN
+// IP cannot be determined, the original address is returned with the error so
+// the caller can fall back to its own behaviour.
+func ResolveListenAddress(rawURL string) (string, error) {
+	ipAddress, err := getLANIP()
+	if err != nil {
+		return rawURL, err
+	}
+	resolved := rawURL
+	resolved = strings.Replace(resolved, "http://localhost", ipAddress, 1)
+	resolved = strings.Replace(resolved, "http://127.0.0.1", ipAddress, 1)
+	resolved = strings.Replace(resolved, "localhost", ipAddress, 1)
+	resolved = strings.Replace(resolved, "127.0.0.1", ipAddress, 1)
+	return resolved, nil
 }

--- a/pkg/host/attestationHandler.go
+++ b/pkg/host/attestationHandler.go
@@ -83,13 +83,8 @@ var (
 )
 
 // collectionIDToName - mapping for ID to Name.
-var collectionIDToName = map[string]string{ //nolint:gochecknoglobals
-	blockSigCollectionID:    constants.CollectionBlockSignature,
-	blockCollectionID:       constants.CollectionBlock,
-	transactionCollectionID: constants.CollectionTransaction,
-	logCollectionID:         constants.CollectionLog,
-	accessListCollectionID:  constants.CollectionAccessListEntry,
-}
+// Populated at runtime by initKnownCollectionIDs after fetching real collection IDs from DefraDB.
+var collectionIDToName = map[string]string{} //nolint:gochecknoglobals
 
 // collectionsWithMetrics - mapping collection to bool.
 var collectionsWithMetrics = map[string]bool{ //nolint:gochecknoglobals
@@ -115,14 +110,19 @@ func (h *Host) initKnownCollectionIDs(ctx context.Context) error {
 		switch col.Name() {
 		case constants.CollectionBlockSignature:
 			blockSigCollectionID = col.CollectionID()
+			collectionIDToName[blockSigCollectionID] = constants.CollectionBlockSignature
 		case constants.CollectionBlock:
 			blockCollectionID = col.CollectionID()
+			collectionIDToName[blockCollectionID] = constants.CollectionBlock
 		case constants.CollectionTransaction:
 			transactionCollectionID = col.CollectionID()
+			collectionIDToName[transactionCollectionID] = constants.CollectionTransaction
 		case constants.CollectionLog:
 			logCollectionID = col.CollectionID()
+			collectionIDToName[logCollectionID] = constants.CollectionLog
 		case constants.CollectionAccessListEntry:
 			accessListCollectionID = col.CollectionID()
+			collectionIDToName[accessListCollectionID] = constants.CollectionAccessListEntry
 		}
 	}
 

--- a/pkg/host/host.go
+++ b/pkg/host/host.go
@@ -718,14 +718,17 @@ func startACPServer(
 		return nil, fmt.Errorf("defradb handler: %w", err)
 	}
 
-	// Bind to a routable interface: loopback hosts in defraURL are rewritten
-	// to the LAN IP so the reverse proxy and external peers can reach the
-	// port. Fall back to the raw address if the LAN IP cannot be resolved.
-	listenAddr, resolveErr := defradb.ResolveListenAddress(defraURL)
-	if resolveErr != nil {
-		logger.Sugar.Warnf("acp: could not resolve LAN IP, falling back to %s: %v", defraURL, resolveErr)
-		listenAddr = defraURL
+	// Bind on host:port. Loopback hosts (localhost, 127.0.0.1, ::1) are
+	// promoted to 0.0.0.0 so the same listener accepts both external
+	// connections and in-process loopback calls (e.g. healthcheck probes).
+	host, port, splitErr := net.SplitHostPort(defraURL)
+	if splitErr != nil {
+		return nil, fmt.Errorf("parse defraURL %q: %w", defraURL, splitErr)
 	}
+	if host == "" || host == "localhost" || host == "127.0.0.1" || host == "::1" {
+		host = "0.0.0.0"
+	}
+	listenAddr := net.JoinHostPort(host, port)
 
 	server, err := defradbHttp.NewServer(mw.Wrap(handler), options.NodeHTTP().SetAddress(listenAddr))
 	if err != nil {

--- a/pkg/host/host.go
+++ b/pkg/host/host.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/shinzonetwork/shinzo-host-client/config"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/acp"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/attestation"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/constants"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/defradb"
@@ -31,6 +32,7 @@ import (
 	"github.com/sourcenetwork/corelog"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
+	defradbHttp "github.com/sourcenetwork/defradb/http"
 	"github.com/sourcenetwork/defradb/node"
 )
 
@@ -101,9 +103,10 @@ type Host struct {
 
 	webhookCleanupFunction func()
 	LensRegistryPath       string
-	processingCancel       context.CancelFunc // For canceling the event processing goroutine
-	playgroundServer       *http.Server       // Playground HTTP server (if enabled)
-	config                 *config.Config     // Host configuration including StartHeight
+	processingCancel       context.CancelFunc  // For canceling the event processing goroutine
+	playgroundServer       *http.Server        // Playground HTTP server (if enabled)
+	acpServer              *defradbHttp.Server // ACP-wrapped GraphQL server (set when the ACP middleware owns the API port)
+	config                 *config.Config      // Host configuration including StartHeight
 
 	// EVENT-DRIVEN ATTESTATION SYSTEM: Only track attestation processing
 	processingPipeline *ProcessingPipeline // Complete message processing pipeline
@@ -134,6 +137,14 @@ func StartHostingWithEventSubscription(cfg *config.Config) (*Host, error) { //no
 
 	logger.Init(cfg.Logger.Development, "./logs")
 
+	// Load ACP middleware configuration from the environment before any
+	// defradb work so a misconfigured host fails fast instead of starting
+	// up ungated.
+	acpCfg, err := acp.LoadConfigFromEnv()
+	if err != nil {
+		return nil, fmt.Errorf("acp config: %w", err)
+	}
+
 	// Configure DefraDB logging - set to error level to hide INFO logs from HTTP requests
 	corelog.SetConfigOverride("http", corelog.Config{
 		Level: corelog.LevelError,
@@ -149,6 +160,13 @@ func StartHostingWithEventSubscription(cfg *config.Config) (*Host, error) { //no
 	// recover from it, so the host process dies. wazero returns traps as Go errors.
 	nodeOpts := options.Node()
 	nodeOpts.DB().SetLensRuntime("wazero")
+
+	// When the ACP middleware is enabled the host owns the GraphQL API port.
+	// Defradb still initializes its store, ACP, P2P, and DB on Start; only
+	// the auto-start of the HTTP server is suppressed.
+	if acpCfg.Enabled {
+		nodeOpts.SetDisableAPI(true)
+	}
 
 	defraNode, networkHandler, err := defradb.StartDefraInstance(
 		cfg.ToInternalConfig(),
@@ -179,6 +197,22 @@ func StartHostingWithEventSubscription(cfg *config.Config) (*Host, error) { //no
 	// Bootstrap from historical snapshots before P2P starts
 	if cfg.HostConfig.Snapshot.Enabled && cfg.HostConfig.Snapshot.IndexerURL != "" && len(cfg.HostConfig.Snapshot.HistoricalRanges) > 0 {
 		bootstrapFromSnapshots(ctx, defraNode, cfg.HostConfig.Snapshot)
+	}
+
+	// View manager has to be built before the ACP server because the
+	// middleware's view registry adapts the manager's accessors.
+	viewManager := view.NewManager(defraNode, cfg.HostConfig.LensRegistryPath)
+
+	// When the middleware is enabled the host owns the GraphQL API. The
+	// handler is constructed here, wrapped, and served on cfg.DefraDB.URL.
+	// defraNode.APIURL is populated inside startACPServer so the playground
+	// proxy below uses our address.
+	var acpServer *defradbHttp.Server
+	if acpCfg.Enabled {
+		acpServer, err = startACPServer(ctx, acpCfg, defraNode, viewManager, cfg.DefraDB.URL)
+		if err != nil {
+			return nil, fmt.Errorf("acp server: %w", err)
+		}
 	}
 
 	// Log API URL
@@ -231,13 +265,11 @@ func StartHostingWithEventSubscription(cfg *config.Config) (*Host, error) { //no
 		LensRegistryPath:       cfg.HostConfig.LensRegistryPath,
 		processingCancel:       func() {},
 		playgroundServer:       playgroundServer,
+		acpServer:              acpServer,
 		config:                 cfg,
 		metrics:                server.NewHostMetrics(),
+		viewManager:            viewManager,
 	}
-
-	// Initialize ViewManager and load persisted views
-	// This handles: 1) Fetch views from ShinzoHub, 2) Load local views, 3) Download WASM files, 4) Register views
-	newHost.viewManager = view.NewManager(defraNode, cfg.HostConfig.LensRegistryPath)
 
 	// Hook up metrics callback for view tracking
 	newHost.viewManager.SetMetricsCallback(func() *server.HostMetrics {
@@ -634,6 +666,14 @@ func (h *Host) Close(ctx context.Context) error {
 		}
 	}
 
+	// Shut down the ACP-wrapped GraphQL server before closing defradb;
+	// the server holds a handler that calls into defraNode.DB.
+	if h.acpServer != nil {
+		if err := h.acpServer.Shutdown(ctx); err != nil {
+			fmt.Printf("Error shutting down ACP server: %v\n", err)
+		}
+	}
+
 	// ViewManager cleanup (no explicit close needed - just log)
 	if h.viewManager != nil {
 		logger.Sugar.Infof("🎯 ViewManager shutdown: %d active views", h.viewManager.GetViewCount())
@@ -651,6 +691,78 @@ func (h *Host) Close(ctx context.Context) error {
 
 	return nil
 }
+
+// startACPServer constructs the host-owned GraphQL HTTP server: it wraps
+// defradb's API handler with the ACP middleware, binds the listener on
+// the resolved LAN address, points defraNode.APIURL at the address so
+// the playground proxy uses it, and waits for the server to answer a
+// health check before returning. Caller shuts the returned server down
+// via Host.Close.
+func startACPServer(
+	ctx context.Context,
+	acpCfg acp.Config,
+	defraNode *node.Node,
+	viewManager *view.Manager,
+	defraURL string,
+) (*defradbHttp.Server, error) {
+	authz, err := acp.NewSourceHubAuthorizer(acpCfg.SourceHubGRPC, acpCfg.SourceHubComet, acpCfg.PolicyID)
+	if err != nil {
+		return nil, fmt.Errorf("authorizer: %w", err)
+	}
+
+	registry := acp.NewViewRegistry(viewManager)
+	mw := acp.NewMiddleware(acp.BearerJWTAuth{}, authz, registry, logger.Sugar)
+
+	handler, err := defradbHttp.NewHandler(defraNode.DB)
+	if err != nil {
+		return nil, fmt.Errorf("defradb handler: %w", err)
+	}
+
+	// Bind to a routable interface: loopback hosts in defraURL are rewritten
+	// to the LAN IP so the reverse proxy and external peers can reach the
+	// port. Fall back to the raw address if the LAN IP cannot be resolved.
+	listenAddr, resolveErr := defradb.ResolveListenAddress(defraURL)
+	if resolveErr != nil {
+		logger.Sugar.Warnf("acp: could not resolve LAN IP, falling back to %s: %v", defraURL, resolveErr)
+		listenAddr = defraURL
+	}
+
+	server, err := defradbHttp.NewServer(mw.Wrap(handler), options.NodeHTTP().SetAddress(listenAddr))
+	if err != nil {
+		return nil, fmt.Errorf("defradb server: %w", err)
+	}
+	if err := server.SetListener(); err != nil {
+		return nil, fmt.Errorf("listener: %w", err)
+	}
+
+	go func() {
+		if err := server.Serve(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Sugar.Errorf("ACP server stopped: %v", err)
+		}
+	}()
+
+	defraNode.APIURL = server.Address()
+
+	healthCtx, cancel := context.WithTimeout(ctx, acpHealthCheckTimeout)
+	defer cancel()
+
+	healthClient, err := defradbHttp.NewClient(server.Address())
+	if err != nil {
+		_ = server.Shutdown(ctx)
+		return nil, fmt.Errorf("health client: %w", err)
+	}
+	if err := healthClient.HealthCheck(healthCtx); err != nil {
+		_ = server.Shutdown(ctx)
+		return nil, fmt.Errorf("health check: %w", err)
+	}
+
+	return server, nil
+}
+
+// acpHealthCheckTimeout bounds the post-listen health check on the
+// ACP-wrapped server. The server is local; a slow response indicates
+// startup is wedged and the host should fail rather than hang.
+const acpHealthCheckTimeout = 5 * time.Second
 
 // GetMetricsHandler returns an HTTP handler for the metrics endpoint.
 func (h *Host) GetMetricsHandler() http.Handler {

--- a/pkg/shinzohub/errors.go
+++ b/pkg/shinzohub/errors.go
@@ -4,11 +4,12 @@ import "errors"
 
 //nolint:revive // package-level error sentinels — names follow Err* convention
 var (
-	ErrTendermintConnection = errors.New("tenderMint connection failure")
-	ErrHTTPErrorResponse    = errors.New("HTTP error response")
-	ErrViewHasNoQuery       = errors.New("view has no query")
-	ErrLCDNotConfigured     = errors.New("LCD URL not configured")
-	ErrEventNoContract      = errors.New("event has no contract_address")
-	ErrLCDEmptyData         = errors.New("LCD response carries empty data")
-	ErrLCDHTTPStatus        = errors.New("LCD returned non-OK HTTP status")
+	ErrTendermintConnection          = errors.New("tenderMint connection failure")
+	ErrHTTPErrorResponse             = errors.New("HTTP error response")
+	ErrViewHasNoQuery                = errors.New("view has no query")
+	ErrLCDNotConfigured              = errors.New("LCD URL not configured")
+	ErrEventNoContract               = errors.New("event has no contract_address")
+	ErrLCDEmptyData                  = errors.New("LCD response carries empty data")
+	ErrLCDHTTPStatus                 = errors.New("LCD returned non-OK HTTP status")
+	errDecodeBundleInvalidWireFormat = errors.New("decode bundle: invalid wire format")
 )

--- a/pkg/shinzohub/events.go
+++ b/pkg/shinzohub/events.go
@@ -16,8 +16,8 @@ import (
 // Live LCD hydration retries while the hub RPC pod catches up to the
 // registering block.
 var (
-	hydrateMaxAttempts = 3
-	hydrateBaseDelay   = 100 * time.Millisecond
+	hydrateMaxAttempts = 3                      //nolint:gochecknoglobals
+	hydrateBaseDelay   = 100 * time.Millisecond //nolint:gochecknoglobals
 )
 
 // log returns a non-nil SugaredLogger. Falls back to a nop logger when

--- a/pkg/shinzohub/events.go
+++ b/pkg/shinzohub/events.go
@@ -3,6 +3,7 @@ package shinzohub
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/rand/v2"
 	"time"
@@ -10,6 +11,13 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
 	"go.uber.org/zap"
+)
+
+// Live LCD hydration retries while the hub RPC pod catches up to the
+// registering block.
+var (
+	hydrateMaxAttempts = 3
+	hydrateBaseDelay   = 100 * time.Millisecond
 )
 
 // log returns a non-nil SugaredLogger. Falls back to a nop logger when
@@ -296,7 +304,7 @@ func hydrateViewBundle(ctx context.Context, lcd *RPCClient, vre *ViewRegisteredE
 		return ErrEventNoContract
 	}
 
-	wireBase64, err := lcd.GetViewBundle(ctx, vre.ContractAddress)
+	wireBase64, err := fetchBundleWithRetry(ctx, lcd, vre.ContractAddress)
 	if err != nil {
 		return fmt.Errorf("fetch bundle: %w", err)
 	}
@@ -308,6 +316,54 @@ func hydrateViewBundle(ctx context.Context, lcd *RPCClient, vre *ViewRegisteredE
 	v.ContractAddress = vre.ContractAddress
 	vre.View = v
 	return nil
+}
+
+// fetchBundleWithRetry calls GetViewBundle with exponential backoff on
+// transient failures (see isTransientHydrationErr).
+func fetchBundleWithRetry(ctx context.Context, lcd *RPCClient, contractAddr string) (string, error) {
+	delay := hydrateBaseDelay
+	var lastErr error
+	for attempt := 1; attempt <= hydrateMaxAttempts; attempt++ {
+		wireBase64, err := lcd.GetViewBundle(ctx, contractAddr)
+		if err == nil {
+			if attempt > 1 {
+				log().Infof("view bundle for contract %s hydrated on attempt %d", contractAddr, attempt)
+			}
+			return wireBase64, nil
+		}
+		if !isTransientHydrationErr(err) {
+			return "", err
+		}
+		lastErr = err
+		if attempt == hydrateMaxAttempts {
+			break
+		}
+		jitter := time.Duration(rand.Int64N(int64(delay) / 2)) //nolint:gosec,mnd
+		wait := delay + jitter - delay/4                       //nolint:mnd
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(wait):
+		}
+		delay *= 2
+	}
+	return "", fmt.Errorf("gave up after %d attempts: %w", hydrateMaxAttempts, lastErr)
+}
+
+// isTransientHydrationErr identifies failures that the hub RPC pod's
+// replication lag can produce.
+func isTransientHydrationErr(err error) bool {
+	if errors.Is(err, ErrLCDHTTPStatus) || errors.Is(err, ErrLCDEmptyData) {
+		return true
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var netErr interface{ Timeout() bool }
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	return false
 }
 
 // isTimeoutError checks whether the error is a read deadline timeout.

--- a/pkg/shinzohub/events.go
+++ b/pkg/shinzohub/events.go
@@ -305,6 +305,7 @@ func hydrateViewBundle(ctx context.Context, lcd *RPCClient, vre *ViewRegisteredE
 	if err != nil {
 		return fmt.Errorf("decode bundle: %w", err)
 	}
+	v.ContractAddress = vre.ContractAddress
 	vre.View = v
 	return nil
 }

--- a/pkg/shinzohub/events_subscription_test.go
+++ b/pkg/shinzohub/events_subscription_test.go
@@ -105,6 +105,10 @@ func TestEventSubscription_HydratesAndEmits(t *testing.T) {
 		require.Equal(t, expectedQuery, vre.View.Data.Query, "view query hydrated from bundle")
 		require.NotEmpty(t, vre.View.Data.Sdl, "view SDL hydrated from bundle")
 		require.Len(t, vre.View.Data.Transform.Lenses, 1, "lens chain decoded from bundle")
+		// The contract address is an event attribute, not part of the bundle.
+		// Hydration must copy it onto the View so the decoded value carries
+		// the on-chain identity end-to-end.
+		require.Equal(t, contract, vre.View.ContractAddress, "view contract address propagated to View struct")
 	case <-time.After(3 * time.Second):
 		t.Fatal("timed out waiting for hydrated view.view_registered event")
 	}

--- a/pkg/shinzohub/events_subscription_test.go
+++ b/pkg/shinzohub/events_subscription_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -109,6 +110,78 @@ func TestEventSubscription_HydratesAndEmits(t *testing.T) {
 		// Hydration must copy it onto the View so the decoded value carries
 		// the on-chain identity end-to-end.
 		require.Equal(t, contract, vre.View.ContractAddress, "view contract address propagated to View struct")
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for hydrated view.view_registered event")
+	}
+}
+
+// When the LCD returns a transient 404 before the registering block has
+// propagated to the LCD-backing RPC pod, hydration must retry rather than
+// drop. This test stubs an LCD that 404s the first two requests and then
+// serves the bundle; the event must be emitted on the channel with its
+// View populated.
+//
+// What this catches: a regression where the retry is bypassed or counted
+// wrong; a mismatch between the retry classifier and what GetViewBundle
+// returns on 404; a deadlock between the retry sleep and the WS read
+// goroutine; the channel-send racing the WARN drop.
+func TestEventSubscription_HydratesAfterTransientLCD(t *testing.T) {
+	useFastHydrateRetries(t, 5, 1*time.Millisecond)
+
+	const contract = "0x6814589574569e6c25e72EB52f62aFaDDf5eF14D"
+	const expectedQuery = "Ethereum__Mainnet__Log { address }"
+	bundleBase64 := makeTestBundle(t, "TestHydration")
+
+	var hits atomic.Int64
+	lcdSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/shinzonetwork/view/v1/views/"+contract {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		count := hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if count <= 2 {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"code":5,"message":"view not found"}`))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			lcdFieldView: LCDView{
+				Name:            "stub",
+				Creator:         testViewCreator,
+				ContractAddress: contract,
+				Data:            bundleBase64,
+				Height:          "1",
+			},
+		})
+	}))
+	defer lcdSrv.Close()
+	lcd := NewRPCClient(lcdSrv.URL, nil)
+
+	wsSrv := NewMockWebSocketServer()
+	defer wsSrv.Close()
+
+	cancel, ch, err := StartEventSubscription(wsSrv.WebsocketURL(), lcd)
+	require.NoError(t, err)
+	defer cancel()
+
+	wsSrv.SendEvent(txResponseFor(Event{
+		Type: eventTypeViewRegistered,
+		Attributes: []EventAttribute{
+			{Key: attrViewID, Value: "TestHydration_" + contract},
+			{Key: attrContractAddress, Value: contract},
+			{Key: attrCreator, Value: testViewCreator},
+		},
+	}))
+
+	select {
+	case ev, ok := <-ch:
+		require.True(t, ok, "event channel closed unexpectedly")
+		vre, ok := ev.(*ViewRegisteredEvent)
+		require.True(t, ok, "expected *ViewRegisteredEvent, got %T", ev)
+		require.Equal(t, contract, vre.ContractAddress)
+		require.Equal(t, expectedQuery, vre.View.Data.Query, "view query hydrated from bundle on retry")
+		require.EqualValues(t, 3, hits.Load(), "two transient failures plus one success")
 	case <-time.After(3 * time.Second):
 		t.Fatal("timed out waiting for hydrated view.view_registered event")
 	}

--- a/pkg/shinzohub/hydration_retry_test.go
+++ b/pkg/shinzohub/hydration_retry_test.go
@@ -1,0 +1,202 @@
+package shinzohub
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// useFastHydrateRetries shrinks the live-path retry budget for tests
+// and restores it on cleanup.
+func useFastHydrateRetries(t *testing.T, attempts int, base time.Duration) {
+	t.Helper()
+	prevAttempts, prevBase := hydrateMaxAttempts, hydrateBaseDelay
+	hydrateMaxAttempts, hydrateBaseDelay = attempts, base
+	t.Cleanup(func() {
+		hydrateMaxAttempts, hydrateBaseDelay = prevAttempts, prevBase
+	})
+}
+
+// servAfterN returns 404 on the first n requests, then 200.
+func servAfterN(t *testing.T, n int, contract, bundle string) (*httptest.Server, *atomic.Int64) {
+	t.Helper()
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if count <= int64(n) {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"code":5,"message":"view not found"}`))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			lcdFieldView: LCDView{
+				Name:            testViewName,
+				Creator:         testViewCreator,
+				ContractAddress: contract,
+				Data:            bundle,
+				Height:          "12345",
+			},
+		})
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &hits
+}
+
+func TestFetchBundleWithRetry_SucceedsAfterTransient404(t *testing.T) {
+	useFastHydrateRetries(t, 5, 1*time.Millisecond)
+	wantBundle := makeTestBundle(t, testViewName)
+
+	srv, hits := servAfterN(t, 2, testContractAddress1, wantBundle)
+
+	c := NewRPCClient(srv.URL, nil)
+	got, err := fetchBundleWithRetry(context.Background(), c, testContractAddress1)
+	require.NoError(t, err)
+	require.Equal(t, wantBundle, got)
+	require.EqualValues(t, 3, hits.Load(), "expected one success after two transient failures")
+}
+
+func TestFetchBundleWithRetry_GivesUpAfterBudget(t *testing.T) {
+	useFastHydrateRetries(t, 4, 1*time.Millisecond)
+
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := NewRPCClient(srv.URL, nil)
+	_, err := fetchBundleWithRetry(context.Background(), c, testContractAddress1)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "gave up after 4 attempts")
+	require.ErrorIs(t, err, ErrLCDHTTPStatus)
+	require.EqualValues(t, 4, hits.Load(), "every attempt should hit the server")
+}
+
+// PermanentErrorSkipsRetry uses an empty LCD URL: GetViewBundle short-
+// circuits before making any HTTP call, so the loop sees a non-transient
+// error on its first iteration and returns it unwrapped.
+func TestFetchBundleWithRetry_PermanentErrorSkipsRetry(t *testing.T) {
+	useFastHydrateRetries(t, 5, 1*time.Millisecond)
+
+	c := NewRPCClient("", nil)
+	_, err := fetchBundleWithRetry(context.Background(), c, testContractAddress1)
+	require.ErrorIs(t, err, ErrLCDNotConfigured)
+	require.NotContains(t, err.Error(), "gave up", "permanent errors bypass retry")
+}
+
+// PermanentErrorAfterHTTPCallSkipsRetry covers the path where the server
+// is reached but returns 200 with malformed JSON. The decode failure must
+// not be retried, and the LCD must see exactly one request.
+func TestFetchBundleWithRetry_PermanentErrorAfterHTTPCallSkipsRetry(t *testing.T) {
+	useFastHydrateRetries(t, 5, 1*time.Millisecond)
+
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`not json`))
+	}))
+	defer srv.Close()
+
+	c := NewRPCClient(srv.URL, nil)
+	_, err := fetchBundleWithRetry(context.Background(), c, testContractAddress1)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "decode LCD response")
+	require.NotContains(t, err.Error(), "gave up", "decode failure bypasses retry")
+	require.EqualValues(t, 1, hits.Load(), "permanent error must not retry")
+}
+
+// SucceedsAfterTransientEmptyData covers the other transient case the
+// classifier accepts: the LCD answered 200 but the data field was empty
+// (view registered but bundle bytes not yet populated). After one such
+// response, a follow-up call returns the bundle.
+func TestFetchBundleWithRetry_SucceedsAfterTransientEmptyData(t *testing.T) {
+	useFastHydrateRetries(t, 5, 1*time.Millisecond)
+	wantBundle := makeTestBundle(t, testViewName)
+
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		count := hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		data := wantBundle
+		if count == 1 {
+			data = "" // first response: bundle bytes not ready yet
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			lcdFieldView: LCDView{
+				Name:            testViewName,
+				ContractAddress: testContractAddress1,
+				Data:            data,
+				Height:          "1",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	c := NewRPCClient(srv.URL, nil)
+	got, err := fetchBundleWithRetry(context.Background(), c, testContractAddress1)
+	require.NoError(t, err)
+	require.Equal(t, wantBundle, got)
+	require.EqualValues(t, 2, hits.Load(), "first empty-data, second populated")
+}
+
+func TestFetchBundleWithRetry_RespectsContextCancel(t *testing.T) {
+	useFastHydrateRetries(t, 5, 50*time.Millisecond)
+
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	c := NewRPCClient(srv.URL, nil)
+	_, err := fetchBundleWithRetry(ctx, c, testContractAddress1)
+	require.ErrorIs(t, err, context.Canceled)
+	require.LessOrEqual(t, hits.Load(), int64(2), "cancellation should stop the loop early")
+}
+
+// fakeNetErr implements the Timeout() probe used by isTransientHydrationErr.
+type fakeNetErr struct{ timeout bool }
+
+func (e fakeNetErr) Timeout() bool { return e.timeout }
+func (e fakeNetErr) Error() string { return "fake net err" }
+
+func TestIsTransientHydrationErr(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil is not transient", nil, false},
+		{"lcd http status wrap", fmt.Errorf("%w: HTTP 404", ErrLCDHTTPStatus), true},
+		{"lcd empty data wrap", fmt.Errorf("%w: contract 0xabc", ErrLCDEmptyData), true},
+		{"context deadline", context.DeadlineExceeded, true},
+		{"timeout interface", fakeNetErr{timeout: true}, true},
+		{"non-timeout interface", fakeNetErr{timeout: false}, false},
+		{"decode failure is permanent", errors.New("decode bundle: invalid wire format"), false},
+		{"missing contract is permanent", ErrEventNoContract, false},
+		{"lcd not configured is permanent", ErrLCDNotConfigured, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, isTransientHydrationErr(tc.err))
+		})
+	}
+}

--- a/pkg/shinzohub/hydration_retry_test.go
+++ b/pkg/shinzohub/hydration_retry_test.go
@@ -3,7 +3,6 @@ package shinzohub
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -29,7 +28,7 @@ func useFastHydrateRetries(t *testing.T, attempts int, base time.Duration) {
 func servAfterN(t *testing.T, n int, contract, bundle string) (*httptest.Server, *atomic.Int64) {
 	t.Helper()
 	var hits atomic.Int64
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		count := hits.Add(1)
 		w.Header().Set("Content-Type", "application/json")
 		if count <= int64(n) {
@@ -173,10 +172,10 @@ func TestFetchBundleWithRetry_RespectsContextCancel(t *testing.T) {
 }
 
 // fakeNetErr implements the Timeout() probe used by isTransientHydrationErr.
-type fakeNetErr struct{ timeout bool }
+type fakeNetError struct{ timeout bool }
 
-func (e fakeNetErr) Timeout() bool { return e.timeout }
-func (e fakeNetErr) Error() string { return "fake net err" }
+func (e fakeNetError) Timeout() bool { return e.timeout }
+func (e fakeNetError) Error() string { return "fake net err" }
 
 func TestIsTransientHydrationErr(t *testing.T) {
 	cases := []struct {
@@ -188,9 +187,9 @@ func TestIsTransientHydrationErr(t *testing.T) {
 		{"lcd http status wrap", fmt.Errorf("%w: HTTP 404", ErrLCDHTTPStatus), true},
 		{"lcd empty data wrap", fmt.Errorf("%w: contract 0xabc", ErrLCDEmptyData), true},
 		{"context deadline", context.DeadlineExceeded, true},
-		{"timeout interface", fakeNetErr{timeout: true}, true},
-		{"non-timeout interface", fakeNetErr{timeout: false}, false},
-		{"decode failure is permanent", errors.New("decode bundle: invalid wire format"), false},
+		{"timeout interface", fakeNetError{timeout: true}, true},
+		{"non-timeout interface", fakeNetError{timeout: false}, false},
+		{"decode failure is permanent", fmt.Errorf("%w: invalid wire format", errDecodeBundleInvalidWireFormat), false},
 		{"missing contract is permanent", ErrEventNoContract, false},
 		{"lcd not configured is permanent", ErrLCDNotConfigured, false},
 	}

--- a/pkg/shinzohub/query.go
+++ b/pkg/shinzohub/query.go
@@ -153,6 +153,7 @@ func (c *RPCClient) FetchAllRegisteredViews(ctx context.Context) ([]view.View, i
 				log().Warnf("📡 failed to decode bundle for view %s (contract %s): %v", lv.Name, lv.ContractAddress, err)
 				continue
 			}
+			v.ContractAddress = lv.ContractAddress
 			log().Debugf("📡 fetched view %s (contract %s)", lv.Name, lv.ContractAddress)
 			views = append(views, v)
 		}

--- a/pkg/shinzohub/query.go
+++ b/pkg/shinzohub/query.go
@@ -143,20 +143,7 @@ func (c *RPCClient) FetchAllRegisteredViews(ctx context.Context) ([]view.View, i
 			return views, len(views), fmt.Errorf("decode LCD response: %w", err)
 		}
 
-		for _, lv := range page.Views {
-			if lv.Data == "" {
-				log().Debugf("📡 view %s (contract %s) has no bundle bytes; skipping", lv.Name, lv.ContractAddress)
-				continue
-			}
-			v, err := ProcessViewFromWireFormat(lv.Data)
-			if err != nil {
-				log().Warnf("📡 failed to decode bundle for view %s (contract %s): %v", lv.Name, lv.ContractAddress, err)
-				continue
-			}
-			v.ContractAddress = lv.ContractAddress
-			log().Debugf("📡 fetched view %s (contract %s)", lv.Name, lv.ContractAddress)
-			views = append(views, v)
-		}
+		views = append(views, decodeLCDViews(page.Views)...)
 
 		nextKey = page.Pagination.NextKey
 		if nextKey == "" {
@@ -166,4 +153,27 @@ func (c *RPCClient) FetchAllRegisteredViews(ctx context.Context) ([]view.View, i
 
 	log().Infof("📡 ShinzoHub query complete: found %d registered views", len(views))
 	return views, len(views), nil
+}
+
+// decodeLCDViews decodes each LCDView's bundle and copies the contract
+// address onto the resulting view.View. Entries with empty or malformed
+// bundle data are logged and skipped so a single bad view does not block
+// the rest of the page.
+func decodeLCDViews(lvs []LCDView) []view.View {
+	out := make([]view.View, 0, len(lvs))
+	for _, lv := range lvs {
+		if lv.Data == "" {
+			log().Debugf("📡 view %s (contract %s) has no bundle bytes; skipping", lv.Name, lv.ContractAddress)
+			continue
+		}
+		v, err := ProcessViewFromWireFormat(lv.Data)
+		if err != nil {
+			log().Warnf("📡 failed to decode bundle for view %s (contract %s): %v", lv.Name, lv.ContractAddress, err)
+			continue
+		}
+		v.ContractAddress = lv.ContractAddress
+		log().Debugf("📡 fetched view %s (contract %s)", lv.Name, lv.ContractAddress)
+		out = append(out, v)
+	}
+	return out
 }

--- a/pkg/shinzohub/query_test.go
+++ b/pkg/shinzohub/query_test.go
@@ -195,6 +195,41 @@ func TestFetchAllRegisteredViews_LCDNotConfigured(t *testing.T) {
 	require.Contains(t, err.Error(), "LCD URL not configured")
 }
 
+// FetchAllRegisteredViews must carry the LCDView contract address onto the
+// decoded view.View. The LCD response is the only place the address is
+// available during the startup backfill; dropping it at decode time would
+// force callers to do a second per-view query to recover it.
+func TestFetchAllRegisteredViews_PopulatesContractAddress(t *testing.T) {
+	bundleA := makeTestBundle(t, testViewNameA)
+	bundleB := makeTestBundle(t, testViewNameB)
+	const contractA = "0xA"
+	const contractB = "0xB"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			lcdFieldViews: []LCDView{
+				{Name: testViewNameA, Creator: "shinzo1a", ContractAddress: contractA, Data: bundleA, Height: "1"},
+				{Name: testViewNameB, Creator: "shinzo1b", ContractAddress: contractB, Data: bundleB, Height: "2"},
+			},
+			lcdFieldPagination: map[string]any{lcdFieldNextKey: nil},
+		})
+	}))
+	defer srv.Close()
+
+	c := NewRPCClient(srv.URL, nil)
+	views, _, err := c.FetchAllRegisteredViews(context.Background())
+	require.NoError(t, err)
+	require.Len(t, views, 2)
+
+	byName := map[string]string{}
+	for _, v := range views {
+		byName[v.Name] = v.ContractAddress
+	}
+	require.Equal(t, contractA, byName[testViewNameA], "ContractAddress for first view propagated from LCD response")
+	require.Equal(t, contractB, byName[testViewNameB], "ContractAddress for second view propagated from LCD response")
+}
+
 func TestFetchAllRegisteredViews_HTTPError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/view/view.go
+++ b/pkg/view/view.go
@@ -27,9 +27,16 @@ type Transform = viewbundle.Transform
 type Lens = viewbundle.Lens
 
 // View represents a Shinzo view with viewbundle integration.
+//
+// ContractAddress is the EVM address of the deployed view contract on
+// ShinzoHub. SourceHub relationship tuples key off this address
+// (`view:<ContractAddress>#subscriber@<did>`); callers that resolve a
+// view name to an on-chain identity rely on it. May be empty for Views
+// constructed without an on-chain origin.
 type View struct {
-	Name string          `json:"name"`
-	Data viewbundle.View `json:"data"`
+	Name            string          `json:"name"`
+	ContractAddress string          `json:"contract_address,omitempty"`
+	Data            viewbundle.View `json:"data"`
 }
 
 // NewViewFromWire creates a new View from a viewbundle wire format.

--- a/pkg/view/viewManager.go
+++ b/pkg/view/viewManager.go
@@ -19,6 +19,15 @@ type Registrar interface {
 	RegisterView(ctx context.Context, v View) error
 }
 
+// ActiveView is the per-registered-view state the Manager retains in memory.
+// Lens is the DefraDB view configuration. ContractAddress is the view's
+// on-chain identity, used to resolve a collection name to the SourceHub
+// relationship-tuple object_id at request time.
+type ActiveView struct {
+	Lens            *client.LensConfig
+	ContractAddress string
+}
+
 // Manager orchestrates the complete lifecycle of Shinzo views including:
 // - Loading views from local storage and external sources
 // - Managing WASM lens files and migrations
@@ -26,7 +35,7 @@ type Registrar interface {
 // - Setting up P2P subscriptions for real-time updates
 // - Tracking active views and metrics.
 type Manager struct {
-	activeViews     map[string]*client.LensConfig
+	activeViews     map[string]*ActiveView
 	defraNode       *node.Node
 	mutex           sync.RWMutex
 	schemaService   *SchemaService
@@ -40,7 +49,7 @@ type Manager struct {
 func NewManager(defraNode *node.Node, registryPath string) *Manager {
 	wasmRegistry, _ := NewWASMRegistry(registryPath, zap.L().Sugar())
 	return &Manager{
-		activeViews:   make(map[string]*client.LensConfig),
+		activeViews:   make(map[string]*ActiveView),
 		defraNode:     defraNode,
 		schemaService: NewSchemaService(),
 		wasmRegistry:  wasmRegistry,
@@ -150,8 +159,8 @@ func (m *Manager) GetActiveViewDetails() [][]string {
 	defer m.mutex.RUnlock()
 
 	details := make([][]string, 0, len(m.activeViews))
-	for name, lensConfig := range m.activeViews {
-		details = append(details, []string{name, lensConfig.DestinationCollectionVersionID})
+	for name, av := range m.activeViews {
+		details = append(details, []string{name, av.Lens.DestinationCollectionVersionID})
 	}
 	return details
 }
@@ -161,6 +170,21 @@ func (m *Manager) GetViewCount() int {
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
 	return len(m.activeViews)
+}
+
+// ContractAddress returns the on-chain contract address for an active view by
+// name. Returns ("", false) when no view by that name is registered or when
+// the registered view has no address set; the boolean lets callers
+// distinguish "no address available" from a legitimate empty string without
+// relying on the string itself.
+func (m *Manager) ContractAddress(viewName string) (string, bool) {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+	av, ok := m.activeViews[viewName]
+	if !ok || av.ContractAddress == "" {
+		return "", false
+	}
+	return av.ContractAddress, true
 }
 
 // RegisterView implements the full view registration flow with validation.
@@ -200,9 +224,12 @@ func (m *Manager) RegisterView(ctx context.Context, v *View) error {
 
 	m.updateMetrics()
 
-	m.activeViews[v.Name] = &client.LensConfig{
-		SourceCollectionVersionID:      v.Data.Query,
-		DestinationCollectionVersionID: v.Data.Sdl,
+	m.activeViews[v.Name] = &ActiveView{
+		Lens: &client.LensConfig{
+			SourceCollectionVersionID:      v.Data.Query,
+			DestinationCollectionVersionID: v.Data.Sdl,
+		},
+		ContractAddress: v.ContractAddress,
 	}
 
 	return nil

--- a/pkg/view/viewManager.go
+++ b/pkg/view/viewManager.go
@@ -172,6 +172,18 @@ func (m *Manager) GetViewCount() int {
 	return len(m.activeViews)
 }
 
+// IsActive reports whether a view with the given name is currently
+// registered, regardless of whether it carries an on-chain contract
+// address. Distinguished from ContractAddress so callers can tell
+// "not a view" (skip) apart from "view without address" (handle
+// explicitly).
+func (m *Manager) IsActive(viewName string) bool {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+	_, ok := m.activeViews[viewName]
+	return ok
+}
+
 // ContractAddress returns the on-chain contract address for an active view by
 // name. Returns ("", false) when no view by that name is registered or when
 // the registered view has no address set; the boolean lets callers

--- a/pkg/view/viewManager_test.go
+++ b/pkg/view/viewManager_test.go
@@ -956,6 +956,46 @@ func TestViewManager_ContractAddress_EmptyAddressReturnsFalse(t *testing.T) {
 	require.Equal(t, "", got)
 }
 
+// TestViewManager_IsActive registers two views (one with a contract address,
+// one without) and verifies IsActive returns true for both, false for an
+// unregistered name. IsActive must report registration independently of
+// whether an address is present so callers can distinguish "not a view"
+// from "view without address".
+func TestViewManager_IsActive(t *testing.T) {
+	ctx := context.Background()
+
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
+	require.NoError(t, err)
+	defer func() { _ = defraNode.Close(ctx) }()
+
+	vm := NewManager(defraNode, t.TempDir())
+
+	_, err = defraNode.DB.AddSchema(ctx, "type Ethereum__Mainnet__Log { address: String }")
+	require.NoError(t, err)
+
+	addressed := &View{
+		Name:            "AddressedView",
+		ContractAddress: "0xc5d55f9a4e8788abaaf74d4772c2a4afe60a23a3",
+		Data: viewbundle.View{
+			Query: queryEthLogAddr,
+			Sdl:   "type AddressedView { address: String }",
+		},
+	}
+	unaddressed := &View{
+		Name: "UnaddressedView",
+		Data: viewbundle.View{
+			Query: queryEthLogAddr,
+			Sdl:   "type UnaddressedView { address: String }",
+		},
+	}
+	require.NoError(t, vm.RegisterView(ctx, addressed))
+	require.NoError(t, vm.RegisterView(ctx, unaddressed))
+
+	require.True(t, vm.IsActive("AddressedView"))
+	require.True(t, vm.IsActive("UnaddressedView"))
+	require.False(t, vm.IsActive("NeverRegistered"))
+}
+
 // TestViewManager_ContractAddress_UnknownViewReturnsFalse verifies that a
 // lookup for a name not in the registry returns ("", false).
 func TestViewManager_ContractAddress_UnknownViewReturnsFalse(t *testing.T) {

--- a/pkg/view/viewManager_test.go
+++ b/pkg/view/viewManager_test.go
@@ -892,3 +892,82 @@ func TestDeduplicateViews_ComplexScenarios(t *testing.T) {
 		})
 	}
 }
+
+// TestViewManager_ContractAddress_StoredAndRetrieved registers a view with a
+// non-empty ContractAddress and verifies Manager.ContractAddress returns the
+// stored value.
+func TestViewManager_ContractAddress_StoredAndRetrieved(t *testing.T) {
+	ctx := context.Background()
+
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
+	require.NoError(t, err)
+	defer func() { _ = defraNode.Close(ctx) }()
+
+	vm := NewManager(defraNode, t.TempDir())
+
+	_, err = defraNode.DB.AddSchema(ctx, "type Ethereum__Mainnet__Log { address: String }")
+	require.NoError(t, err)
+
+	const addr = "0xc5d55f9a4e8788abaaf74d4772c2a4afe60a23a3"
+	v := &View{
+		Name:            "AddressedView",
+		ContractAddress: addr,
+		Data: viewbundle.View{
+			Query: queryEthLogAddr,
+			Sdl:   "type AddressedView { address: String }",
+		},
+	}
+
+	require.NoError(t, vm.RegisterView(ctx, v))
+
+	got, ok := vm.ContractAddress("AddressedView")
+	require.True(t, ok, "expected ContractAddress lookup to succeed for a registered addressed view")
+	require.Equal(t, addr, got)
+}
+
+// TestViewManager_ContractAddress_EmptyAddressReturnsFalse registers a view
+// whose ContractAddress is the empty string and verifies the accessor returns
+// ("", false). The boolean lets callers gate on presence without inferring it
+// from the string.
+func TestViewManager_ContractAddress_EmptyAddressReturnsFalse(t *testing.T) {
+	ctx := context.Background()
+
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
+	require.NoError(t, err)
+	defer func() { _ = defraNode.Close(ctx) }()
+
+	vm := NewManager(defraNode, t.TempDir())
+
+	_, err = defraNode.DB.AddSchema(ctx, "type Ethereum__Mainnet__Log { address: String }")
+	require.NoError(t, err)
+
+	v := &View{
+		Name: "UnaddressedView",
+		Data: viewbundle.View{
+			Query: queryEthLogAddr,
+			Sdl:   "type UnaddressedView { address: String }",
+		},
+	}
+
+	require.NoError(t, vm.RegisterView(ctx, v))
+
+	got, ok := vm.ContractAddress("UnaddressedView")
+	require.False(t, ok, "expected ContractAddress lookup to fail for a view registered without an address")
+	require.Equal(t, "", got)
+}
+
+// TestViewManager_ContractAddress_UnknownViewReturnsFalse verifies that a
+// lookup for a name not in the registry returns ("", false).
+func TestViewManager_ContractAddress_UnknownViewReturnsFalse(t *testing.T) {
+	ctx := context.Background()
+
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, &defradb.MockSchemaApplierThatSucceeds{})
+	require.NoError(t, err)
+	defer func() { _ = defraNode.Close(ctx) }()
+
+	vm := NewManager(defraNode, t.TempDir())
+
+	got, ok := vm.ContractAddress("NeverRegistered")
+	require.False(t, ok)
+	require.Equal(t, "", got)
+}


### PR DESCRIPTION
  - ACP middleware gates view queries against SourceHub    
  - View bundles now track their contract address so the middleware can look them up
  - ACP middleware traverses GraphQL fragments                 
  - ACP middleware mirrors defradb's URL-query precedence on POST             
  - LCD hydration retries on transient failures                                      
  - Defradb bind mount points at /app/.defra                                                                
  - ACP server bind reads from cfg.DefraDB.URL; DEFRA_URL env supported                                      
  - Dockerfile HEALTHCHECK matches the prod :standard image