### PR TITLE
refactor/attestations

### DIFF
--- a/pkg/attestation/blockAttestationService.go
+++ b/pkg/attestation/blockAttestationService.go
@@ -1,0 +1,152 @@
+package attestation
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/shinzonetwork/shinzo-host-client/pkg/constants"
+	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/node"
+)
+
+// SignFunc signs a canonical payload and returns a hex-encoded signature. The host
+// supplies one backed by its cached DefraDB identity so the write path can sign
+// without reopening the keyring on every attestation.
+type SignFunc func(payload string) (string, error)
+
+// BlockAttestationSigningPayload returns the canonical bytes the host signs for a
+// block attestation. A verifier (e.g. the accounting service) must reconstruct the
+// identical string to check hostSignature. Signer identities are sorted so the
+// payload does not depend on the order indexers were observed.
+func BlockAttestationSigningPayload(r *constants.BlockAttestation) string {
+	signers := append([]string(nil), r.SignerIdentities...)
+	sort.Strings(signers)
+	return fmt.Sprintf("%s|%d|%s|%s|%s",
+		r.HostID, r.BlockNumber, r.BlockHash, r.MerkleRoot, strings.Join(signers, ","))
+}
+
+// PostBlockAttestation writes or updates the host's attestation for a block. It is
+// a read-modify-write keyed by (hostId, blockNumber, merkleRoot): a second indexer attesting
+// the same block+root is unioned into the existing record's signer set; a different
+// merkleRoot for the same block lands on its own record (divergence). The host is the
+// sole writer of its records, so the list fields are safe under last-writer-wins.
+func PostBlockAttestation(ctx context.Context, defraNode *node.Node, record *constants.BlockAttestation, sign SignFunc) error {
+	col, err := defraNode.DB.GetCollectionByName(ctx, constants.CollectionBlockAttestation)
+	if err != nil {
+		return fmt.Errorf("failed to get block attestation collection: %w", err)
+	}
+
+	existing, err := lookupExistingBlockAttestation(ctx, defraNode, col, record.HostID, record.BlockNumber, record.MerkleRoot)
+	if err != nil {
+		return fmt.Errorf("failed to lookup existing block attestation: %w", err)
+	}
+
+	if existing != nil {
+		return updateBlockAttestation(ctx, col, existing, record, sign)
+	}
+	return createBlockAttestation(ctx, col, record, sign)
+}
+
+// createBlockAttestation writes a new record, setting voteCount to the distinct
+// signer count and hostSignature over the canonical payload.
+func createBlockAttestation(ctx context.Context, col client.Collection, record *constants.BlockAttestation, sign SignFunc) error {
+	record.VoteCount = len(record.SignerIdentities)
+	sig, err := sign(BlockAttestationSigningPayload(record))
+	if err != nil {
+		return fmt.Errorf("failed to sign block attestation: %w", err)
+	}
+	record.HostSignature = sig
+
+	data := map[string]any{
+		"hostId":           record.HostID,
+		"blockNumber":      record.BlockNumber,
+		"blockHash":        record.BlockHash,
+		"merkleRoot":       record.MerkleRoot,
+		"signerIdentities": toAnySlice(record.SignerIdentities),
+		"cids":             toAnySlice(record.CIDs),
+		"voteCount":        record.VoteCount,
+		"hostSignature":    record.HostSignature,
+		"shinzoHeight":     record.ShinzoHeight,
+		"createdAt":        record.CreatedAt,
+	}
+
+	doc, err := client.NewDocFromMap(ctx, data, col.Version())
+	if err != nil {
+		return fmt.Errorf("failed to create block attestation document: %w", err)
+	}
+	return col.Save(ctx, doc)
+}
+
+// updateBlockAttestation unions the new signer and CIDs into an existing record,
+// recomputes voteCount as the distinct signer count, and re-signs so hostSignature
+// always matches the identities currently stored. mergeStringListField and
+// extractDocIDFromResult are defined in attestationRecordService.go (same package).
+func updateBlockAttestation(ctx context.Context, col client.Collection, doc *client.Document, record *constants.BlockAttestation, sign SignFunc) error {
+	mergedSigners := mergeStringListField(doc, "signerIdentities", record.SignerIdentities)
+	if err := doc.Set(ctx, "signerIdentities", toAnySlice(mergedSigners)); err != nil {
+		return fmt.Errorf("failed to set signerIdentities: %w", err)
+	}
+
+	mergedCIDs := mergeStringListField(doc, "cids", record.CIDs)
+	if err := doc.Set(ctx, "cids", toAnySlice(mergedCIDs)); err != nil {
+		return fmt.Errorf("failed to set cids: %w", err)
+	}
+
+	if err := doc.Set(ctx, "voteCount", len(mergedSigners)); err != nil {
+		return fmt.Errorf("failed to set voteCount: %w", err)
+	}
+
+	resigned := &constants.BlockAttestation{
+		HostID:           record.HostID,
+		BlockNumber:      record.BlockNumber,
+		BlockHash:        record.BlockHash,
+		MerkleRoot:       record.MerkleRoot,
+		SignerIdentities: mergedSigners,
+	}
+	sig, err := sign(BlockAttestationSigningPayload(resigned))
+	if err != nil {
+		return fmt.Errorf("failed to sign block attestation: %w", err)
+	}
+	if err := doc.Set(ctx, "hostSignature", sig); err != nil {
+		return fmt.Errorf("failed to set hostSignature: %w", err)
+	}
+
+	return col.Save(ctx, doc)
+}
+
+// lookupExistingBlockAttestation finds this host's record for a given block and
+// merkleRoot. The filter is scoped by hostId so the read-modify-write only ever
+// matches this host's own record, even if another host's record is present
+// locally. Returns (nil, nil) when none exists.
+func lookupExistingBlockAttestation(ctx context.Context, defraNode *node.Node, col client.Collection, hostID string, blockNumber int64, merkleRoot string) (*client.Document, error) {
+	query := fmt.Sprintf(`query {
+		%s(filter: {hostId: {_eq: "%s"}, blockNumber: {_eq: %d}, merkleRoot: {_eq: "%s"}}) {
+			_docID
+		}
+	}`, constants.CollectionBlockAttestation, hostID, blockNumber, merkleRoot)
+
+	result := defraNode.DB.ExecRequest(ctx, query)
+
+	docIDStr := extractDocIDFromResult(result.GQL.Data, constants.CollectionBlockAttestation)
+	if docIDStr == "" {
+		return nil, nil //nolint:nilnil
+	}
+
+	docID, err := client.NewDocIDFromString(docIDStr)
+	if err != nil {
+		return nil, err
+	}
+
+	return col.Get(ctx, docID)
+}
+
+// toAnySlice converts a string slice to []any for a DefraDB document map.
+func toAnySlice(ss []string) []any {
+	out := make([]any, len(ss))
+	for i, s := range ss {
+		out[i] = s
+	}
+	return out
+}

