### PR TITLE
Bump golangci-lint from v6 to v7

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -32,7 +32,7 @@ jobs:
           ${{ runner.os }}-go-
 
     - name: Linting - golangci-lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v7
       with:
         version: v2.12.2
 


### PR DESCRIPTION
# Pull Request

## Description
Bumps go-test linter from v6 to v7

## Changes
- golangci-lint action ~~v6~~ -> v7

## Related Issue
https://github.com/shinzonetwork/shinzo-host-client/issues/263

## Checklist
- [x] Code compiles / runs
- [x] Tests added / updated
- [x] Documentation updated if needed
- [x] PR is self-contained and focused
- [x] Code does not break any existing features
- [x] Code passes personal internal testing

## Notes
chore: update action from v6 to v7
