### PR TITLE
Remove old commands from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,6 @@
 build:
 	go build -o bin/host cmd/main.go
 
-build-branchable:
-	go build -tags branchable -o bin/host cmd/main.go
-
 build-playground: deps-playground
 	go generate -tags hostplayground ./playground
 	go build -tags hostplayground -o ./bin/host cmd/main.go
@@ -16,10 +13,6 @@ start:
 # Download playground static assets
 deps-playground:
 	cd playground && go generate .
-
-# Build with both branchable tag and playground enabled
-build-branchable-with-playground: deps-playground
-	go build -tags "branchable,hostplayground" -o bin/host cmd/main.go
 
 lint:
 	@echo "🔍 Running golangci-lint..."

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-playground build-branchable build-branchable-with-playground start deps-playground lint lint-fix
+.PHONY: build build-playground start deps-playground lint lint-fix
 
 build:
 	go build -o bin/host cmd/main.go


### PR DESCRIPTION
## Description
Remove old commands from Makefile that includes 

- `build-branchable `
-  `build-branchable-with-playground`

## Related Issue
#258 

## Checklist
- [ ] Code compiles / runs
- [ ] Tests added / updated
- [ ] Documentation updated if needed
- [x] PR is self-contained and focused
- [ ] Code does not break any existing features
- [ ] Code passes personal internal testing