### PR TITLE
ci: raise golangci-lint timeout to 10m

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 version: "2"
 run:
-  timeout: 5m
+  timeout: 10m
   modules-download-mode: readonly
 linters:
   default: standard


### PR DESCRIPTION
Keeps golangci-lint green after the defradb bump.