### PR TITLE
CollectionIDToName populated at runtime

### DIFF
--- a/pkg/host/attestationHandler.go
+++ b/pkg/host/attestationHandler.go
@@ -83,13 +83,8 @@ var (
 )
 
 // collectionIDToName - mapping for ID to Name.
-var collectionIDToName = map[string]string{ //nolint:gochecknoglobals
-	blockSigCollectionID:    constants.CollectionBlockSignature,
-	blockCollectionID:       constants.CollectionBlock,
-	transactionCollectionID: constants.CollectionTransaction,
-	logCollectionID:         constants.CollectionLog,
-	accessListCollectionID:  constants.CollectionAccessListEntry,
-}
+// Populated at runtime by initKnownCollectionIDs after fetching real collection IDs from DefraDB.
+var collectionIDToName = map[string]string{} //nolint:gochecknoglobals
 
 // collectionsWithMetrics - mapping collection to bool.
 var collectionsWithMetrics = map[string]bool{ //nolint:gochecknoglobals
@@ -115,14 +110,19 @@ func (h *Host) initKnownCollectionIDs(ctx context.Context) error {
 		switch col.Name() {
 		case constants.CollectionBlockSignature:
 			blockSigCollectionID = col.CollectionID()
+			collectionIDToName[blockSigCollectionID] = constants.CollectionBlockSignature
 		case constants.CollectionBlock:
 			blockCollectionID = col.CollectionID()
+			collectionIDToName[blockCollectionID] = constants.CollectionBlock
 		case constants.CollectionTransaction:
 			transactionCollectionID = col.CollectionID()
+			collectionIDToName[transactionCollectionID] = constants.CollectionTransaction
 		case constants.CollectionLog:
 			logCollectionID = col.CollectionID()
+			collectionIDToName[logCollectionID] = constants.CollectionLog
 		case constants.CollectionAccessListEntry:
 			accessListCollectionID = col.CollectionID()
+			collectionIDToName[accessListCollectionID] = constants.CollectionAccessListEntry
 		}
 	}
 


### PR DESCRIPTION
# Pull Request

## Description
The function initKnownCollectionIDs was being mapped to null values and therefore no events were being triggered to create attestations or process documents.

## Changes
- updated the function to initialize the map with collection ids from defra

## Related Issue
fixes #246 

## Steps to Test
1. make build
2. make start 
3. look for attestation log

## Checklist
- [x] Code compiles / runs
- [x] Tests added / updated
- [x] Documentation updated if needed
- [x] PR is self-contained and focused
- [x] Code does not break any existing features
- [x] Code passes personal internal testing

## Notes
chore: col.ID was returning empty IDs at runtime, moved them to be set within initKnownCollectionIDs