--- a/pkg/attestation/blockAttestationService_test.go
+++ b/pkg/attestation/blockAttestationService_test.go
@@ -1,0 +1,185 @@
+package attestation
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/shinzonetwork/shinzo-host-client/pkg/constants"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/defradb"
+	localschema "github.com/shinzonetwork/shinzo-host-client/pkg/schema"
+	"github.com/sourcenetwork/defradb/node"
+	"github.com/stretchr/testify/require"
+)
+
+// Test fixtures, prefixed "ba-" to avoid colliding with literals in other attestation
+// test files (goconst counts string occurrences per package).
+const (
+	baHostID  = "ba-host"
+	baSignerA = "ba-signer-a"
+	baSignerB = "ba-signer-b"
+	baCID1    = "ba-cid-1"
+	baCID2    = "ba-cid-2"
+)
+
+// stubSign is a deterministic SignFunc for tests. Returning the payload prefixed
+// lets a test assert that hostSignature tracks the exact bytes that were signed.
+func stubSign(payload string) (string, error) { return "sig:" + payload, nil }
+
+// newBlockAttestationNode spins up an in-memory DefraDB with only the
+// BlockAttestation collection registered.
+func newBlockAttestationNode(t *testing.T) *node.Node {
+	t.Helper()
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(
+		t, defradb.DefaultConfig,
+		defradb.NewSchemaApplierFromProvidedSchema(localschema.BlockAttestationSchema),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = defraNode.Close(context.Background()) })
+	return defraNode
+}
+
+func queryBlockAttestations(ctx context.Context, defraNode *node.Node, blockNumber int64) ([]constants.BlockAttestation, error) {
+	query := fmt.Sprintf(`query {
+		%s(filter: {blockNumber: {_eq: %d}}) {
+			hostId
+			blockNumber
+			blockHash
+			merkleRoot
+			signerIdentities
+			cids
+			voteCount
+			hostSignature
+			shinzoHeight
+			createdAt
+		}
+	}`, constants.CollectionBlockAttestation, blockNumber)
+	return defradb.QueryArray[constants.BlockAttestation](ctx, defraNode, query)
+}
+
+// TestBlockAttestationSigningPayload_DeterministicAndSorted asserts the canonical
+// payload is independent of the order signer identities were observed, which is
+// what lets the accounting service reconstruct and verify hostSignature.
+func TestBlockAttestationSigningPayload_DeterministicAndSorted(t *testing.T) {
+	r1 := &constants.BlockAttestation{
+		HostID: baHostID, BlockNumber: 42, BlockHash: "ba-hash", MerkleRoot: "ba-root",
+		SignerIdentities: []string{baSignerB, baSignerA},
+	}
+	r2 := &constants.BlockAttestation{
+		HostID: baHostID, BlockNumber: 42, BlockHash: "ba-hash", MerkleRoot: "ba-root",
+		SignerIdentities: []string{baSignerA, baSignerB},
+	}
+	require.Equal(t, BlockAttestationSigningPayload(r1), BlockAttestationSigningPayload(r2))
+	require.Equal(t, baHostID+"|42|ba-hash|ba-root|"+baSignerA+","+baSignerB, BlockAttestationSigningPayload(r1))
+}
+
+// TestPostBlockAttestation_VoteCountIsDistinctSigners posts the same
+// (block, merkleRoot) for two distinct indexers, then re-posts one, and expects one
+// record with voteCount == 2 (distinct signers), not 3 (write count).
+func TestPostBlockAttestation_VoteCountIsDistinctSigners(t *testing.T) {
+	ctx := context.Background()
+	defraNode := newBlockAttestationNode(t)
+
+	record := func(signer string) *constants.BlockAttestation {
+		return &constants.BlockAttestation{
+			HostID: baHostID, BlockNumber: 500, BlockHash: "ba-hash-500", MerkleRoot: "ba-root-500",
+			SignerIdentities: []string{signer}, CIDs: []string{baCID1, baCID2},
+			ShinzoHeight: 123, CreatedAt: 1000,
+		}
+	}
+
+	require.NoError(t, PostBlockAttestation(ctx, defraNode, record(baSignerA), stubSign))
+	require.NoError(t, PostBlockAttestation(ctx, defraNode, record(baSignerB), stubSign))
+	require.NoError(t, PostBlockAttestation(ctx, defraNode, record(baSignerA), stubSign)) // duplicate write
+
+	recs, err := queryBlockAttestations(ctx, defraNode, 500)
+	require.NoError(t, err)
+	require.Len(t, recs, 1, "same (block, merkleRoot) must merge into one record")
+
+	rec := recs[0]
+	require.ElementsMatch(t, []string{baSignerA, baSignerB}, rec.SignerIdentities)
+	require.Equal(t, 2, rec.VoteCount, "voteCount must be distinct signers, not write count")
+	require.Equal(t, baHostID, rec.HostID)
+	require.Equal(t, "ba-hash-500", rec.BlockHash)
+	require.Equal(t, int64(123), rec.ShinzoHeight)
+
+	// hostSignature is re-signed over the merged, sorted signer set.
+	want, _ := stubSign(BlockAttestationSigningPayload(&constants.BlockAttestation{
+		HostID: baHostID, BlockNumber: 500, BlockHash: "ba-hash-500", MerkleRoot: "ba-root-500",
+		SignerIdentities: []string{baSignerA, baSignerB},
+	}))
+	require.Equal(t, want, rec.HostSignature)
+}
+
+// TestPostBlockAttestation_DivergentMerkleRoots_SeparateRecords verifies two
+// indexers reporting different merkle roots for the same block produce two
+// separate records.
+func TestPostBlockAttestation_DivergentMerkleRoots_SeparateRecords(t *testing.T) {
+	ctx := context.Background()
+	defraNode := newBlockAttestationNode(t)
+
+	recX := &constants.BlockAttestation{HostID: baHostID, BlockNumber: 600, BlockHash: "ba-hash-x", MerkleRoot: "ba-root-x", SignerIdentities: []string{baSignerA}, CIDs: []string{"ba-cid-x1"}}
+	recY := &constants.BlockAttestation{HostID: baHostID, BlockNumber: 600, BlockHash: "ba-hash-y", MerkleRoot: "ba-root-y", SignerIdentities: []string{baSignerB}, CIDs: []string{"ba-cid-y1"}}
+	require.NoError(t, PostBlockAttestation(ctx, defraNode, recX, stubSign))
+	require.NoError(t, PostBlockAttestation(ctx, defraNode, recY, stubSign))
+
+	recs, err := queryBlockAttestations(ctx, defraNode, 600)
+	require.NoError(t, err)
+	require.Len(t, recs, 2, "different merkleRoots for the same block must be separate records")
+}
+
+// TestPostBlockAttestation_PreservesFields confirms the indexer identity, CID list,
+// and signature are persisted, and voteCount starts at the single signer.
+func TestPostBlockAttestation_PreservesFields(t *testing.T) {
+	ctx := context.Background()
+	defraNode := newBlockAttestationNode(t)
+
+	rec := &constants.BlockAttestation{
+		HostID: baHostID, BlockNumber: 700, BlockHash: "ba-hash-700", MerkleRoot: "ba-root-700",
+		SignerIdentities: []string{baSignerA}, CIDs: []string{"ba-cid-p1", "ba-cid-p2", "ba-cid-p3"},
+		ShinzoHeight: 9, CreatedAt: 42,
+	}
+	require.NoError(t, PostBlockAttestation(ctx, defraNode, rec, stubSign))
+
+	recs, err := queryBlockAttestations(ctx, defraNode, 700)
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+	got := recs[0]
+	require.Equal(t, []string{baSignerA}, got.SignerIdentities)
+	require.Equal(t, []string{"ba-cid-p1", "ba-cid-p2", "ba-cid-p3"}, got.CIDs)
+	require.Equal(t, 1, got.VoteCount)
+	require.Equal(t, "ba-root-700", got.MerkleRoot)
+	require.NotEmpty(t, got.HostSignature)
+	require.Equal(t, int64(42), got.CreatedAt)
+}
+
+// TestPostBlockAttestation_DifferentHosts_SeparateRecords guards the host-scoped
+// lookup: two hosts writing the same (blockNumber, merkleRoot) must keep separate
+// records, so one host's write never merges into or re-signs another's. Without the
+// hostId filter the second write would update the first host's record instead.
+func TestPostBlockAttestation_DifferentHosts_SeparateRecords(t *testing.T) {
+	ctx := context.Background()
+	defraNode := newBlockAttestationNode(t)
+
+	recA := &constants.BlockAttestation{
+		HostID: "ba-host-a", BlockNumber: 800, BlockHash: "ba-hash-800", MerkleRoot: "ba-root-800",
+		SignerIdentities: []string{baSignerA}, CIDs: []string{baCID1},
+	}
+	recB := &constants.BlockAttestation{
+		HostID: "ba-host-b", BlockNumber: 800, BlockHash: "ba-hash-800", MerkleRoot: "ba-root-800",
+		SignerIdentities: []string{baSignerB}, CIDs: []string{baCID1},
+	}
+	require.NoError(t, PostBlockAttestation(ctx, defraNode, recA, stubSign))
+	require.NoError(t, PostBlockAttestation(ctx, defraNode, recB, stubSign))
+
+	recs, err := queryBlockAttestations(ctx, defraNode, 800)
+	require.NoError(t, err)
+	require.Len(t, recs, 2, "same (block, merkleRoot) from different hosts must not merge")
+
+	byHost := map[string][]string{}
+	for _, r := range recs {
+		byHost[r.HostID] = r.SignerIdentities
+	}
+	require.Equal(t, []string{baSignerA}, byHost["ba-host-a"], "host A record must keep only its own signer")
+	require.Equal(t, []string{baSignerB}, byHost["ba-host-b"], "host B record must keep only its own signer")
+}

