### PR TITLE
feat: registration improvements

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -35,7 +35,7 @@ services:
       - LOG_SOURCE=false
       - LOG_STACKTRACE=false
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:6060/metrics"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/metrics"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/host-prod-setup.sh
+++ b/host-prod-setup.sh
@@ -252,6 +252,27 @@ http {
       add_header 'Vary'                         'Origin' always;
       proxy_pass http://$backend:8080/registration;
       proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-Host $host;
+      proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location = /registration-app {
+      if ($request_method = OPTIONS) {
+        add_header 'Access-Control-Allow-Origin'  $cors_origin always;
+        add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS' always;
+        add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type, Accept, Origin' always;
+        add_header 'Access-Control-Max-Age'       3600 always;
+        add_header 'Vary'                         'Origin' always;
+        return 204;
+      }
+      add_header 'Access-Control-Allow-Origin'  $cors_origin always;
+      add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS' always;
+      add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type, Accept, Origin' always;
+      add_header 'Vary'                         'Origin' always;
+      proxy_pass http://$backend:8080/registration-app;
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-Host $host;
+      proxy_set_header X-Forwarded-Proto $scheme;
     }
 
     location = /api/v0/graphql {

--- a/nginx.conf
+++ b/nginx.conf
@@ -49,6 +49,30 @@ http {
     }
 
     # Registration endpoint
+    location = /registration {
+      if ($request_method = OPTIONS) {
+        return 204;
+      }
+
+      proxy_pass http://shinzo-host:8080/registration;
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-Host $host;
+      proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Registration app redirect endpoint
+    location = /registration-app {
+      if ($request_method = OPTIONS) {
+        return 204;
+      }
+
+      proxy_pass http://shinzo-host:8080/registration-app;
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-Host $host;
+      proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Backward-compatible registration endpoint
     location = /api/v0/registration {
       if ($request_method = OPTIONS) {
         return 204;
@@ -56,6 +80,8 @@ http {
 
       proxy_pass http://shinzo-host:8080/registration;
       proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-Host $host;
+      proxy_set_header X-Forwarded-Proto $scheme;
     }
 
     # GraphQL endpoint

--- a/pkg/server/health.go
+++ b/pkg/server/health.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	_ "embed"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -49,26 +48,6 @@ type PeerInfo struct {
 	ID        string   `json:"id"`
 	Addresses []string `json:"addresses"`
 	PublicKey string   `json:"public_key,omitempty"`
-}
-
-// DisplayRegistration represents the registration status and signed messages for display in the health endpoint.
-type DisplayRegistration struct {
-	Enabled             bool                `json:"enabled"`
-	Message             string              `json:"message"`
-	DefraPKRegistration DefraPKRegistration `json:"defra_pk_registration,omitzero"`
-	PeerIDRegistration  PeerIDRegistration  `json:"peer_id_registration,omitzero"`
-}
-
-// DefraPKRegistration represents the registration information for the host's DefraDB public key, including the signed message.
-type DefraPKRegistration struct {
-	PublicKey   string `json:"public_key,omitempty"`
-	SignedPKMsg string `json:"signed_pk_message,omitempty"`
-}
-
-// PeerIDRegistration represents the registration information for the host's P2P peer ID, including the signed message.
-type PeerIDRegistration struct {
-	PeerID        string `json:"peer_id,omitempty"`
-	SignedPeerMsg string `json:"signed_peer_message,omitempty"`
 }
 
 // HealthResponse represents the health check response.
@@ -188,35 +167,6 @@ func (hs *HealthServer) healthHandler(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(response)
 }
 
-// getRegistrationData returns the signed registration data for the indexer.
-func (hs *HealthServer) getRegistrationData() (*DisplayRegistration, error) {
-	if hs.host == nil {
-		return nil, ErrHostNotAvailable
-	}
-
-	const registrationMessage = "Shinzo Network host registration"
-	defraReg, peerReg, signErr := hs.host.SignMessages(registrationMessage)
-	registration := &DisplayRegistration{
-		Enabled: signErr == nil,
-		Message: normalizeHex(hex.EncodeToString([]byte(registrationMessage))),
-	}
-	if signErr != nil {
-		return registration, signErr
-	}
-
-	// Normalize signed fields to 0x-prefixed hex strings for API consumers.
-	registration.DefraPKRegistration = DefraPKRegistration{
-		PublicKey:   normalizeHex(defraReg.PublicKey),
-		SignedPKMsg: normalizeHex(defraReg.SignedPKMsg),
-	}
-	registration.PeerIDRegistration = PeerIDRegistration{
-		PeerID:        normalizeHex(peerReg.PeerID),
-		SignedPeerMsg: normalizeHex(peerReg.SignedPeerMsg),
-	}
-
-	return registration, nil
-}
-
 // registrationHandler handles readiness probe requests.
 func (hs *HealthServer) registrationHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -258,7 +208,7 @@ func (hs *HealthServer) registrationHandler(w http.ResponseWriter, r *http.Reque
 			return
 		}
 
-		registration, _ := hs.getRegistrationData()
+		registration, _ := hs.getRegistrationData(r)
 		response.Registration = registration
 	}
 
@@ -269,26 +219,6 @@ func (hs *HealthServer) registrationHandler(w http.ResponseWriter, r *http.Reque
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(response)
-}
-
-// registrationAppHandler redirects to the registration app with registration data as query params.
-func (hs *HealthServer) registrationAppHandler(w http.ResponseWriter, r *http.Request) {
-	registration, err := hs.getRegistrationData()
-	if err != nil || registration == nil || !registration.Enabled {
-		http.Error(w, "Registration data not available", http.StatusServiceUnavailable)
-		return
-	}
-
-	redirectURL := fmt.Sprintf(
-		"https://registration.shinzo.network/?role=host&signedMessage=%s&peerId=%s&peerSignedMessage=%s&defraPublicKey=%s&defraPublicKeySignedMessage=%s",
-		registration.Message,
-		registration.PeerIDRegistration.PeerID,
-		registration.PeerIDRegistration.SignedPeerMsg,
-		registration.DefraPKRegistration.PublicKey,
-		registration.DefraPKRegistration.SignedPKMsg,
-	)
-
-	http.Redirect(w, r, redirectURL, http.StatusTemporaryRedirect)
 }
 
 // metricsHandler provides basic metrics in JSON format.
@@ -381,17 +311,4 @@ func (hs *HealthServer) getHealthStatusPageHTML() []byte {
 	// Fallback to embedded version (for production or if file not found)
 	logger.Sugar.Debug("Using embedded health status page")
 	return []byte(embeddedHealthStatusPageHTML)
-}
-
-// normalizeHex ensures a string is represented as a 0x-prefixed hex string.
-// If the string is empty, it is returned unchanged.
-func normalizeHex(s string) string {
-	if s == "" {
-		return s
-	}
-	if strings.HasPrefix(s, "0x") || strings.HasPrefix(s, "0X") {
-		// Normalize any 0X to 0x for consistency.
-		return "0x" + s[2:]
-	}
-	return "0x" + s
 }

--- a/pkg/server/health_status_page.html
+++ b/pkg/server/health_status_page.html
@@ -347,7 +347,7 @@
     </div>
 
     <script>
-        const SHINZOHUB_REST_BASE = 'http://rpc.develop.devnet.shinzo.network:1317';
+        const SHINZOHUB_REST_BASE = 'http://rpc.testnet.shinzo.network:1317';
         let refreshInterval;
 
         function formatNumber(num) {

--- a/pkg/server/health_status_page.html
+++ b/pkg/server/health_status_page.html
@@ -106,13 +106,17 @@
 
         .info-row {
             display: flex;
+            align-items: center;
+            gap: 16px;
             justify-content: space-between;
             padding: 12px 0;
             border-bottom: 1px solid #f5f5f5;
             font-size: 14px;
+            min-width: 0;
         }
 
         .info-label {
+            flex-shrink: 0;
             font-weight: 500;
             color: #666;
         }
@@ -121,6 +125,16 @@
             font-family: 'Courier New', monospace;
             color: #000;
             text-align: right;
+            min-width: 0;
+        }
+
+        .truncated-value {
+            display: inline-block;
+            max-width: 100%;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            vertical-align: bottom;
+            white-space: nowrap;
         }
 
         .copyable {
@@ -288,6 +302,24 @@
                     </div>
                 </div>
             </div>
+
+            <div class="col-4">
+                <div class="info-group">
+                    <h2>Registration</h2>
+                    <div class="info-row">
+                        <span class="info-label">Status</span>
+                        <span class="info-value" id="registrationStatusValue">Checking...</span>
+                    </div>
+                    <div class="info-row">
+                        <span class="info-label">Address</span>
+                        <span class="info-value" id="registrationAddressValue">-</span>
+                    </div>
+                    <div class="info-row" id="registrationActionRow" style="display: none;">
+                        <span class="info-label">Action</span>
+                        <span class="info-value"><a id="registrationActionLink" href="/registration-app">Register host</a></span>
+                    </div>
+                </div>
+            </div>
         </div>
 
         <div class="section-label">P2P Network</div>
@@ -315,6 +347,7 @@
     </div>
 
     <script>
+        const SHINZOHUB_REST_BASE = 'http://rpc.develop.devnet.shinzo.network:1317';
         let refreshInterval;
 
         function formatNumber(num) {
@@ -405,6 +438,101 @@
             }).join('');
         }
 
+        function renderRegistrationStatus(status, address, errorMessage) {
+            const statusValue = document.getElementById('registrationStatusValue');
+            const addressValue = document.getElementById('registrationAddressValue');
+            const actionRow = document.getElementById('registrationActionRow');
+            const actionLink = document.getElementById('registrationActionLink');
+
+            if (status === 'registered') {
+                statusValue.textContent = 'Registered';
+                statusValue.className = 'info-value status-indicator-inline status-healthy';
+                addressValue.textContent = address || '-';
+                addressValue.title = address || '';
+                addressValue.className = address ? 'info-value copyable truncated-value' : 'info-value';
+                addressValue.onclick = address ? () => copyToClipboard(address, addressValue) : null;
+                actionRow.style.display = 'none';
+                return;
+            }
+
+            if (status === 'not-registered') {
+                statusValue.textContent = 'Not registered';
+                statusValue.className = 'info-value status-indicator-inline status-disconnected';
+                addressValue.textContent = '-';
+                addressValue.title = '';
+                addressValue.className = 'info-value';
+                addressValue.onclick = null;
+                actionLink.href = '/registration-app';
+                actionRow.style.display = '';
+                return;
+            }
+
+            statusValue.textContent = errorMessage || 'Unable to check';
+            statusValue.className = 'info-value status-indicator-inline status-disconnected';
+            addressValue.textContent = '-';
+            addressValue.title = '';
+            addressValue.className = 'info-value';
+            addressValue.onclick = null;
+            actionLink.href = '/registration-app';
+            actionRow.style.display = '';
+        }
+
+        async function findRegisteredHostByDid(did) {
+            let nextKey = '';
+            const limit = 200;
+
+            do {
+                const params = new URLSearchParams({ 'pagination.limit': String(limit) });
+                if (nextKey) {
+                    params.set('pagination.key', nextKey);
+                }
+
+                const response = await fetch(`${SHINZOHUB_REST_BASE}/shinzonetwork/host/v1/hosts?${params.toString()}`);
+                if (!response.ok) {
+                    throw new Error(`ShinzoHub returned HTTP ${response.status}`);
+                }
+
+                const data = await response.json();
+                const match = (data.hosts || []).find(host => host.did === did);
+                if (match) {
+                    return match;
+                }
+                nextKey = data.pagination && data.pagination.next_key ? data.pagination.next_key : '';
+            } while (nextKey);
+
+            return null;
+        }
+
+        async function loadRegistrationData() {
+            try {
+                const response = await fetch('/registration', {
+                    headers: {
+                        'Accept': 'application/json'
+                    }
+                });
+                if (!response.ok) {
+                    renderRegistrationStatus('unknown', '', `Local registration unavailable (${response.status})`);
+                    return;
+                }
+
+                const data = await response.json();
+                const did = data.registration && data.registration.did;
+                if (!did) {
+                    renderRegistrationStatus('unknown', '', 'Missing host DID');
+                    return;
+                }
+
+                const host = await findRegisteredHostByDid(did);
+                if (host) {
+                    renderRegistrationStatus('registered', host.address || '');
+                } else {
+                    renderRegistrationStatus('not-registered');
+                }
+            } catch (error) {
+                renderRegistrationStatus('unknown', '', `Error checking registration: ${error.message}`);
+            }
+        }
+
         async function loadHealthData() {
             try {
                 document.getElementById('loading').style.display = 'block';
@@ -457,6 +585,7 @@
                     document.getElementById('peerList').innerHTML = '<div class="peer-card"><div class="peer-id">No P2P data available</div></div>';
                 }
 
+                loadRegistrationData();
                 document.getElementById('loading').style.display = 'none';
             } catch (error) {
                 document.getElementById('loading').style.display = 'none';

--- a/pkg/server/health_test.go
+++ b/pkg/server/health_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -237,18 +238,39 @@ func TestRegistrationAppHandler_SuccessRedirect(t *testing.T) {
 		healthy:  true,
 		defraReg: DefraPKRegistration{PublicKey: "0xabc", SignedPKMsg: "0xdef"},
 		peerReg:  PeerIDRegistration{PeerID: "0xpeer1", SignedPeerMsg: "0xsig1"},
+		peerInfo: &P2PInfo{
+			Self: &PeerInfo{
+				ID:        "12D3KooWTestPeer",
+				Addresses: []string{"/ip4/0.0.0.0/tcp/9171"},
+			},
+		},
 	}
 	hs := newHS(mock, "")
 
 	req := httptest.NewRequest(http.MethodGet, "/registration-app", nil)
+	req.Host = "35.239.160.177:8080"
+	req.Header.Set("X-Forwarded-Proto", "https")
+	req.Header.Set("X-Forwarded-Host", "host.example.com")
 	w := httptest.NewRecorder()
 
 	hs.registrationAppHandler(w, req)
 
 	require.Equal(t, http.StatusTemporaryRedirect, w.Code)
 	loc := w.Header().Get("Location")
-	require.Contains(t, loc, "https://registration.shinzo.network/")
-	require.Contains(t, loc, "defraPublicKey=")
+	redirectURL, err := url.Parse(loc)
+	require.NoError(t, err)
+	require.Equal(t, "https", redirectURL.Scheme)
+	require.Equal(t, "registration.shinzo.network", redirectURL.Host)
+	require.Equal(t, "/host-registration", redirectURL.Path)
+	query := redirectURL.Query()
+	require.Equal(t, "host", query.Get("role"))
+	require.Equal(t, "0x5368696e7a6f204e6574776f726b20686f737420726567697374726174696f6e", query.Get("signedMessage"))
+	require.Equal(t, "0xabc", query.Get("defraPublicKey"))
+	require.Equal(t, "0xdef", query.Get("defraPublicKeySignedMessage"))
+	require.Equal(t, "/ip4/35.239.160.177/tcp/9171/p2p/12D3KooWTestPeer", query.Get("connectionString"))
+	require.Equal(t, "https://host.example.com/api/v0/graphql", query.Get("endpointAddress"))
+	require.Empty(t, query.Get("peerId"))
+	require.Empty(t, query.Get("peerSignedMessage"))
 }
 
 func TestRegistrationAppHandler_NilHost(t *testing.T) {
@@ -480,27 +502,44 @@ func TestNewHealthServer_NilMetrics(t *testing.T) {
 
 func TestGetRegistrationData_NilHost(t *testing.T) {
 	hs := newHS(nil, "")
-	reg, err := hs.getRegistrationData()
+	req := httptest.NewRequest(http.MethodGet, "/registration", nil)
+	reg, err := hs.getRegistrationData(req)
 	require.Error(t, err)
 	require.Nil(t, reg)
 }
 
 func TestGetRegistrationData_WithHost(t *testing.T) {
 	mock := &mockHealthChecker{
-		defraReg: DefraPKRegistration{PublicKey: testRegPublicKey, SignedPKMsg: testRegSignedPKMsg},
-		peerReg:  PeerIDRegistration{PeerID: testRegPeerID, SignedPeerMsg: testRegSignedPeerID},
+		defraReg: DefraPKRegistration{
+			PublicKey:   "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+			SignedPKMsg: testRegSignedPKMsg,
+		},
+		peerReg: PeerIDRegistration{PeerID: testRegPeerID, SignedPeerMsg: testRegSignedPeerID},
+		peerInfo: &P2PInfo{
+			Self: &PeerInfo{
+				ID:        "12D3KooWTestPeer",
+				Addresses: []string{"/ip4/198.51.100.10/tcp/9171"},
+			},
+		},
 	}
 	hs := newHS(mock, "")
 
-	reg, err := hs.getRegistrationData()
+	req := httptest.NewRequest(http.MethodGet, "/registration", nil)
+	req.Host = "203.0.113.25:8080"
+	req.Header.Set("X-Forwarded-Proto", "https")
+	req.Header.Set("X-Forwarded-Host", "host.example.com")
+	reg, err := hs.getRegistrationData(req)
 	require.NoError(t, err)
 	require.NotNil(t, reg)
 	require.True(t, reg.Enabled)
 	// The function normalizes hex strings
-	require.Equal(t, "0xabc", reg.DefraPKRegistration.PublicKey)
+	require.Equal(t, "0x0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798", reg.DefraPKRegistration.PublicKey)
 	require.Equal(t, "0xdef", reg.DefraPKRegistration.SignedPKMsg)
 	require.Equal(t, "0xpeer1", reg.PeerIDRegistration.PeerID)
 	require.Equal(t, "0xsig1", reg.PeerIDRegistration.SignedPeerMsg)
+	require.NotEmpty(t, reg.DID)
+	require.Equal(t, "/ip4/203.0.113.25/tcp/9171/p2p/12D3KooWTestPeer", reg.ConnectionString)
+	require.Equal(t, "https://host.example.com/api/v0/graphql", reg.EndpointAddress)
 }
 
 func TestGetRegistrationData_SignError(t *testing.T) {
@@ -509,7 +548,8 @@ func TestGetRegistrationData_SignError(t *testing.T) {
 	}
 	hs := newHS(mock, "")
 
-	reg, err := hs.getRegistrationData()
+	req := httptest.NewRequest(http.MethodGet, "/registration", nil)
+	reg, err := hs.getRegistrationData(req)
 	require.Error(t, err)
 	require.NotNil(t, reg)
 	require.False(t, reg.Enabled)

--- a/pkg/server/registration.go
+++ b/pkg/server/registration.go
@@ -1,0 +1,250 @@
+package server
+
+import (
+	"encoding/hex"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+
+	sdkcrypto "github.com/TBD54566975/ssi-sdk/crypto"
+	didkey "github.com/TBD54566975/ssi-sdk/did/key"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
+)
+
+const (
+	registrationMessage = "Shinzo Network host registration"
+	registrationAppHost = "registration-staging.shinzo.network"
+)
+
+// DisplayRegistration represents the registration status and signed messages for display in the health endpoint.
+type DisplayRegistration struct {
+	Enabled             bool                `json:"enabled"`
+	Message             string              `json:"message"`
+	DID                 string              `json:"did,omitempty"`
+	ConnectionString    string              `json:"connection_string,omitempty"`
+	EndpointAddress     string              `json:"endpoint_address,omitempty"`
+	DefraPKRegistration DefraPKRegistration `json:"defra_pk_registration,omitzero"`
+	PeerIDRegistration  PeerIDRegistration  `json:"peer_id_registration,omitzero"`
+}
+
+// DefraPKRegistration represents the registration information for the host's DefraDB public key, including the signed message.
+type DefraPKRegistration struct {
+	PublicKey   string `json:"public_key,omitempty"`
+	SignedPKMsg string `json:"signed_pk_message,omitempty"`
+}
+
+// PeerIDRegistration represents the registration information for the host's P2P peer ID, including the signed message.
+type PeerIDRegistration struct {
+	PeerID        string `json:"peer_id,omitempty"`
+	SignedPeerMsg string `json:"signed_peer_message,omitempty"`
+}
+
+// getRegistrationData returns the signed registration data for the host.
+func (hs *HealthServer) getRegistrationData(r *http.Request) (*DisplayRegistration, error) {
+	if hs.host == nil {
+		return nil, ErrHostNotAvailable
+	}
+
+	defraReg, peerReg, signErr := hs.host.SignMessages(registrationMessage)
+	registration := &DisplayRegistration{
+		Enabled: signErr == nil,
+		Message: normalizeHex(hex.EncodeToString([]byte(registrationMessage))),
+	}
+	if signErr != nil {
+		return registration, signErr
+	}
+
+	registration.DefraPKRegistration = DefraPKRegistration{
+		PublicKey:   normalizeHex(defraReg.PublicKey),
+		SignedPKMsg: normalizeHex(defraReg.SignedPKMsg),
+	}
+	registration.PeerIDRegistration = PeerIDRegistration{
+		PeerID:        normalizeHex(peerReg.PeerID),
+		SignedPeerMsg: normalizeHex(peerReg.SignedPeerMsg),
+	}
+	if did, err := deriveDID(registration.DefraPKRegistration.PublicKey); err == nil {
+		registration.DID = did
+	} else {
+		logger.Sugar.Debugf("failed to derive registration DID: %v", err)
+	}
+	registration.EndpointAddress = deriveEndpointAddress(r)
+	if p2p, err := hs.host.GetPeerInfo(); err == nil {
+		registration.ConnectionString = deriveConnectionString(r, p2p)
+	}
+
+	return registration, nil
+}
+
+// registrationAppHandler redirects to the registration app with registration data as query params.
+func (hs *HealthServer) registrationAppHandler(w http.ResponseWriter, r *http.Request) {
+	registration, err := hs.getRegistrationData(r)
+	if err != nil || registration == nil || !registration.Enabled {
+		http.Error(w, "Registration data not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	http.Redirect(w, r, buildRegistrationAppURL(registration), http.StatusTemporaryRedirect)
+}
+
+func buildRegistrationAppURL(registration *DisplayRegistration) string {
+	redirectURL := url.URL{
+		Scheme: "https",
+		Host:   registrationAppHost,
+		Path:   "/host-registration",
+	}
+	query := redirectURL.Query()
+	query.Set("role", "host")
+	query.Set("signedMessage", registration.Message)
+	query.Set("defraPublicKey", registration.DefraPKRegistration.PublicKey)
+	query.Set("defraPublicKeySignedMessage", registration.DefraPKRegistration.SignedPKMsg)
+	query.Set("connectionString", registration.ConnectionString)
+	query.Set("endpointAddress", registration.EndpointAddress)
+	redirectURL.RawQuery = query.Encode()
+
+	return redirectURL.String()
+}
+
+// normalizeHex ensures a string is represented as a 0x-prefixed hex string.
+// If the string is empty, it is returned unchanged.
+func normalizeHex(s string) string {
+	if s == "" {
+		return s
+	}
+	if strings.HasPrefix(s, "0x") || strings.HasPrefix(s, "0X") {
+		return "0x" + s[2:]
+	}
+	return "0x" + s
+}
+
+func deriveDID(publicKeyHex string) (string, error) {
+	publicKeyBytes, err := hex.DecodeString(strings.TrimPrefix(normalizeHex(publicKeyHex), "0x"))
+	if err != nil {
+		return "", fmt.Errorf("decode public key: %w", err)
+	}
+	didDoc, err := didkey.CreateDIDKey(sdkcrypto.SECP256k1, publicKeyBytes)
+	if err != nil {
+		return "", fmt.Errorf("create did key: %w", err)
+	}
+	return didDoc.String(), nil
+}
+
+func deriveEndpointAddress(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+
+	proto := firstForwardedValue(r.Header.Get("X-Forwarded-Proto"))
+	if proto == "" {
+		if r.TLS != nil {
+			proto = "https"
+		} else {
+			proto = "http"
+		}
+	}
+
+	host := firstForwardedValue(r.Header.Get("X-Forwarded-Host"))
+	if host == "" {
+		host = r.Host
+	}
+	if host == "" && r.URL != nil {
+		host = r.URL.Host
+	}
+	if host == "" {
+		return ""
+	}
+
+	return (&url.URL{
+		Scheme: proto,
+		Host:   host,
+		Path:   "/api/v0/graphql",
+	}).String()
+}
+
+func deriveConnectionString(r *http.Request, p2p *P2PInfo) string {
+	if p2p == nil || p2p.Self == nil || p2p.Self.ID == "" {
+		return ""
+	}
+
+	port := p2pPort(p2p.Self.Addresses)
+	if ip := requestHostIP(r); ip != "" {
+		return fmt.Sprintf("/ip4/%s/tcp/%s/p2p/%s", ip, port, p2p.Self.ID)
+	}
+
+	if addr := firstUsableP2PAddress(p2p.Self.Addresses); addr != "" {
+		return fmt.Sprintf("%s/p2p/%s", addr, p2p.Self.ID)
+	}
+	if len(p2p.Self.Addresses) > 0 && p2p.Self.Addresses[0] != "" {
+		return fmt.Sprintf("%s/p2p/%s", p2p.Self.Addresses[0], p2p.Self.ID)
+	}
+	return ""
+}
+
+func firstForwardedValue(value string) string {
+	if value == "" {
+		return ""
+	}
+	return strings.TrimSpace(strings.Split(value, ",")[0])
+}
+
+func requestHostIP(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	hosts := []string{
+		firstForwardedValue(r.Header.Get("X-Forwarded-Host")),
+		r.Host,
+	}
+	for _, host := range hosts {
+		if ip := hostIP(host); ip != "" {
+			return ip
+		}
+	}
+	return ""
+}
+
+func hostIP(host string) string {
+	if splitHost, _, err := net.SplitHostPort(host); err == nil {
+		host = splitHost
+	}
+	host = strings.Trim(host, "[]")
+	ip := net.ParseIP(host)
+	if ip == nil || ip.To4() == nil {
+		return ""
+	}
+	return ip.String()
+}
+
+func p2pPort(addresses []string) string {
+	for _, addr := range addresses {
+		parts := strings.Split(addr, "/")
+		for i := 0; i < len(parts)-1; i++ {
+			if parts[i] == "tcp" && parts[i+1] != "" {
+				return parts[i+1]
+			}
+		}
+	}
+	return "9171"
+}
+
+func firstUsableP2PAddress(addresses []string) string {
+	for _, addr := range addresses {
+		if isUsableIP4Multiaddr(addr) {
+			return addr
+		}
+	}
+	return ""
+}
+
+func isUsableIP4Multiaddr(addr string) bool {
+	parts := strings.Split(addr, "/")
+	for i := 0; i < len(parts)-1; i++ {
+		if parts[i] != "ip4" {
+			continue
+		}
+		ip := net.ParseIP(parts[i+1])
+		return ip != nil && ip.To4() != nil && !ip.IsLoopback() && !ip.IsUnspecified()
+	}
+	return false
+}

--- a/pkg/server/registration.go
+++ b/pkg/server/registration.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	registrationMessage = "Shinzo Network host registration"
-	registrationAppHost = "registration-staging.shinzo.network"
+	registrationAppHost = "registration.shinzo.network"
 )
 
 // DisplayRegistration represents the registration status and signed messages for display in the health endpoint.


### PR DESCRIPTION
Closes #198 

Changes:
1. Updated `/registration` and `/registration-app` with newer date required by ShinzoHub for registration.
2. Updated `/status` HTML page with registration info (see screenshots)
3. Updated nginx configs to include registration endpoints

Status page (see "registration" card). If not registered, it shows a link to "register" and redirects to `/registration-app`

<img width="1512" height="835" alt="image" src="https://github.com/user-attachments/assets/2804bff8-2157-426c-950b-91104e83fc5b" />





