### PR TITLE
fix: gate P2PNoPeers reconnect on zero active peers

### DIFF
--- a/pkg/defradb/network_handler.go
+++ b/pkg/defradb/network_handler.go
@@ -247,7 +247,8 @@ func (nh *NetworkHandler) startReconnectionLoop() {
 	nh.startNoPeersEventListener()
 }
 
-// startNoPeersEventListener subscribes to P2PNoPeers events and triggers immediate reconnection.
+// startNoPeersEventListener subscribes to P2PNoPeers events and forces an
+// immediate reconnect when the node has lost all of its active peers.
 func (nh *NetworkHandler) startNoPeersEventListener() {
 	if nh.node == nil || nh.node.DB == nil {
 		return
@@ -269,7 +270,12 @@ func (nh *NetworkHandler) startNoPeersEventListener() {
 					return
 				}
 				if _, ok := msg.Data.(event.P2PNoPeers); ok {
-					nh.forceReconnectAll()
+					// P2PNoPeers fires whenever a publish finds no subscribers on its
+					// topic, which is normal for freshly created documents. Only force a
+					// reconnect on a genuine mesh loss, when no active peers remain.
+					if peers, err := nh.node.DB.ActivePeers(nh.ctx); err == nil && len(peers) == 0 {
+						nh.forceReconnectAll()
+					}
 				}
 			}
 		}


### PR DESCRIPTION
The host logged a peer reconnect on every replicated document. defra v1 emits `P2PNoPeers` per publish when a topic has no subscribers, which is the normal case for a freshly created doc, and the listener reacted to each one by force-reconnecting every peer even though the transport was already connected.

This gates the force-reconnect on `ActivePeers() == 0`, so it only fires on genuine total peer loss. Immediate reconnect on real mesh loss is unchanged; normal replication no longer triggers it.