--- a/pkg/constants/blockAttestation.go
+++ b/pkg/constants/blockAttestation.go
@@ -1,0 +1,39 @@
+package constants
+
+// BlockAttestation is one host's record that a set of indexers attested to a block,
+// identified by (hostId, blockNumber, merkleRoot). The host is the sole writer of its
+// own records, so the list fields are safe under DefraDB's last-writer-wins merge. It
+// is host-owned: written locally from BlockSignatures and excluded from host-to-host
+// P2P sync (absent from AllCollections, the P2P subscription set). Separate from
+// AttestationRecord, which serves the per-document and snapshot paths.
+type BlockAttestation struct {
+	// HostID is the producing host's cached signing identity, and the first component
+	// of the (hostId, blockNumber, merkleRoot) record identity.
+	HostID string `json:"hostId"`
+	// BlockNumber is the height of the attested block.
+	BlockNumber int64 `json:"blockNumber"`
+	// BlockHash is the hash of the attested block.
+	BlockHash string `json:"blockHash"`
+	// MerkleRoot is the indexer-signed merkle root over the block's CIDs. A different
+	// root for the same block is a divergent attestation and lands on its own record.
+	MerkleRoot string `json:"merkleRoot"`
+	// SignerIdentities are the signing identities of the indexers whose BlockSignatures
+	// the host merged for this (block, merkleRoot), deduped on each write.
+	SignerIdentities []string `json:"signerIdentities"`
+	// CIDs are the block's document CIDs carried by the merged BlockSignatures.
+	CIDs []string `json:"cids"`
+	// VoteCount is the distinct-signer count, set to len(SignerIdentities) on every
+	// write (not incremented), so it counts indexers rather than writes.
+	VoteCount int `json:"voteCount"`
+	// HostSignature is the host's secp256k1 signature over the canonical payload
+	// returned by attestation.BlockAttestationSigningPayload. It authenticates the
+	// host's claim about which indexers it saw and is recomputed whenever
+	// SignerIdentities changes.
+	HostSignature string `json:"hostSignature"`
+	// ShinzoHeight is the ShinzoHub block height observed when the record was written,
+	// used by the accounting service to bin attestations into epochs. Zero means the
+	// height was unavailable at write time (no hub configured, or not yet polled).
+	ShinzoHeight int64 `json:"shinzoHeight"`
+	// CreatedAt is the unix time of the record's first write, preserved across later merges.
+	CreatedAt int64 `json:"createdAt"`
+}

