### PR TITLE
fix: re-queue drained docs when a purge fails

### DIFF
--- a/pkg/pruner/event_queue.go
+++ b/pkg/pruner/event_queue.go
@@ -205,6 +205,34 @@ func (q *EventQueue) DrainBlocks(count int) *DrainResult {
 	return result
 }
 
+// Requeue re-inserts entries at the front of the queue. A purge that fails drained its docs
+// without deleting them; they are the oldest entries, so they go back to the front to be
+// pruned again on the next cycle.
+func (q *EventQueue) Requeue(collectionName string, docIDs []string) {
+	colType, ok := q.collectionEnums[collectionName]
+	if !ok {
+		return
+	}
+
+	entries := make([]eventEntry, 0, len(docIDs))
+	blocks := 0
+	for _, docID := range docIDs {
+		uuid, err := extractUUID(docID)
+		if err != nil {
+			continue
+		}
+		entries = append(entries, eventEntry{Collection: colType, UUID: uuid})
+		if colType == colBlock {
+			blocks++
+		}
+	}
+
+	q.mu.Lock()
+	q.entries = append(entries, q.entries...)
+	q.blockCount += blocks
+	q.mu.Unlock()
+}
+
 // Len returns the total number of entries in the queue.
 func (q *EventQueue) Len() int {
 	q.mu.Lock()

--- a/pkg/pruner/event_queue_test.go
+++ b/pkg/pruner/event_queue_test.go
@@ -1,0 +1,52 @@
+package pruner
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testBlockCollection = "Ethereum__Mainnet__Block"
+	testLogCollection   = "Ethereum__Mainnet__Log"
+)
+
+func testDocID(n int) string {
+	return fmt.Sprintf("bae-%08x-0000-0000-0000-000000000000", n)
+}
+
+// TestEventQueueRequeue verifies that re-queued docs return to the front of the queue so the
+// next drain retries them, and that the block count is restored only when a block is re-queued.
+func TestEventQueueRequeue(t *testing.T) {
+	q := NewEventQueue(CollectionConfig{
+		BlockCollection:      testBlockCollection,
+		DependentCollections: []string{testLogCollection},
+	})
+
+	q.Push(testBlockCollection, testDocID(1))
+	q.Push(testLogCollection, testDocID(2))
+	q.Push(testLogCollection, testDocID(3))
+	q.Push(testLogCollection, testDocID(4)) // ingested later; must stay behind the re-queued docs
+
+	drained := q.DrainDocs(3)
+	require.NotNil(t, drained)
+	require.Equal(t, 1, drained.BlockCount)
+	require.Equal(t, 0, q.BlockCount())
+
+	logIDs := drained.DocIDsByCollection[testLogCollection]
+	blockIDs := drained.DocIDsByCollection[testBlockCollection]
+	require.Len(t, logIDs, 2)
+	require.Len(t, blockIDs, 1)
+
+	// A failed dependent purge re-queues its docs at the front, so the next drain returns them
+	// before the later doc, and the block count is unchanged.
+	q.Requeue(testLogCollection, logIDs)
+	require.Equal(t, 3, q.Len())
+	require.Equal(t, 0, q.BlockCount())
+	require.Equal(t, logIDs, q.DrainDocs(2).DocIDsByCollection[testLogCollection])
+
+	// A failed block purge restores the block count.
+	q.Requeue(testBlockCollection, blockIDs)
+	require.Equal(t, 1, q.BlockCount())
+}

--- a/pkg/pruner/pruner.go
+++ b/pkg/pruner/pruner.go
@@ -206,12 +206,13 @@ func (p *Pruner) runEventQueuePrune(ctx context.Context, q *EventQueue) error {
 	logger.Sugar.Infof("Pruning %d docs (%d blocks) — queue had %d docs, keeping %d (max_blocks=%d × docs_per_block=%d)",
 		excess, result.BlockCount, totalDocs, maxDocs, p.cfg.MaxBlocks, p.cfg.DocsPerBlock)
 
-	return p.purgeFromDrainResult(ctx, result)
+	return p.purgeFromDrainResult(ctx, q, result)
 }
 
-// purgeFromDrainResult deletes documents from a DrainResult.
-// Deletes dependent collections first, then the block collection last.
-func (p *Pruner) purgeFromDrainResult(ctx context.Context, result *DrainResult) error {
+// purgeFromDrainResult deletes documents from a DrainResult, dependent collections first and
+// the block collection last. A collection whose purge fails is re-queued rather than dropped,
+// so its docs are retried on the next cycle instead of leaking from the store.
+func (p *Pruner) purgeFromDrainResult(ctx context.Context, q *EventQueue, result *DrainResult) error {
 	startTime := time.Now()
 	totalPurged := int64(0)
 
@@ -223,7 +224,8 @@ func (p *Pruner) purgeFromDrainResult(ctx context.Context, result *DrainResult) 
 		}
 		purged, err := p.purgeByDocIDs(ctx, colName, docIDs)
 		if err != nil {
-			logger.Sugar.Errorf("Failed to purge %s: %v", colName, err)
+			logger.Sugar.Warnf("Failed to purge %s, re-queuing %d docs: %v", colName, len(docIDs), err)
+			q.Requeue(colName, docIDs)
 		} else {
 			totalPurged += purged
 		}
@@ -232,7 +234,8 @@ func (p *Pruner) purgeFromDrainResult(ctx context.Context, result *DrainResult) 
 	if blockIDs, ok := result.DocIDsByCollection[p.collections.BlockCollection]; ok && len(blockIDs) > 0 {
 		purged, err := p.purgeByDocIDs(ctx, p.collections.BlockCollection, blockIDs)
 		if err != nil {
-			logger.Sugar.Errorf("Failed to purge blocks: %v", err)
+			logger.Sugar.Warnf("Failed to purge blocks, re-queuing %d docs: %v", len(blockIDs), err)
+			q.Requeue(p.collections.BlockCollection, blockIDs)
 		} else {
 			totalPurged += purged
 		}


### PR DESCRIPTION
Re-queue the docs a purge drained when the purge fails, so they retry next cycle instead of being dropped. `DrainDocs` removes docs from the queue before the purge runs, so a failed purge silently leaked them: blocks never deleted, never retried. Adds `EventQueue.Requeue` (front-insert) called from `purgeFromDrainResult` on failure, plus a test.