### PR TITLE
Fix/pruner

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -107,7 +107,7 @@ pruner:
   max_blocks: 2000         # Number of blocks to retain
   docs_per_block: 1000      # Average docs per block (~1000 on Ethereum mainnet). Pruning triggers at max_blocks * docs_per_block docs
   interval_seconds: 30      # How often to check and prune
-  prune_history: false      # Walk DAG chains to delete historical block versions (2-3x slower)
+  prune_history: true       # true: each prune also deletes the removed docs' block history (walks their DAG, slower per prune); false keeps it, so the blockstore only grows.
 logger:
   development: true
   level: "info"

--- a/host-prod-setup.sh
+++ b/host-prod-setup.sh
@@ -108,7 +108,7 @@ pruner:
   max_blocks: 2000         # Number of blocks to retain
   docs_per_block: 1000      # Average docs per block (~1000 on Ethereum mainnet). Pruning triggers at max_blocks * docs_per_block docs
   interval_seconds: 30      # How often to check and prune
-  prune_history: false      # Walk DAG chains to delete historical block versions (2-3x slower)
+  prune_history: true       # true: each prune also deletes the removed docs' block history (walks their DAG, slower per prune); false keeps it, so the blockstore only grows.
 logger:
   development: false
   level: "error"

--- a/pkg/host/attestationHandler.go
+++ b/pkg/host/attestationHandler.go
@@ -80,6 +80,7 @@ var (
 	transactionCollectionID string //nolint:gochecknoglobals
 	logCollectionID         string //nolint:gochecknoglobals
 	accessListCollectionID  string //nolint:gochecknoglobals
+	attRecCollectionID      string //nolint:gochecknoglobals
 )
 
 // collectionIDToName - mapping for ID to Name.
@@ -123,6 +124,9 @@ func (h *Host) initKnownCollectionIDs(ctx context.Context) error {
 		case constants.CollectionAccessListEntry:
 			accessListCollectionID = col.CollectionID()
 			collectionIDToName[accessListCollectionID] = constants.CollectionAccessListEntry
+		case constants.CollectionAttestationRecord:
+			attRecCollectionID = col.CollectionID()
+			collectionIDToName[attRecCollectionID] = constants.CollectionAttestationRecord
 		}
 	}
 
@@ -222,12 +226,8 @@ func (h *Host) startEventBusListener(ctx context.Context) {
 
 			if msg.Name == event.UpdateName {
 				update, ok := msg.Data.(event.Update)
-				if !ok || !update.IsRelay {
+				if !ok {
 					continue
-				}
-
-				if h.metrics != nil {
-					h.metrics.IncrementDocumentsReceived()
 				}
 
 				collectionName, known := collectionIDToName[update.CollectionID]
@@ -235,14 +235,25 @@ func (h *Host) startEventBusListener(ctx context.Context) {
 					continue
 				}
 
+				if h.pruneQueue != nil {
+					h.pruneQueue.Push(collectionName, update.DocID)
+				}
+
+				// Local writes skip the metric and verification: "documents received"
+				// only counts inbound peer traffic, and a BlockSignature only needs
+				// verification when a peer sent it.
+				if !update.IsRelay {
+					continue
+				}
+
+				if h.metrics != nil {
+					h.metrics.IncrementDocumentsReceived()
+				}
 				if collectionsWithMetrics[collectionName] && h.metrics != nil {
 					h.metrics.IncrementDocumentByType(collectionName)
 				}
 				if collectionName == constants.CollectionBlockSignature {
 					enqueueDoc(docEvent{docID: update.DocID, collectionName: collectionName})
-				}
-				if h.pruneQueue != nil {
-					h.pruneQueue.Push(collectionName, update.DocID)
 				}
 			}
 		}

--- a/pkg/host/constants.go
+++ b/pkg/host/constants.go
@@ -18,7 +18,7 @@ const (
 	// defaultMaxProcessingDepth is a const for max processing depth.
 	defaultMaxProcessingDepth = 5
 	// knownCollectionIDs is a const for known collection ids is a const for the number of known collection ids.
-	knownCollectionIDs = 5
+	knownCollectionIDs = 6
 	// maxAttestationRetries is a const for the number of max attestation retries.
 	maxAttestationRetries = 5
 	// attestationRetryDelayMs is a const for the attestation retry delay in ms.

--- a/pkg/pruner/config.go
+++ b/pkg/pruner/config.go
@@ -22,6 +22,8 @@ type CollectionConfig struct {
 }
 
 // DefaultCollectionConfig returns the default Ethereum mainnet collection config.
+// Adding to DependentCollections also requires an enum entry in
+// pkg/pruner/event_queue.go's knownCollections map; otherwise Push discards it.
 func DefaultCollectionConfig() CollectionConfig {
 	return CollectionConfig{
 		BlockCollection:  "Ethereum__Mainnet__Block",
@@ -31,6 +33,8 @@ func DefaultCollectionConfig() CollectionConfig {
 			"Ethereum__Mainnet__AccessListEntry",
 			"Ethereum__Mainnet__Log",
 			"Ethereum__Mainnet__Transaction",
+			"Ethereum__Mainnet__BlockSignature",
+			"Ethereum__Mainnet__AttestationRecord",
 		},
 	}
 }

--- a/pkg/pruner/event_queue.go
+++ b/pkg/pruner/event_queue.go
@@ -22,6 +22,8 @@ const (
 	colLog      byte = 2
 	colALE      byte = 3
 	colBatchSig byte = 4
+	colBlockSig byte = 5
+	colAttRec   byte = 6
 )
 
 // eventQueueSnapshot is the serializable form of the event queue.
@@ -60,10 +62,12 @@ func NewEventQueue(collections CollectionConfig) *EventQueue {
 
 	// Register dependent collections with known enums
 	knownCollections := map[string]byte{
-		"Ethereum__Mainnet__Transaction":     colTx,
-		"Ethereum__Mainnet__Log":             colLog,
-		"Ethereum__Mainnet__AccessListEntry": colALE,
-		"Ethereum__Mainnet__BatchSignature":  colBatchSig,
+		"Ethereum__Mainnet__Transaction":       colTx,
+		"Ethereum__Mainnet__Log":               colLog,
+		"Ethereum__Mainnet__AccessListEntry":   colALE,
+		"Ethereum__Mainnet__BatchSignature":    colBatchSig,
+		"Ethereum__Mainnet__BlockSignature":    colBlockSig,
+		"Ethereum__Mainnet__AttestationRecord": colAttRec,
 	}
 
 	for _, name := range collections.DependentCollections {


### PR DESCRIPTION
- Add BlockSignature and AttestationRecord to the prune scope so they stop accumulating.
- Default prune_history to true so pruning also deletes old block history, which otherwise grows without bound and fills the host disk.