--- a/pkg/constants/collections.go
+++ b/pkg/constants/collections.go
@@ -7,13 +7,15 @@ const (
 	CollectionLog               = "Ethereum__Mainnet__Log"
 	CollectionAccessListEntry   = "Ethereum__Mainnet__AccessListEntry"
 	CollectionAttestationRecord = "Ethereum__Mainnet__AttestationRecord"
+	CollectionBlockAttestation  = "Ethereum__Mainnet__BlockAttestation"
 	CollectionBlockSignature    = "Ethereum__Mainnet__BlockSignature"
 	CollectionSnapshotSignature = "Ethereum__Mainnet__SnapshotSignature"
 	CollectionChain             = "Ethereum__Mainnet"
 )
 
 // Collection name slice for bulk operations (used for P2P replication subscriptions).
-// AttestationRecord is excluded — each host builds its own attestation state independently.
+// AttestationRecord and BlockAttestation are excluded from host-to-host sync: each
+// host builds its own attestation state independently.
 
 // AllCollections is a list of DefraDB collection names.
 var AllCollections = []string{ //nolint:gochecknoglobals

--- a/pkg/host/attestationHandler.go
+++ b/pkg/host/attestationHandler.go
@@ -439,38 +439,42 @@ func (h *Host) processBlockSignatureDocument(ctx context.Context, doc *client.Do
 	}
 }
 
