### PR TITLE
Fix/docker volumes

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -9,7 +9,6 @@ services:
     ports:
       - "443:443"  # HTTPS
       - "80:80"    # HTTP (redirects to HTTPS)
-      - "444:444"  # GraphQL Playground
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
       - ~/ssl/nginx.crt:/etc/nginx/ssl/nginx.crt:ro

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -11,8 +11,9 @@ services:
       - "80:80"    # HTTP (redirects to HTTPS)
       - "444:444"  # GraphQL Playground
     volumes:
-      - ~/nginx.conf:/etc/nginx/nginx.conf:ro
-      - ~/ssl:/etc/nginx/ssl:ro
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - ~/ssl/nginx.crt:/etc/nginx/ssl/nginx.crt:ro
+      - ~/ssl/nginx.key:/etc/nginx/ssl/nginx.key:ro
     depends_on:
       - shinzo-host
     networks:
@@ -26,8 +27,9 @@ services:
     container_name: shinzo-host
     volumes:
       - ~/data/defradb:/app/.defra
-      - ~/data/lens:/app/.lens
-      - ~/shinzo-host-client/config.yaml:/app/config.yaml:ro
+      - ~/data/keys:/app/.defra/keys
+      - ~/data/lens:/app/.defra/lens
+      - ~/config.yaml:/app/config.yaml:ro
     environment:
       - DEFRA_URL=0.0.0.0:9181  # Change port here if needed
       - LOG_LEVEL=error

--- a/host-prod-setup.sh
+++ b/host-prod-setup.sh
@@ -169,7 +169,8 @@ services:
   nginx:
     image: nginx:alpine
     ports:
-      - "8080:8080"
+      - "80:80"
+      - "443:443"   
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
       - ~/ssl/nginx.crt:/etc/nginx/ssl/nginx.crt:ro

--- a/host-prod-setup.sh
+++ b/host-prod-setup.sh
@@ -150,7 +150,7 @@ services:
     volumes:
       - ~/data/defradb:/app/.defra
       - ~/data/keys:/app/.defra/keys
-      - ~/data/lens:/app/.lens`
+      - ~/data/lens:/app/.defra/lens`
       - ~/config.yaml:/app/config.yaml:ro
     environment:
       - DEFRA_URL=0.0.0.0:9181

--- a/host-prod-setup.sh
+++ b/host-prod-setup.sh
@@ -126,8 +126,6 @@ host:
         end: 24528999
 EOF
 
-&&
-
 sudo tee ~/docker-compose.yml <<'EOF'
 networks:
   shinzo-net:
@@ -181,8 +179,6 @@ services:
       - shinzo-net
     restart: unless-stopped
 EOF
-
-&&
 
 sudo tee ~/nginx.conf <<'EOF'
 events { worker_connections 1024; }

--- a/host-prod-setup.sh
+++ b/host-prod-setup.sh
@@ -149,7 +149,8 @@ services:
       - "9171:9171"  # P2P networking (still needs external access)
     volumes:
       - ~/data/defradb:/app/.defra
-      - ~/data/lens:/app/.lens
+      - ~/data/keys:/app/.defra/keys
+      - ~/data/lens:/app/.lens`
       - ~/config.yaml:/app/config.yaml:ro
     environment:
       - DEFRA_URL=0.0.0.0:9181
@@ -171,6 +172,8 @@ services:
       - "8080:8080"
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - ~/ssl/nginx.crt:/etc/nginx/ssl/nginx.crt:ro
+      - ~/ssl/nginx.key:/etc/nginx/ssl/nginx.key:ro
     depends_on:
       - shinzo-host
     networks:


### PR DESCRIPTION
# Pull Request

## Description
This PR fixes the discrepency between config path and docker volumes for the host and nginx.

## Changes
- updates docker volume to the correct defra path for data + lens
- update host-prod-setup with corrected docker-compose
- updates nginx to the ssl volumes created in host-prod.sh

## Related Issue
https://github.com/shinzonetwork/shinzo-host-client/issues/259


## Checklist
- [x] Code compiles / runs
- [x] Tests added / updated
- [x] Documentation updated if needed
- [x] PR is self-contained and focused
- [x] Code does not break any existing features
- [x] Code passes personal internal testing

## Notes
Code tested on host-3
