### PR TITLE
Menna/prune history false

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -106,7 +106,7 @@ pruner:
   max_blocks: 2000         # Number of blocks to retain
   docs_per_block: 1000      # Average docs per block (~1000 on Ethereum mainnet). Pruning triggers at max_blocks * docs_per_block docs
   interval_seconds: 30      # How often to check and prune
-  prune_history: true       # true: each prune also deletes the removed docs' block history (walks their DAG, slower per prune); false keeps it, so the blockstore only grows.
+  prune_history: false      # true: each prune also deletes the removed docs' block history (walks their DAG, slower per prune); false keeps it, so the blockstore only grows.
 schema:
   indexer_schema_endpoint: /api/v1/schema
   http_client_timeout_secs: 30

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -7,8 +7,7 @@ services:
   nginx:
     image: nginx:alpine
     ports:
-      - "443:443"  # HTTPS
-      - "80:80"    # HTTP (redirects to HTTPS)
+      - "8080:8080"  # health/registration surface the dashboard probes
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
       - ~/ssl/nginx.crt:/etc/nginx/ssl/nginx.crt:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     image: nginx:alpine
     platform: linux/amd64
     ports:
-      - "80:8080"
+      - "8080:8080"
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
     depends_on:

--- a/host-prod-setup.sh
+++ b/host-prod-setup.sh
@@ -107,7 +107,7 @@ pruner:
   max_blocks: 2000         # Number of blocks to retain
   docs_per_block: 1000      # Average docs per block (~1000 on Ethereum mainnet). Pruning triggers at max_blocks * docs_per_block docs
   interval_seconds: 30      # How often to check and prune
-  prune_history: true       # true: each prune also deletes the removed docs' block history (walks their DAG, slower per prune); false keeps it, so the blockstore only grows.
+  prune_history: false      # true: each prune also deletes the removed docs' block history (walks their DAG, slower per prune); false keeps it, so the blockstore only grows.
 logger:
   development: false
   level: "error"

--- a/host-prod-setup.sh
+++ b/host-prod-setup.sh
@@ -147,7 +147,7 @@ services:
     volumes:
       - ~/data/defradb:/app/.defra
       - ~/data/keys:/app/.defra/keys
-      - ~/data/lens:/app/.defra/lens`
+      - ~/data/lens:/app/.defra/lens
       - ~/config.yaml:/app/config.yaml:ro
     environment:
       - DEFRA_URL=0.0.0.0:9181
@@ -166,7 +166,8 @@ services:
   nginx:
     image: nginx:alpine
     ports:
-      - "80:8080"  
+      - "8080:8080"  # health/registration surface the dashboard probes
+      - "80:80"
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
       - ~/ssl/nginx.crt:/etc/nginx/ssl/nginx.crt:ro
@@ -192,6 +193,7 @@ http {
   server {
     listen 80;
     listen 443 ssl;
+    listen 8080;
     server_name api.shinzo.network;
 
     ssl_certificate     /etc/nginx/ssl/nginx.crt;


### PR DESCRIPTION
- Sets `prune_history` to `false` by default (in `config/config.yaml` and `host-prod-setup.sh`) so the host keeps up with the chain tip instead of falling behind. 
- Publishes nginx on host port 8080 (`docker-compose.yml`, `docker-compose-prod.yml`, `host-prod-setup.sh`) so hosts show Online on the registration dashboard, which checks port 8080.