### PR TITLE
chore: resolve golangci-lint findings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,9 +58,17 @@ linters:
         linters:
           - containedctx
           - dupl
-          - gochecknoglobals
-          - mnd
+          - err113
           - funlen
+          - gochecknoglobals
+          - goconst
+          - gosec
+          - mnd
+      # Pool.sol's embedded creation bytecode and ABI args are package-level
+      # vars: a byte slice cannot be a const.
+      - path: pool/bytecode\.go
+        linters:
+          - gochecknoglobals
 
 formatters:
   enable:

--- a/pkg/accounting/client.go
+++ b/pkg/accounting/client.go
@@ -6,12 +6,21 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
 	"time"
 )
+
+// maxErrorBodyBytes caps how much of a non-success response body is read into
+// the returned error.
+const maxErrorBodyBytes = 512
+
+// errAccountingStatus is wrapped when the accounting service answers a service
+// record with a non-success HTTP status.
+var errAccountingStatus = errors.New("accounting service returned non-success status")
 
 // ServiceRecord is the JSON body the host POSTs to the accounting service. Hash,
 // address, and signature fields are 0x-prefixed hex; timestamps are unix seconds.
@@ -69,9 +78,9 @@ func (c *Client) Submit(ctx context.Context, record ServiceRecord) error {
 		_ = resp.Body.Close()
 	}()
 
-	if resp.StatusCode/100 != 2 {
-		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
-		return fmt.Errorf("accounting service returned %d: %s", resp.StatusCode, strings.TrimSpace(string(msg)))
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
+		return fmt.Errorf("%w: %d: %s", errAccountingStatus, resp.StatusCode, strings.TrimSpace(string(msg)))
 	}
 	return nil
 }