-// processAttestationsFromBlockSignature creates or updates an attestation record for a block.
+// processAttestationsFromBlockSignature builds a BlockAttestation from a verified
+// BlockSignature and writes it to the host-owned Ethereum__Mainnet__BlockAttestation
+// collection. PostBlockAttestation handles the merge by (hostId, blockNumber, merkleRoot).
 func (h *Host) processAttestationsFromBlockSignature(ctx context.Context, blockSig *attestationService.BlockSignature) {
 	if h.DefraNode == nil {
 		return
 	}
 
 	blockNumber := blockSig.BlockNumber
-	blockAttestedID := fmt.Sprintf("block:%d:%s", blockNumber, blockSig.MerkleRoot)
 
 	if len(blockSig.CIDs) == 0 {
 		logger.Sugar.Warnf("Skipping attestation for block %d: block signature has no CID list", blockNumber)
 		return
 	}
 
-	record := &constants.AttestationRecord{
-		AttestedDocID: blockAttestedID,
-		SourceDocIDs:  []string{blockSig.SignatureIdentity},
-		CIDs:          blockSig.CIDs,
-		DocType:       docTypeBlock,
-		VoteCount:     1,
+	record := &constants.BlockAttestation{
+		HostID:           h.hostID,
+		BlockNumber:      blockNumber,
+		BlockHash:        blockSig.BlockHash,
+		MerkleRoot:       blockSig.MerkleRoot,
+		SignerIdentities: []string{blockSig.SignatureIdentity},
+		CIDs:             blockSig.CIDs,
+		ShinzoHeight:     h.heightPoller.Latest(),
+		CreatedAt:        time.Now().Unix(),
 	}
 
 	var lastErr error
 	for attempt := range maxAttestationRetries {
-		if err := attestationService.PostAttestationRecord(ctx, h.DefraNode, record); err != nil {
+		if err := attestationService.PostBlockAttestation(ctx, h.DefraNode, record, h.signBlockAttestation); err != nil {
 			lastErr = err
 			if strings.Contains(err.Error(), "transaction conflict") || strings.Contains(err.Error(), "Please retry") {
 				time.Sleep(time.Duration(attestationBackoffBase*(1<<attempt)) * time.Millisecond)
 				continue
 			}
 			// Non-retryable error
-			logger.Sugar.Warnf("Failed to post attestation for block %d: %v", blockNumber, err)
+			logger.Sugar.Warnf("Failed to post block attestation for block %d: %v", blockNumber, err)
 			if h.metrics != nil {
 				h.metrics.IncrementAttestationErrors()
 			}
@@ -478,13 +482,13 @@ func (h *Host) processAttestationsFromBlockSignature(ctx context.Context, blockS
 		}
 		// Success
 		if _, existed := attestedBlocks.LoadOrStore(blockNumber, true); existed {
-			logger.Sugar.Infof("Updated attestation for block %d (indexer: %s)", blockNumber, truncateString(blockSig.SignatureIdentity, identityTruncateLength))
+			logger.Sugar.Infof("Updated block attestation for block %d (indexer: %s)", blockNumber, truncateString(blockSig.SignatureIdentity, identityTruncateLength))
 		} else {
 			if h.metrics != nil {
 				h.metrics.IncrementAttestationsCreated()
 				h.metrics.IncrementDocumentByType(constants.CollectionBlock)
 			}
-			logger.Sugar.Infof("Created attestation for block %d (indexer: %s)", blockNumber, truncateString(blockSig.SignatureIdentity, identityTruncateLength))
+			logger.Sugar.Infof("Created block attestation for block %d (indexer: %s)", blockNumber, truncateString(blockSig.SignatureIdentity, identityTruncateLength))
 		}
 		if h.metrics != nil {
 			h.metrics.UpdateMostRecentBlock(uint64(blockNumber)) //nolint:gosec // block numbers are always positive
@@ -492,7 +496,7 @@ func (h *Host) processAttestationsFromBlockSignature(ctx context.Context, blockS
 		return
 	}
 
-	logger.Sugar.Warnf("Failed to post attestation for block %d after retries: %v", blockNumber, lastErr)
+	logger.Sugar.Warnf("Failed to post block attestation for block %d after retries: %v", blockNumber, lastErr)
 	if h.metrics != nil {
 		h.metrics.IncrementAttestationErrors()
 	}

--- a/pkg/host/attestationHandler_test.go
+++ b/pkg/host/attestationHandler_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/shinzonetwork/shinzo-host-client/pkg/logger"
 	localschema "github.com/shinzonetwork/shinzo-host-client/pkg/schema"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/server"
+	"github.com/shinzonetwork/shinzo-host-client/pkg/signer"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/crypto"
 	"github.com/sourcenetwork/defradb/node"
@@ -493,30 +494,53 @@ func TestEnqueueDoc_Concurrent(t *testing.T) {
 // processAttestationsFromBlockSignature - retryable error path
 // ---------------------------------------------------------------------------
 
-func TestProcessAttestationsFromBlockSignature_EmptyBlockAttestedID(t *testing.T) {
-	// This test verifies the blockAttestedID format
+func TestProcessAttestationsFromBlockSignature_RecordShape(t *testing.T) {
+	// Drives the real handler with a BlockSignature, then reads the stored record back
+	// to check the field mapping: typed block fields (not a packed string), the signer
+	// recorded, cids and the host's own id persisted, and voteCount at one signer.
+	ctx := context.Background()
+
+	defraNode, err := defradb.StartDefraInstanceWithTestConfig(t, defradb.DefaultConfig, defradb.NewSchemaApplierFromProvidedSchema(localschema.GetSchema()))
+	require.NoError(t, err)
+	defer func() { _ = defraNode.Close(ctx) }()
+
+	h := newBlockAttestationHost(t, defraNode)
+
+	attestedBlocks.Delete(int64(42))
+	defer attestedBlocks.Delete(int64(42))
+
 	blockSig := &attestationService.BlockSignature{
 		BlockNumber:       42,
+		BlockHash:         "0xhash42",
 		MerkleRoot:        "abc123",
 		SignatureIdentity: testSignerAddr,
 		CIDs:              []string{testCID1, testCID2},
 	}
+	h.processAttestationsFromBlockSignature(ctx, blockSig)
 
-	blockAttestedID := fmt.Sprintf("block:%d:%s", blockSig.BlockNumber, blockSig.MerkleRoot)
-	require.Equal(t, "block:42:abc123", blockAttestedID)
+	query := fmt.Sprintf(`query {
+		%s(filter: {blockNumber: {_eq: 42}}) {
+			hostId
+			blockNumber
+			blockHash
+			merkleRoot
+			signerIdentities
+			cids
+			voteCount
+		}
+	}`, constants.CollectionBlockAttestation)
+	recs, err := defradb.QueryArray[constants.BlockAttestation](ctx, defraNode, query)
+	require.NoError(t, err)
+	require.Len(t, recs, 1, "handler should write exactly one record")
 
-	record := &constants.AttestationRecord{
-		AttestedDocID: blockAttestedID,
-		SourceDocIDs:  []string{blockSig.SignatureIdentity},
-		CIDs:          blockSig.CIDs,
-		DocType:       docTypeBlock,
-		VoteCount:     1,
-	}
-	require.Equal(t, "block:42:abc123", record.AttestedDocID)
-	require.Equal(t, []string{testSignerAddr}, record.SourceDocIDs)
-	require.Equal(t, []string{testCID1, testCID2}, record.CIDs)
-	require.Equal(t, docTypeBlock, record.DocType)
-	require.Equal(t, 1, record.VoteCount)
+	got := recs[0]
+	require.Equal(t, h.hostID, got.HostID, "handler must stamp the host's own id")
+	require.Equal(t, int64(42), got.BlockNumber)
+	require.Equal(t, "0xhash42", got.BlockHash)
+	require.Equal(t, "abc123", got.MerkleRoot)
+	require.Equal(t, []string{testSignerAddr}, got.SignerIdentities)
+	require.Equal(t, []string{testCID1, testCID2}, got.CIDs)
+	require.Equal(t, 1, got.VoteCount)
 }
 
 // ---------------------------------------------------------------------------
@@ -934,12 +958,8 @@ func TestProcessAttestationsFromBlockSignature_WithRealDefraDB(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = defraNode.Close(ctx) }()
 
-	metrics := server.NewHostMetrics()
-
-	h := &Host{
-		DefraNode: defraNode,
-		metrics:   metrics,
-	}
+	h := newBlockAttestationHost(t, defraNode)
+	metrics := h.metrics
 
 	// Clean up global attestedBlocks state for this block number
 	attestedBlocks.Delete(int64(200))
@@ -951,17 +971,29 @@ func TestProcessAttestationsFromBlockSignature_WithRealDefraDB(t *testing.T) {
 		CIDs:              []string{"cid-a", "cid-b", "cid-c"},
 	}
 
-	// First call should create the attestation
+	// First call creates the attestation.
+	h.processAttestationsFromBlockSignature(ctx, blockSig)
+	require.Equal(t, int64(1), atomic.LoadInt64(&metrics.AttestationsCreated),
+		"first call must create exactly one attestation")
+	require.Equal(t, int64(0), atomic.LoadInt64(&metrics.AttestationErrors),
+		"first call must not error")
+
+	// Re-posting the same signer for the same block must not duplicate the record
+	// or inflate the distinct-signer count.
 	h.processAttestationsFromBlockSignature(ctx, blockSig)
 
-	// Verify metrics were updated
-	require.True(t, metrics.AttestationsCreated > 0 || metrics.AttestationErrors > 0,
-		"either attestations created or errors should be incremented")
+	query := fmt.Sprintf(`query {
+		%s(filter: {blockNumber: {_eq: 200}}) {
+			signerIdentities
+			voteCount
+		}
+	}`, constants.CollectionBlockAttestation)
+	recs, err := defradb.QueryArray[constants.BlockAttestation](ctx, defraNode, query)
+	require.NoError(t, err)
+	require.Len(t, recs, 1, "re-posting the same signer must stay one record")
+	require.Equal(t, []string{blockSig.SignatureIdentity}, recs[0].SignerIdentities)
+	require.Equal(t, 1, recs[0].VoteCount, "re-posting the same signer must not inflate voteCount")
 
-	// Second call with same block should hit the "existed" path in attestedBlocks
-	h.processAttestationsFromBlockSignature(ctx, blockSig)
-
-	// Clean up
 	attestedBlocks.Delete(int64(200))
 }
 
@@ -1247,6 +1279,29 @@ func TestProcessBlockSignatureFromEventBus_WithRealDefraDB_FullPath(t *testing.T
 // processAttestationsFromBlockSignature - multiple calls to exercise "existed" metrics path
 // ---------------------------------------------------------------------------
 
+// newBlockAttestationHost builds a Host wired for block-attestation writes against
+// a test DefraDB: it registers the BlockAttestation collection and loads the node's
+// identity (saved to the test keyring by StartDefraInstanceWithTestConfig) so the
+// host can sign records, matching the production startup wiring.
+func newBlockAttestationHost(t *testing.T, defraNode *node.Node) *Host {
+	t.Helper()
+	ctx := context.Background()
+
+	_, err := defraNode.DB.AddSchema(ctx, localschema.BlockAttestationSchema)
+	require.NoError(t, err)
+
+	id, err := signer.LoadIdentity(defraNode, defradb.DefaultConfig)
+	require.NoError(t, err)
+	require.NotNil(t, id.PublicKey())
+
+	return &Host{
+		DefraNode:       defraNode,
+		metrics:         server.NewHostMetrics(),
+		signingIdentity: id,
+		hostID:          id.PublicKey().String(),
+	}
+}
+
 func TestProcessAttestationsFromBlockSignature_ExistedPath(t *testing.T) {
 	ctx := context.Background()
 
@@ -1254,11 +1309,8 @@ func TestProcessAttestationsFromBlockSignature_ExistedPath(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = defraNode.Close(ctx) }()
 
-	metrics := server.NewHostMetrics()
-	h := &Host{
-		DefraNode: defraNode,
-		metrics:   metrics,
-	}
+	h := newBlockAttestationHost(t, defraNode)
+	metrics := h.metrics
 
 	// Clean up global attestedBlocks state
 	attestedBlocks.Delete(int64(300))
@@ -1271,14 +1323,13 @@ func TestProcessAttestationsFromBlockSignature_ExistedPath(t *testing.T) {
 		CIDs:              []string{testCIDName1, testCIDName2},
 	}
 
-	// First call creates attestation
-	h.processAttestationsFromBlockSignature(ctx, blockSig)
-	_ = atomic.LoadInt64(&metrics.AttestationsCreated)
-
-	// Second call hits the "existed" path — should update rather than create
+	// First call creates the block attestation
 	h.processAttestationsFromBlockSignature(ctx, blockSig)
 
-	// MostRecentBlock should have been updated
+	// Second call hits the "existed" path, updating rather than creating
+	h.processAttestationsFromBlockSignature(ctx, blockSig)
+
+	// MostRecentBlock should have been updated (which only happens on a successful write)
 	require.GreaterOrEqual(t, atomic.LoadUint64(&metrics.MostRecentBlock), uint64(300))
 }
 
@@ -1293,11 +1344,7 @@ func TestProcessAttestationsFromBlockSignature_MultipleIndexers_PreservesBothIde
 	require.NoError(t, err)
 	defer func() { _ = defraNode.Close(ctx) }()
 
-	metrics := server.NewHostMetrics()
-	h := &Host{
-		DefraNode: defraNode,
-		metrics:   metrics,
-	}
+	h := newBlockAttestationHost(t, defraNode)
 
 	// Clean up global attestedBlocks state
 	attestedBlocks.Delete(int64(400))
@@ -1321,15 +1368,22 @@ func TestProcessAttestationsFromBlockSignature_MultipleIndexers_PreservesBothIde
 	}
 	h.processAttestationsFromBlockSignature(ctx, blockSigB)
 
-	// Query the attestation record
-	records, err := attestationService.CheckExistingAttestation(ctx, defraNode, "block:400:aaa", docTypeBlock)
+	// Query the block attestation for this (block, merkleRoot).
+	query := fmt.Sprintf(`query {
+		%s(filter: {blockNumber: {_eq: 400}, merkleRoot: {_eq: "aaa"}}) {
+			signerIdentities
+			voteCount
+		}
+	}`, constants.CollectionBlockAttestation)
+	records, err := defradb.QueryArray[constants.BlockAttestation](ctx, defraNode, query)
 	require.NoError(t, err)
-	require.Len(t, records, 1, "Should have exactly one attestation record for this block")
+	require.Len(t, records, 1, "Should have exactly one block attestation for this (block, merkleRoot)")
 
 	record := records[0]
-	require.Contains(t, record.SourceDocIDs, "indexer-A", "Should contain first indexer's identity")
-	require.Contains(t, record.SourceDocIDs, "indexer-B", "Should contain second indexer's identity")
-	require.Len(t, record.SourceDocIDs, 2, "Should have exactly 2 indexer identities")
+	require.Contains(t, record.SignerIdentities, "indexer-A", "Should contain first indexer's identity")
+	require.Contains(t, record.SignerIdentities, "indexer-B", "Should contain second indexer's identity")
+	require.Len(t, record.SignerIdentities, 2, "Should have exactly 2 distinct indexer identities")
+	require.Equal(t, 2, record.VoteCount, "voteCount must be the distinct signer count")
 }
 
 func TestDebugSchema(t *testing.T) {

--- a/pkg/host/constants.go
+++ b/pkg/host/constants.go
@@ -31,6 +31,10 @@ const (
 	nanosecondsPerMillisecond = 1_000_000.0
 	// defaultTimeout is a const for the default timeout in s.
 	defaultTimeout = 5 * time.Second
+	// shinzoHeightPollInterval is how often the host refreshes the cached ShinzoHub
+	// height stamped onto block attestations. Epoch binning is coarse, so a few
+	// seconds of staleness is acceptable and avoids a chain call per attestation.
+	shinzoHeightPollInterval = 10 * time.Second
 )
 
 // Short document-type aliases. The provenance + processing pipelines

--- a/pkg/host/host.go
+++ b/pkg/host/host.go
@@ -30,6 +30,7 @@ import (
 	"github.com/shinzonetwork/shinzo-host-client/pkg/signer"
 	"github.com/shinzonetwork/shinzo-host-client/pkg/view"
 	"github.com/sourcenetwork/corelog"
+	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
 	defradbHttp "github.com/sourcenetwork/defradb/http"
@@ -100,6 +101,15 @@ type Host struct {
 	signatureVerifier      *attestation.DefraSignatureVerifier // Cached signature verifier for attestation processing
 	blockSignatureVerifier *attestation.BlockSignatureVerifier // Block signature verifier for block-signed documents
 	blockCIDCollector      *attestation.BlockCIDCollector      // Collects CIDs per block for batch verification
+
+	// Cached host identity for block attestations, loaded once at startup to avoid
+	// reopening the keyring per attestation. hostID is the host's secp256k1 defra
+	// public key hex (matches BlockSignature.signatureIdentity keyspace);
+	// signingIdentity produces the record's hostSignature.
+	hostID          string
+	signingIdentity identity.FullIdentity
+	// heightPoller tracks the latest ShinzoHub height stamped onto block attestations.
+	heightPoller *shinzohub.HeightPoller
 
 	webhookCleanupFunction func()
 	LensRegistryPath       string
@@ -292,6 +302,11 @@ func StartHostingWithEventSubscription(cfg *config.Config) (*Host, error) { //no
 		rpcClient = shinzohub.NewRPCClient(lcdURL, defraNode)
 	}
 
+	// Poll the ShinzoHub chain tip so block attestations can record the height they
+	// were written at (for accounting-service epoch binning). An empty rpcURL yields
+	// height 0 rather than a failure.
+	newHost.heightPoller = shinzohub.NewHeightPoller(rpcURL)
+
 	// Fetch views from ShinzoHub if RPC URL is configured
 	var hubViews []view.View
 	logger.Sugar.Infof("ShinzoHub base URL: %s", rpcURL)
@@ -384,6 +399,7 @@ func StartHostingWithEventSubscription(cfg *config.Config) (*Host, error) { //no
 	processingCtx, processingCancel := context.WithCancel(context.Background())
 	newHost.processingCancel = processingCancel
 	go newHost.processAttestationEventsWithSubscription(processingCtx)
+	go newHost.heightPoller.Start(processingCtx, shinzoHeightPollInterval)
 
 	// Block monitoring is now handled by the event-driven processAllViews goroutine
 	// No separate monitoring goroutine needed
@@ -401,6 +417,18 @@ func StartHostingWithEventSubscription(cfg *config.Config) (*Host, error) { //no
 		newHost.blockSignatureVerifier = attestation.NewBlockSignatureVerifier(blockSignatureCacheSize)
 		newHost.blockCIDCollector = attestation.NewBlockCIDCollector()
 		logger.Sugar.Info("🔐 Optimized signature verifier initialized (with block signature support)")
+
+		// Cache the host identity once so signing each block attestation does not
+		// reopen the keyring. hostID is the host's secp256k1 defra public key hex.
+		if id, idErr := signer.LoadIdentity(defraNode, cfg.ToInternalConfig()); idErr == nil {
+			newHost.signingIdentity = id
+			if pk := id.PublicKey(); pk != nil {
+				newHost.hostID = pk.String()
+			}
+			logger.Sugar.Infof("🪪 Host attestation identity cached (hostId=%s)", truncateString(newHost.hostID, identityTruncateLength))
+		} else {
+			logger.Sugar.Warnf("Failed to cache host identity for block attestations: %v", idErr)
+		}
 	}
 
 	port := cfg.HostConfig.HealthServerPort
@@ -927,17 +955,32 @@ func applySchema(ctx context.Context, defraNode *node.Node) error {
 	fmt.Println("Applying schema...")
 
 	_, err := defraNode.DB.AddSchema(ctx, localschema.GetSchema())
-	if err != nil && strings.Contains(err.Error(), "collection already exists") {
+	if err != nil {
+		if !strings.Contains(err.Error(), "collection already exists") {
+			return err
+		}
 		fmt.Println("Schema already exists, trying to add new types individually...")
 		// Try adding Config__LastProcessedPage separately in case it's new
 		configSchema := `type Config__LastProcessedPage { page: Int, pageSize: Int }`
-		_, configErr := defraNode.DB.AddSchema(ctx, configSchema)
-		if configErr != nil && !strings.Contains(configErr.Error(), "collection already exists") {
+		if _, configErr := defraNode.DB.AddSchema(ctx, configSchema); configErr != nil && !strings.Contains(configErr.Error(), "collection already exists") {
 			fmt.Printf("Note: Could not add Config__LastProcessedPage: %v\n", configErr)
 		}
-		return nil
 	}
-	return err
+
+	// BlockAttestation is host-owned and not in the shared schema, so register it on
+	// its own. This runs whether the bulk AddSchema above created the shared schema
+	// (fresh datastore) or no-oped (existing one). Re-adding an existing collection
+	// returns "collection already exists", which is ignored.
+	if _, baErr := defraNode.DB.AddSchema(ctx, localschema.BlockAttestationSchema); baErr != nil && !strings.Contains(baErr.Error(), "collection already exists") {
+		return fmt.Errorf("failed to register BlockAttestation collection: %w", baErr)
+	}
+	return nil
+}
+
+// signBlockAttestation signs a block-attestation payload with the host's cached
+// DefraDB identity. It is passed as the SignFunc to attestation.PostBlockAttestation.
+func (h *Host) signBlockAttestation(payload string) (string, error) {
+	return signer.SignWithIdentity(h.signingIdentity, payload)
 }
 
 // RegisterViewWithManager registers a view and manages its lifecycle.

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -13,3 +13,20 @@ var SchemaGraphQL string
 func GetSchema() string {
 	return SchemaGraphQL
 }
+
+// BlockAttestationSchema is the SDL for the host-owned BlockAttestation collection.
+// It is registered separately from the shared schema (see host.applySchema), not in
+// schema.graphql. One record per (hostId, blockNumber, merkleRoot); the host is the
+// sole writer, so the list fields are safe under DefraDB's last-writer-wins.
+const BlockAttestationSchema = `type Ethereum__Mainnet__BlockAttestation {
+    hostId: String @index
+    blockNumber: Int @index
+    blockHash: String @index
+    merkleRoot: String @index
+    signerIdentities: [String]
+    cids: [String]
+    voteCount: Int
+    hostSignature: String
+    shinzoHeight: Int @index
+    createdAt: Int @index
+}`

--- a/pkg/shinzohub/errors.go
+++ b/pkg/shinzohub/errors.go
@@ -11,5 +11,6 @@ var (
 	ErrEventNoContract               = errors.New("event has no contract_address")
 	ErrLCDEmptyData                  = errors.New("LCD response carries empty data")
 	ErrLCDHTTPStatus                 = errors.New("LCD returned non-OK HTTP status")
+	ErrEmptyHeight                   = errors.New("status response carries empty height")
 	errDecodeBundleInvalidWireFormat = errors.New("decode bundle: invalid wire format")
 )

--- a/pkg/shinzohub/height.go
+++ b/pkg/shinzohub/height.go
@@ -1,0 +1,127 @@
+package shinzohub
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"sync/atomic"
+	"time"
+)
+
+// heightPollTimeout bounds a single /status call so a slow hub RPC pod cannot
+// stall the poller goroutine.
+const heightPollTimeout = 10 * time.Second
+
+// cometStatus is the subset of the CometBFT /status RPC response carrying the
+// chain tip height.
+type cometStatus struct {
+	Result struct {
+		SyncInfo struct {
+			LatestBlockHeight string `json:"latest_block_height"`
+		} `json:"sync_info"`
+	} `json:"result"`
+}
+
+// HeightPoller tracks the latest ShinzoHub block height by polling the hub's
+// CometBFT /status endpoint. The cached height is stamped onto attestation
+// records as shinzoHeight so the accounting service can bin them into epochs.
+// A cached value of 0 means the height is not yet known.
+type HeightPoller struct {
+	rpcURL     string
+	httpClient *http.Client
+	latest     atomic.Int64
+}
+
+// NewHeightPoller builds a poller against a CometBFT RPC base URL (for example
+// "http://host:26657"). An empty rpcURL yields a poller that always reports 0,
+// so a host with no hub configured degrades to shinzoHeight=0 rather than failing.
+func NewHeightPoller(rpcURL string) *HeightPoller {
+	return &HeightPoller{
+		rpcURL:     rpcURL,
+		httpClient: &http.Client{Timeout: heightPollTimeout},
+	}
+}
+
+// Latest returns the most recently observed ShinzoHub height, or 0 if none has
+// been observed yet (including a nil poller).
+func (p *HeightPoller) Latest() int64 {
+	if p == nil {
+		return 0
+	}
+	return p.latest.Load()
+}
+
+// Start fetches the height once, then refreshes it on the given interval until
+// ctx is cancelled. It is a no-op when rpcURL is empty. Refresh failures keep
+// the last good value rather than resetting it to 0.
+func (p *HeightPoller) Start(ctx context.Context, interval time.Duration) {
+	if p == nil || p.rpcURL == "" {
+		return
+	}
+
+	if h, err := p.fetch(ctx); err == nil {
+		p.latest.Store(h)
+	} else {
+		log().Warnf("ShinzoHub height: initial fetch failed: %v", err)
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if h, err := p.fetch(ctx); err == nil {
+				p.latest.Store(h)
+			} else {
+				log().Debugf("ShinzoHub height: refresh failed: %v", err)
+			}
+		}
+	}
+}
+
+// fetch reads the chain tip height from the CometBFT /status endpoint.
+func (p *HeightPoller) fetch(ctx context.Context) (int64, error) {
+	endpoint := p.rpcURL + "/status"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return 0, fmt.Errorf("build status request: %w", err)
+	}
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("status GET %s: %w", endpoint, err)
+	}
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil {
+			log().Warnf("close status response body: %v", cerr)
+		}
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, fmt.Errorf("read status response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("%w: %s returned HTTP %d", ErrHTTPErrorResponse, endpoint, resp.StatusCode)
+	}
+
+	var status cometStatus
+	if err := json.Unmarshal(body, &status); err != nil {
+		return 0, fmt.Errorf("decode status response: %w", err)
+	}
+
+	heightStr := status.Result.SyncInfo.LatestBlockHeight
+	if heightStr == "" {
+		return 0, ErrEmptyHeight
+	}
+	height, err := strconv.ParseInt(heightStr, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse height %q: %w", heightStr, err)
+	}
+	return height, nil
+}

--- a/pkg/signer/signer.go
+++ b/pkg/signer/signer.go
@@ -134,6 +134,44 @@ func SignWithDefraKeys(message string, defraNode *node.Node, cfg *defradb.Config
 	return hex.EncodeToString(signature), nil
 }
 
+// LoadIdentity loads the host's DefraDB identity (secp256k1) once so callers can
+// cache it and sign on a hot path without re-opening the keyring per call. It
+// uses the same keyring-then-file load path as SignWithDefraKeys.
+func LoadIdentity(defraNode *node.Node, cfg *defradb.Config) (identity.FullIdentity, error) {
+	storePath, err := getStorePath(defraNode, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get store path: %w", err)
+	}
+
+	fullIdentity, err := loadIdentityFromStoreFn(cfg, storePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load identity: %w", err)
+	}
+
+	return fullIdentity, nil
+}
+
+// SignWithIdentity signs a message with an already-loaded identity and returns a
+// hex-encoded signature. Pair it with LoadIdentity to sign repeatedly without
+// reloading the key (the standalone SignWithDefraKeys reloads on every call).
+func SignWithIdentity(id identity.FullIdentity, message string) (string, error) {
+	if id == nil {
+		return "", ErrNoPrivateKey
+	}
+
+	privateKey := id.PrivateKey()
+	if privateKey == nil {
+		return "", ErrNoPrivateKey
+	}
+
+	signature, err := privateKey.Sign([]byte(message))
+	if err != nil {
+		return "", fmt.Errorf("failed to sign message: %w", err)
+	}
+
+	return hex.EncodeToString(signature), nil
+}
+
 // SignWithP2PKeys signs a message using the LibP2P private key (Ed25519) derived from the DefraDB identity.
 // The signature is returned as a hex-encoded string.
 // If cfg is provided and has a KeyringSecret, it will use the keyring; otherwise falls back to file-based storage.


### PR DESCRIPTION
### Summary
Adds a host-owned `BlockAttestation` collection. The host writes one record per `(hostId, blockNumber, merkleRoot)` from the `BlockSignature`s it verifies. Resolves #221.

### Per-host identity
The host is the only writer of its own records, so `signerIdentities` and `cids` are safe under DefraDB last-writer-wins.

### Separate collection from AttestationRecord
  - Indexers produce only `BlockSignature`; the host is the sole writer of attestation records.
  - `AttestationRecord` still backs the per-document and snapshot paths.


### Replication
Excluded from `AllCollections` (the P2P subscription set); not replicated between hosts.

  ### Schema
  | Field | Type | Note |
  |---|---|---|
  | hostId | String @index | identity |
  | blockNumber | Int @index | |
  | blockHash | String @index | |
  | merkleRoot | String @index | different root for a block = separate record |
  | signerIdentities | [String] | deduped |
  | cids | [String] | |
  | voteCount | Int | distinct signers |
  | hostSignature | String | secp256k1 over canonical payload |
  | shinzoHeight | Int @index | hub height at write, for epoch binning |
  | createdAt | Int @index | unix, first write |

### Out of scope
  - Host to accounting-service push (replicator).
  - No change to `AttestationRecord`, per-document mode, or snapshots.

### Tests
Integration tests on in-memory DefraDB: distinct-signer `voteCount`, divergent `merkleRoot`s as separate records, host-scoped lookup.