### PR TITLE
fix(startup): add progress logging and SKIP_SCHEMA_FETCH flag for silent startup

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -91,6 +91,11 @@ type SchemaConfig struct {
 	// the host will start with an empty token, causing schema fetches to
 	// receive 401/503 and fall back to the embedded schema (fail-closed).
 	AuthToken string `yaml:"-"`
+	// SkipFetch bypasses the remote schema fetch entirely and uses the
+	// embedded schema instead. Set this to avoid the up-to-HTTPClientTimeoutSecs
+	// startup stall when the indexer schema endpoint is slow or unreachable.
+	// Overridable at runtime via the SKIP_SCHEMA_FETCH environment variable.
+	SkipFetch bool `yaml:"skip_fetch"`
 }
 
 // ShinzoConfig represents configuration specific to the Shinzo host application.
@@ -227,6 +232,14 @@ func LoadConfig(path string) (*Config, error) {
 	if v := os.Getenv("INDEXER_SCHEMA_ENDPOINT_AUTH_TOKEN"); v != "" {
 		cfg.Schema.AuthToken = v
 	}
+	if v := os.Getenv("SKIP_SCHEMA_FETCH"); v != "" {
+		skip, err := strconv.ParseBool(v)
+		if err != nil {
+			return nil, fmt.Errorf("invalid SKIP_SCHEMA_FETCH value %q: %w", v, err)
+		}
+		cfg.Schema.SkipFetch = skip
+	}
+
 	if cfg.Schema.IndexerSchemaEndpoint == "" {
 		cfg.Schema.IndexerSchemaEndpoint = DefaultIndexerSchemaEndpoint
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -94,7 +94,7 @@ type SchemaConfig struct {
 	// SkipFetch bypasses the remote schema fetch entirely and uses the
 	// embedded schema instead. Set this to avoid the up-to-HTTPClientTimeoutSecs
 	// startup stall when the indexer schema endpoint is slow or unreachable.
-	// Overridable at runtime via the SKIP_SCHEMA_FETCH environment variable.
+	// Overridable at runtime via the INDEXER_SCHEMA_SKIP_FETCH environment variable.
 	SkipFetch bool `yaml:"skip_fetch"`
 }
 
@@ -232,10 +232,10 @@ func LoadConfig(path string) (*Config, error) {
 	if v := os.Getenv("INDEXER_SCHEMA_ENDPOINT_AUTH_TOKEN"); v != "" {
 		cfg.Schema.AuthToken = v
 	}
-	if v := os.Getenv("SKIP_SCHEMA_FETCH"); v != "" {
+	if v := os.Getenv("INDEXER_SCHEMA_SKIP_FETCH"); v != "" {
 		skip, err := strconv.ParseBool(v)
 		if err != nil {
-			return nil, fmt.Errorf("invalid SKIP_SCHEMA_FETCH value %q: %w", v, err)
+			return nil, fmt.Errorf("invalid INDEXER_SCHEMA_SKIP_FETCH value %q: %w", v, err)
 		}
 		cfg.Schema.SkipFetch = skip
 	}

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -111,6 +111,11 @@ pruner:
 schema:
   indexer_schema_endpoint: /api/v1/schema
   http_client_timeout_secs: 30
+  # Skip the remote schema fetch entirely and use the embedded schema.
+  # Useful when the indexer schema endpoint is slow or unreachable — avoids
+  # the up-to-http_client_timeout_secs startup stall. Defaults to false.
+  # Can also be set at runtime with the SKIP_SCHEMA_FETCH env var.
+  skip_fetch: false
   # ⚠ auth_token is NOT configurable in this file (the field uses yaml:"-").
   # You MUST set the token via the INDEXER_SCHEMA_ENDPOINT_AUTH_TOKEN environment variable.
   # Example: INDEXER_SCHEMA_ENDPOINT_AUTH_TOKEN=my-secret-token

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -114,7 +114,7 @@ schema:
   # Skip the remote schema fetch entirely and use the embedded schema.
   # Useful when the indexer schema endpoint is slow or unreachable — avoids
   # the up-to-http_client_timeout_secs startup stall. Defaults to false.
-  # Can also be set at runtime with the SKIP_SCHEMA_FETCH env var.
+  # Can also be set at runtime with the INDEXER_SCHEMA_SKIP_FETCH env var.
   skip_fetch: false
   # ⚠ auth_token is NOT configurable in this file (the field uses yaml:"-").
   # You MUST set the token via the INDEXER_SCHEMA_ENDPOINT_AUTH_TOKEN environment variable.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -387,3 +387,32 @@ func TestLoadConfig_SchemaAuthToken(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadConfig_SkipSchemaFetchEnvOverride(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.yaml")
+
+	// Default in YAML is false; env should flip it on.
+	err := os.WriteFile(configPath, []byte("schema:\n  skip_fetch: false\n"), 0o600)
+	require.NoError(t, err)
+
+	t.Setenv("SKIP_SCHEMA_FETCH", "true")
+
+	cfg, err := LoadConfig(configPath)
+	require.NoError(t, err)
+	require.True(t, cfg.Schema.SkipFetch)
+}
+
+func TestLoadConfig_InvalidSkipSchemaFetchEnv(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.yaml")
+
+	err := os.WriteFile(configPath, []byte("schema:\n  skip_fetch: false\n"), 0o600)
+	require.NoError(t, err)
+
+	t.Setenv("SKIP_SCHEMA_FETCH", "not_a_bool")
+
+	_, err = LoadConfig(configPath)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid SKIP_SCHEMA_FETCH")
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -396,7 +396,7 @@ func TestLoadConfig_SkipSchemaFetchEnvOverride(t *testing.T) {
 	err := os.WriteFile(configPath, []byte("schema:\n  skip_fetch: false\n"), 0o600)
 	require.NoError(t, err)
 
-	t.Setenv("SKIP_SCHEMA_FETCH", "true")
+	t.Setenv("INDEXER_SCHEMA_SKIP_FETCH", "true")
 
 	cfg, err := LoadConfig(configPath)
 	require.NoError(t, err)
@@ -410,9 +410,9 @@ func TestLoadConfig_InvalidSkipSchemaFetchEnv(t *testing.T) {
 	err := os.WriteFile(configPath, []byte("schema:\n  skip_fetch: false\n"), 0o600)
 	require.NoError(t, err)
 
-	t.Setenv("SKIP_SCHEMA_FETCH", "not_a_bool")
+	t.Setenv("INDEXER_SCHEMA_SKIP_FETCH", "not_a_bool")
 
 	_, err = LoadConfig(configPath)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "invalid SKIP_SCHEMA_FETCH")
+	require.Contains(t, err.Error(), "invalid INDEXER_SCHEMA_SKIP_FETCH")
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -416,3 +416,29 @@ func TestLoadConfig_InvalidSkipSchemaFetchEnv(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid INDEXER_SCHEMA_SKIP_FETCH")
 }
+
+func TestLoadConfig_SkipSchemaFetchYAML(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.yaml")
+
+	err := os.WriteFile(configPath, []byte("schema:\n  skip_fetch: true\n"), 0o600)
+	require.NoError(t, err)
+
+	cfg, err := LoadConfig(configPath)
+	require.NoError(t, err)
+	require.True(t, cfg.Schema.SkipFetch)
+}
+
+func TestLoadConfig_SkipSchemaFetchEnvDisablesYAML(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.yaml")
+
+	err := os.WriteFile(configPath, []byte("schema:\n  skip_fetch: true\n"), 0o600)
+	require.NoError(t, err)
+
+	t.Setenv("INDEXER_SCHEMA_SKIP_FETCH", "false")
+
+	cfg, err := LoadConfig(configPath)
+	require.NoError(t, err)
+	require.False(t, cfg.Schema.SkipFetch)
+}

--- a/pkg/defradb/defra.go
+++ b/pkg/defradb/defra.go
@@ -352,6 +352,7 @@ func StartDefraInstance(cfg *Config, schemaApplier SchemaApplier, nodeOpts []opt
 	allOpts := []options.Enumerable[options.NodeOptions]{nb}
 	allOpts = append(allOpts, nodeOpts...)
 
+	logger.Sugar.Info("Creating DefraDB node (opening store, initializing WASM runtime)...")
 	defraNode, err := node.New(ctx, allOpts...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create defra node: %w ", err)

--- a/pkg/host/host.go
+++ b/pkg/host/host.go
@@ -145,6 +145,7 @@ func StartHostingWithEventSubscription(cfg *config.Config) (*Host, error) { //no
 	}
 
 	logger.Init(cfg.Logger.Development, "./logs")
+	logger.Sugar.Info("🚀 Starting Shinzo host...")
 
 	// Load ACP middleware configuration from the environment before any
 	// defradb work so a misconfigured host fails fast instead of starting
@@ -171,6 +172,8 @@ func StartHostingWithEventSubscription(cfg *config.Config) (*Host, error) { //no
 	nodeOpts.DB().SetLensRuntime("wazero")
 
 	schemaCtx, schemaCtxCancel := context.WithTimeout(context.Background(), time.Duration(cfg.Schema.HTTPClientTimeoutSecs)*time.Second)
+
+	logger.Sugar.Infof("Resolving schema (timeout %ds)...", cfg.Schema.HTTPClientTimeoutSecs)
 	resolvedSchema := resolveSchema(schemaCtx, cfg)
 	schemaCtxCancel()
 
@@ -182,6 +185,7 @@ func StartHostingWithEventSubscription(cfg *config.Config) (*Host, error) { //no
 	}
 
 	internalCfg := cfg.ToInternalConfig()
+	logger.Sugar.Info("Starting DefraDB node (first run can take ~30-60s)...")
 	defraNode, networkHandler, err := defradb.StartDefraInstance(
 		internalCfg,
 		defradb.NewSchemaApplierFromProvidedSchema(resolvedSchema),

--- a/pkg/host/host.go
+++ b/pkg/host/host.go
@@ -185,7 +185,7 @@ func StartHostingWithEventSubscription(cfg *config.Config) (*Host, error) { //no
 	}
 
 	internalCfg := cfg.ToInternalConfig()
-	logger.Sugar.Info("Starting DefraDB node (first run can take ~30-60s)...")
+	logger.Sugar.Info("Starting DefraDB node (first run can take some time)...")
 	defraNode, networkHandler, err := defradb.StartDefraInstance(
 		internalCfg,
 		defradb.NewSchemaApplierFromProvidedSchema(resolvedSchema),

--- a/pkg/host/host_test.go
+++ b/pkg/host/host_test.go
@@ -1698,3 +1698,28 @@ func TestHost_Close_Full(t *testing.T) {
 	err = h.Close(ctx)
 	require.NoError(t, err)
 }
+
+func TestResolveSchema_SkipFetch(t *testing.T) {
+	// Server that must never be called when SkipFetch is set.
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Error("resolveSchema made an HTTP request despite SkipFetch being enabled")
+	}))
+	defer srv.Close()
+
+	cfg := &config.Config{
+		HostConfig: config.HostConfig{
+			Snapshot: config.SnapshotConfig{
+				IndexerURL: srv.URL, // a reachable, valid URL — only SkipFetch should stop the fetch
+			},
+		},
+		Schema: config.SchemaConfig{
+			IndexerSchemaEndpoint: config.DefaultIndexerSchemaEndpoint,
+			HTTPClientTimeoutSecs: 5,
+			SkipFetch:             true,
+		},
+	}
+
+	result := resolveSchema(context.Background(), cfg)
+
+	require.Equal(t, localschema.GetSchema(), result)
+}

--- a/pkg/host/schema_resolve.go
+++ b/pkg/host/schema_resolve.go
@@ -14,6 +14,11 @@ import (
 // embedded schema. On fetch failure the embedded schema is returned and the
 // error is logged.
 func resolveSchema(ctx context.Context, cfg *config.Config) string {
+	if cfg.Schema.SkipFetch {
+		logger.Sugar.Info("Schema fetch skipped (SKIP_SCHEMA_FETCH / schema.skip_fetch set), using embedded schema")
+		return schema.GetSchema()
+	}
+
 	parsedURL, parseErr := url.Parse(cfg.HostConfig.Snapshot.IndexerURL)
 
 	var resolvedSchema string

--- a/pkg/host/schema_resolve.go
+++ b/pkg/host/schema_resolve.go
@@ -15,7 +15,7 @@ import (
 // error is logged.
 func resolveSchema(ctx context.Context, cfg *config.Config) string {
 	if cfg.Schema.SkipFetch {
-		logger.Sugar.Info("Schema fetch skipped (SKIP_SCHEMA_FETCH / schema.skip_fetch set), using embedded schema")
+		logger.Sugar.Info("Schema fetch skipped (INDEXER_SCHEMA_SKIP_FETCH / schema.skip_fetch set), using embedded schema")
 		return schema.GetSchema()
 	}
 


### PR DESCRIPTION
# Pull Request

## Description
On startup the host was silent for ~30–45s before printing anything, so users couldn't tell whether it had hung and would sometimes kill the process. The gap was the schema resolution step (`resolveSchema`) blocking on an HTTP fetch to the
indexer for up to `schema.http_client_timeout_secs` (default 30s), followed by the DefraDB node creation — neither of which logged before starting.

This PR makes the startup sequence narrate itself and adds a flag to skip the schema fetch entirely, so operators who don't need a dynamic schema (or whose indexer endpoint is slow/unreachable) can avoid the delay.

## Changes
- Add `Info`-level progress logs across the previously-silent startup window:
  - "🚀 Starting Shinzo host..." immediately after logger init
  - "Resolving schema (timeout Ns)..." before the schema fetch
  - "Starting DefraDB node (first run can take ~30-60s)..." before `StartDefraInstance`
  - "Creating DefraDB node (opening store, initializing WASM runtime)..." before `node.New`
- Add a `schema.skip_fetch` config option (env override `SKIP_SCHEMA_FETCH`) that bypasses the remote schema fetch and uses the embedded schema. Defaults to `false`, so existing behaviour is unchanged.

## Related Issue
Closes #302

## Steps to Test
1. Pull branch locally
2. `make build && make start`
3. Verify the startup now logs continuously — the previously-silent window is bracketed by "Resolving schema (timeout 30s)..." and shows each subsequent step, with no dead air.
4. Run `make build && SKIP_SCHEMA_FETCH=true make start` and verify the schema fetch is skipped ("Schema fetch skipped ... using embedded schema"), the ~30s stall and `context deadline exceeded` are gone, and startup is correspondingly faster.

## Checklist
- [x] Code compiles / runs
- [x] Tests added / updated
- [x] Documentation updated if needed
- [x] PR is self-contained and focused
- [x] Code does not break any existing features
- [x] Code passes personal internal testing

## Notes
- Default behaviour is unchanged; `skip_fetch` is opt-in.
- Worth a follow-up: the 30s silent schema timeout with a silent embedded-schema fallback is a sharp edge in general — if the indexer URL is misconfigured, every startup eats the full timeout. The new log line makes that visible; a shorter default or fail-fast option could be considered separately.