--- a/pkg/accounting/recorder.go
+++ b/pkg/accounting/recorder.go
@@ -65,7 +65,7 @@ func (r *Recorder) Record(ctx context.Context, in RecordInput) error {
 	if err != nil {
 		return fmt.Errorf("derive pool id: %w", err)
 	}
-	respondedAt := uint64(r.now().Unix())
+	respondedAt := uint64(r.now().Unix()) //nolint:gosec // Unix seconds for the current time is always within uint64 range
 	cids := []string{}
 
 	signature, err := billing.SignQueryResponse(r.chainID, r.signer, billing.QueryResponse{

--- a/pkg/acp/balance_test.go
+++ b/pkg/acp/balance_test.go
@@ -47,8 +47,8 @@ func (g *gateBalanceReader) GetQueryBalance(context.Context, string) (*big.Int, 
 	return g.balance, nil
 }
 
-func authorizer(hub QueryBalanceReader, epochs EpochSource, min int64) *BalanceAuthorizer {
-	return NewBalanceAuthorizer(hub, epochs, big.NewInt(min), "shinzo")
+func authorizer(hub QueryBalanceReader, epochs EpochSource, minBalance int64) *BalanceAuthorizer {
+	return NewBalanceAuthorizer(hub, epochs, big.NewInt(minBalance), "shinzo")
 }
 
 // TestBalanceAuthorizerAllowsFundedAndEncodesAddress checks a funded payer is

--- a/pkg/acp/capture.go
+++ b/pkg/acp/capture.go
@@ -12,6 +12,7 @@ import (
 // passed through unbuffered.
 type captureWriter struct {
 	http.ResponseWriter
+
 	status    int
 	streaming bool
 	body      bytes.Buffer

--- a/pkg/acp/config.go
+++ b/pkg/acp/config.go
@@ -14,6 +14,9 @@ import (
 // errors.Is; the formatted error names the offending env var for debugging.
 var ErrConfigIncomplete = errors.New("acp middleware enabled without required config")
 
+// decimalBase is the radix for parsing the query-balance integer strings.
+const decimalBase = 10
+
 // Environment variable names the middleware reads at startup.
 const (
 	EnvEnabled         = "ACP_MIDDLEWARE_ENABLED"
@@ -88,7 +91,7 @@ func (c Config) Validate() error {
 	if c.EpochLength == 0 {
 		return fmt.Errorf("%w: %s is required", ErrConfigIncomplete, EnvEpochLength)
 	}
-	if _, ok := new(big.Int).SetString(c.MinQueryBalance, 10); !ok {
+	if _, ok := new(big.Int).SetString(c.MinQueryBalance, decimalBase); !ok {
 		return fmt.Errorf("%w: %s must be a base-10 integer, got %q", ErrConfigIncomplete, EnvMinQueryBalance, c.MinQueryBalance)
 	}
 	return nil
@@ -97,7 +100,7 @@ func (c Config) Validate() error {
 // MinBalance returns MinQueryBalance as a big.Int. It assumes Validate has
 // already accepted the value.
 func (c Config) MinBalance() *big.Int {
-	n, _ := new(big.Int).SetString(c.MinQueryBalance, 10)
+	n, _ := new(big.Int).SetString(c.MinQueryBalance, decimalBase)
 	return n
 }
 
@@ -110,7 +113,7 @@ func parseUintEnv(name string) (uint64, error) {
 	}
 	v, err := strconv.ParseUint(raw, 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf("%w: %s is not a valid unsigned integer: %v", ErrConfigIncomplete, name, err)
+		return 0, fmt.Errorf("%w: %s is not a valid unsigned integer: %w", ErrConfigIncomplete, name, err)
 	}
 	return v, nil
 }
@@ -124,7 +127,7 @@ func parseDurationEnv(name string) (time.Duration, error) {
 	}
 	d, err := time.ParseDuration(raw)
 	if err != nil {
-		return 0, fmt.Errorf("%w: %s is not a valid duration: %v", ErrConfigIncomplete, name, err)
+		return 0, fmt.Errorf("%w: %s is not a valid duration: %w", ErrConfigIncomplete, name, err)
 	}
 	return d, nil
 }

--- a/pkg/acp/middleware.go
+++ b/pkg/acp/middleware.go
@@ -122,7 +122,7 @@ type viewLookup struct {
 	Address string
 }
 
-func (m *Middleware) handleGraphQL(w http.ResponseWriter, r *http.Request, next http.Handler) {
+func (m *Middleware) handleGraphQL(w http.ResponseWriter, r *http.Request, next http.Handler) { //nolint:funlen // linear guard-clause pipeline; splitting obscures the request flow
 	req, err := parseGraphQLRequest(r)
 	if err != nil {
 		m.log.Warnw("billing.parse_failed", "err", err, "path", r.URL.Path)
@@ -201,7 +201,7 @@ func (m *Middleware) handleGraphQL(w http.ResponseWriter, r *http.Request, next 
 	// Bill only a 2xx response: a well-formed body can accompany a non-2xx
 	// status, and the client treats that as a failure.
 	if served && cw.status/100 == 2 {
-		m.submitRecord(payer, ext, lookups[0], rows)
+		m.submitRecord(payer, ext, lookups[0], rows) //nolint:contextcheck // record runs on a background context by design so a client disconnect does not cancel billing submission
 	}
 }
 
@@ -287,19 +287,24 @@ func (m *Middleware) collectViewLookups(w http.ResponseWriter, collections []str
 	return lookups, true
 }
 
+var (
+	errNoExtensions       = errors.New("no extensions")
+	errNoRequestSignature = errors.New("no request signature")
+)
+
 // parseExtensions decodes the signed billing envelope from a request's
 // extensions. An absent envelope, or one without a signature, is an error: a
 // billed query must carry a request signature.
 func parseExtensions(raw json.RawMessage) (billing.Extensions, error) {
 	if len(raw) == 0 {
-		return billing.Extensions{}, errors.New("no extensions")
+		return billing.Extensions{}, errNoExtensions
 	}
 	var ext billing.Extensions
 	if err := json.Unmarshal(raw, &ext); err != nil {
 		return billing.Extensions{}, fmt.Errorf("parse extensions: %w", err)
 	}
 	if ext.RequestSignature == "" {
-		return billing.Extensions{}, errors.New("no request signature")
+		return billing.Extensions{}, errNoRequestSignature
 	}
 	return ext, nil
 }

--- a/pkg/host/errors.go
+++ b/pkg/host/errors.go
@@ -13,4 +13,6 @@ var ( //nolint:revive
 	ErrNoPeerIDMismatchInfo = errors.New("error does not contain peer ID mismatch info") //nolint:revive
 	ErrMissingFilterFields  = errors.New("document missing required filter fields")      //nolint:revive
 	ErrEmptyMerkleRoot      = errors.New("empty merkleRoot")
+
+	errHubBaseURLMissing = errors.New("billing middleware enabled but the Shinzo hub base URL is not configured")
 )

--- a/pkg/host/host.go
+++ b/pkg/host/host.go
@@ -734,7 +734,7 @@ func (h *Host) Close(ctx context.Context) error {
 // non-nil whenever an accounting service URL is set.
 func buildRecording(acpCfg acp.Config, internalCfg *defradb.Config, defraNode *node.Node, attesters *observedAttesters) (*acp.Recording, error) {
 	if acpCfg.ASBaseURL == "" {
-		return nil, nil
+		return nil, nil //nolint:nilnil // (nil recording, nil error) signals billing is disabled, a valid state
 	}
 	nodeKey, err := signer.NodeECDSAKey(defraNode, internalCfg)
 	if err != nil {
@@ -764,7 +764,7 @@ func startACPServer(
 	attesters *observedAttesters,
 ) (*defradbHttp.Server, *acp.Middleware, error) {
 	if hubBaseURL == "" {
-		return nil, nil, errors.New("billing middleware enabled but the Shinzo hub base URL is not configured")
+		return nil, nil, errHubBaseURLMissing
 	}
 	// The host reads the hub over its Cosmos LCD (REST) port. HubBaseURL points
 	// at the CometBFT RPC port; the LCD is the same host on :1317.

--- a/pkg/pool/pool.go
+++ b/pkg/pool/pool.go
@@ -23,7 +23,7 @@ const deployer = "0x0000000000000000000000000000000000000213"
 // PoolID returns the CREATE2 address ShinzoHub deploys the pool for
 // (viewAddr, windowSize) at. It errors if the constructor args cannot be packed,
 // so an ABI mismatch surfaces instead of producing a wrong id.
-func PoolID(viewAddr common.Address, windowSize uint64) (common.Address, error) {
+func PoolID(viewAddr common.Address, windowSize uint64) (common.Address, error) { //nolint:revive // PoolID reads clearly at call sites; renaming to ID churns the public API
 	salt := poolSalt(viewAddr, windowSize)
 	initCode, err := buildInitCode(viewAddr)
 	if err != nil {

--- a/pkg/shinzohub/balance.go
+++ b/pkg/shinzohub/balance.go
@@ -9,6 +9,9 @@ import (
 	"net/http"
 )
 
+// decimalBase is the radix for parsing the hub's integer balance strings.
+const decimalBase = 10
+
 // GetQueryBalance returns the spendable query balance for a bech32 address from
 // the hub's x/querybalance module. A never-funded address reports "0", so a zero
 // balance is a normal result, not an error.
@@ -50,9 +53,9 @@ func (c *RPCClient) GetQueryBalance(ctx context.Context, bech32Address string) (
 	if wrap.Amount == "" {
 		return big.NewInt(0), nil
 	}
-	amount, ok := new(big.Int).SetString(wrap.Amount, 10)
+	amount, ok := new(big.Int).SetString(wrap.Amount, decimalBase)
 	if !ok {
-		return nil, fmt.Errorf("invalid balance amount %q", wrap.Amount)
+		return nil, fmt.Errorf("%w: %q", errInvalidBalanceAmount, wrap.Amount)
 	}
 	return amount, nil
 }

--- a/pkg/shinzohub/errors.go
+++ b/pkg/shinzohub/errors.go
@@ -12,4 +12,5 @@ var (
 	ErrLCDEmptyData                  = errors.New("LCD response carries empty data")
 	ErrLCDHTTPStatus                 = errors.New("LCD returned non-OK HTTP status")
 	errDecodeBundleInvalidWireFormat = errors.New("decode bundle: invalid wire format")
+	errInvalidBalanceAmount          = errors.New("invalid balance amount")
 )


### PR DESCRIPTION
Resolves the 33 golangci-lint findings keeping Go Lint CI red on develop, which blocks pr #309