### PR TITLE
Bug 319 Fix hardcoded testnet value in health server

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -96,7 +96,7 @@ type SchemaConfig struct {
 // ShinzoConfig represents configuration specific to the Shinzo host application.
 type ShinzoConfig struct {
 	MinimumAttestations int    `yaml:"minimum_attestations"`
-	HubBaseURL          string `yaml:"hub_base_url"`
+	HubBaseURL          string `yaml:"hub_base_url"` // ShinzoHub hostname only — no scheme, no port (e.g. "testnet.shinzo.network")
 	StartHeight         uint64 `yaml:"start_height"`
 
 	// P2P Control Settings

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -27,7 +27,7 @@ defradb:
 shinzo:
   minimum_attestations: 1
   start_height: 0 # Indexer auto-detects from chain tip
-  hub_base_url: testnet.shinzo.network:26657
+  hub_base_url: testnet.shinzo.network
   # P2P Control Settings
   wait_for_gaps: true         # Wait for gap processing before starting P2P
   max_gap_size: 1000          # Skip P2P if gap is larger than this

--- a/pkg/host/host.go
+++ b/pkg/host/host.go
@@ -59,6 +59,35 @@ func maxInt(a, b int) int {
 	return b
 }
 
+const (
+	// shinzoHubRPCPort is the CometBFT RPC port ShinzoHub listens on.
+	shinzoHubRPCPort = "26657"
+	// shinzoHubLCDPort is the Cosmos LCD (REST) port ShinzoHub listens on.
+	shinzoHubLCDPort = "1317"
+)
+
+// shinzoHubURLs holds the URLs derived from a ShinzoHub hostname for each protocol
+// the host talks to it over.
+type shinzoHubURLs struct {
+	rpc string
+	ws  string
+	lcd string
+}
+
+// deriveShinzoHubURLs builds the RPC, WebSocket, and LCD (REST) URLs from a bare
+// ShinzoHub hostname (config.Shinzo.HubBaseURL — no scheme, no port). Returns the
+// zero value if hostname is empty.
+func deriveShinzoHubURLs(hostname string) shinzoHubURLs {
+	if hostname == "" {
+		return shinzoHubURLs{}
+	}
+	return shinzoHubURLs{
+		rpc: "http://" + hostname + ":" + shinzoHubRPCPort,
+		ws:  "ws://" + hostname + ":" + shinzoHubRPCPort + "/websocket",
+		lcd: "http://" + hostname + ":" + shinzoHubLCDPort,
+	}
+}
+
 // DefaultConfig provides a template for host configuration with sensible defaults.
 var DefaultConfig *config.Config = func() *config.Config { //nolint:gochecknoglobals
 	cfg := &config.Config{
@@ -306,15 +335,9 @@ func StartHostingWithEventSubscription(cfg *config.Config) (*Host, error) { //no
 		return newHost.metrics
 	})
 
-	// Build RPC, WebSocket, and LCD URLs from the hub base URL
-	// (e.g., "shinzohub-rpc.infra.source.network:26657"). The Cosmos LCD listens
-	// on a separate port (1317 by convention) on the same host.
-	var rpcURL, wsURL, lcdURL string
-	if cfg.Shinzo.HubBaseURL != "" {
-		rpcURL = "http://" + cfg.Shinzo.HubBaseURL
-		wsURL = "ws://" + cfg.Shinzo.HubBaseURL + "/websocket"
-		lcdURL = "http://" + strings.Replace(cfg.Shinzo.HubBaseURL, ":26657", ":1317", 1)
-	}
+	// Build RPC, WebSocket, and LCD URLs from the hub hostname (e.g. "testnet.shinzo.network").
+	hubURLs := deriveShinzoHubURLs(cfg.Shinzo.HubBaseURL)
+	rpcURL, wsURL, lcdURL := hubURLs.rpc, hubURLs.ws, hubURLs.lcd
 
 	// One client serves both the startup backfill and the live-event hydration.
 	var rpcClient *shinzohub.RPCClient
@@ -437,7 +460,7 @@ func StartHostingWithEventSubscription(cfg *config.Config) (*Host, error) { //no
 	if port == 0 {
 		port = 8080
 	}
-	newHost.healthServer = server.NewHealthServer(port, newHost, healthDefraURL, newHost.metrics)
+	newHost.healthServer = server.NewHealthServer(port, newHost, healthDefraURL, newHost.metrics, lcdURL)
 
 	// Start health server in background
 	go func() {
@@ -766,9 +789,8 @@ func startACPServer(
 	if hubBaseURL == "" {
 		return nil, nil, errHubBaseURLMissing
 	}
-	// The host reads the hub over its Cosmos LCD (REST) port. HubBaseURL points
-	// at the CometBFT RPC port; the LCD is the same host on :1317.
-	lcdURL := "http://" + strings.Replace(hubBaseURL, ":26657", ":1317", 1)
+	// The host reads the hub over its Cosmos LCD (REST) port.
+	lcdURL := deriveShinzoHubURLs(hubBaseURL).lcd
 	hubClient := shinzohub.NewRPCClient(lcdURL, defraNode)
 	epochClock := acp.NewEpochClock(hubClient, acpCfg.EpochLength, epochPollInterval)
 	// "shinzo" is the chain's bech32 account prefix: the recovered EVM payer is
@@ -977,7 +999,8 @@ func StartHostingWithTestConfig(t *testing.T) (*Host, error) {
 		if testConfig.DefraDB.URL != "" {
 			healthDefraURL = "http://" + testConfig.DefraDB.URL
 		}
-		host.healthServer = server.NewHealthServer(port, host, healthDefraURL, host.metrics)
+		testLCDURL := deriveShinzoHubURLs(testConfig.Shinzo.HubBaseURL).lcd
+		host.healthServer = server.NewHealthServer(port, host, healthDefraURL, host.metrics, testLCDURL)
 
 		// Start the new health server
 		go func() {

--- a/pkg/host/host_test.go
+++ b/pkg/host/host_test.go
@@ -484,7 +484,7 @@ func TestHost_Close_WithHealthServer(t *testing.T) {
 	ctx := context.Background()
 
 	metrics := server.NewHostMetrics()
-	hs := server.NewHealthServer(0, nil, "", metrics)
+	hs := server.NewHealthServer(0, nil, "", metrics, "")
 
 	host := &Host{
 		DefraNode:              nil,
@@ -1688,7 +1688,7 @@ func TestHost_Close_Full(t *testing.T) {
 		processingCancel:       func() {},
 		metrics:                metrics,
 		processingPipeline:     NewProcessingPipeline(ctx, &Host{config: DefaultConfig, metrics: metrics}, 10, 1, 5, 50, false),
-		healthServer:           server.NewHealthServer(0, nil, "", metrics),
+		healthServer:           server.NewHealthServer(0, nil, "", metrics, ""),
 	}
 
 	h.processingPipeline.Start()

--- a/pkg/host/shinzohub_view_fetching_test.go
+++ b/pkg/host/shinzohub_view_fetching_test.go
@@ -34,8 +34,8 @@ func TestHostIntegration_ShinzoHubViewFetching(t *testing.T) {
 	// Enable debug logging to see SDL schemas
 	testConfig.Logger.Development = true
 
-	// Use ShinzoHub devnet RPC URL from config.yaml
-	testConfig.Shinzo.HubBaseURL = "rpc.devnet.shinzo.network:26657"
+	// Use ShinzoHub devnet hostname
+	testConfig.Shinzo.HubBaseURL = "rpc.devnet.shinzo.network"
 
 	h, err := StartHostingWithEventSubscription(&testConfig)
 	require.NoError(t, err)

--- a/pkg/server/health.go
+++ b/pkg/server/health.go
@@ -21,10 +21,11 @@ var healthStatusPagePath = filepath.Join("pkg", "server", "health_status_page.ht
 
 // HealthServer provides HTTP endpoints for health checks and metrics.
 type HealthServer struct {
-	server      *http.Server
-	host        HealthChecker
-	defraURL    string
-	hostMetrics http.Handler
+	server            *http.Server
+	host              HealthChecker
+	defraURL          string
+	hostMetrics       http.Handler
+	shinzoHubRESTBase string
 }
 
 // HealthChecker interface for checking host health.
@@ -74,7 +75,17 @@ type MetricsResponse struct {
 var startTime = time.Now() // nolint:gochecknoglobals
 
 // NewHealthServer creates a new health server.
-func NewHealthServer(port int, host HealthChecker, defraURL string, metricsHandler http.Handler) *HealthServer {
+// shinzoHubRESTBase is the base URL (scheme + host) of the ShinzoHub Cosmos LCD/REST
+// API, e.g. "http://testnet.shinzo.network:1317". It's injected into the health status
+// page so the browser can query ShinzoHub for host registration status. May be empty
+// if the hub base URL is not configured.
+func NewHealthServer(
+	port int,
+	host HealthChecker,
+	defraURL string,
+	metricsHandler http.Handler,
+	shinzoHubRESTBase string,
+) *HealthServer {
 	mux := http.NewServeMux()
 
 	hs := &HealthServer{
@@ -84,9 +95,10 @@ func NewHealthServer(port int, host HealthChecker, defraURL string, metricsHandl
 			ReadTimeout:  defaultHTTPClientTimeout * healthTimeoutMultiplier,
 			WriteTimeout: defaultHTTPClientTimeout * healthTimeoutMultiplier,
 		},
-		host:        host,
-		defraURL:    defraURL,
-		hostMetrics: metricsHandler,
+		host:              host,
+		defraURL:          defraURL,
+		hostMetrics:       metricsHandler,
+		shinzoHubRESTBase: shinzoHubRESTBase,
 	}
 
 	// Register routes
@@ -294,6 +306,14 @@ func (hs *HealthServer) checkDefraDB() bool {
 // getHealthStatusPageHTML reads the HTML file from disk at runtime, falling back to embedded version
 // This allows hot-reloading during development without rebuilding.
 func (hs *HealthServer) getHealthStatusPageHTML() []byte {
+	raw := hs.loadHealthStatusPageTemplate()
+	rendered := strings.ReplaceAll(string(raw), "{{SHINZOHUB_REST_BASE}}", hs.shinzoHubRESTBase)
+	return []byte(rendered)
+}
+
+// loadHealthStatusPageTemplate reads the raw HTML template from disk, falling back to
+// the embedded version.
+func (hs *HealthServer) loadHealthStatusPageTemplate() []byte {
 	// Try to read from disk first (for development hot-reload)
 	// Check multiple possible paths relative to where the binary might be running
 	possiblePaths := []string{

--- a/pkg/server/health_status_page.html
+++ b/pkg/server/health_status_page.html
@@ -347,7 +347,7 @@
     </div>
 
     <script>
-        const SHINZOHUB_REST_BASE = 'http://testnet.shinzo.network:1317';
+        const SHINZOHUB_REST_BASE = '{{SHINZOHUB_REST_BASE}}';
         let refreshInterval;
 
         function formatNumber(num) {

--- a/pkg/server/health_test.go
+++ b/pkg/server/health_test.go
@@ -119,6 +119,34 @@ func TestHealthHandler_GET_HTML(t *testing.T) {
 	require.NotEmpty(t, w.Body.Bytes())
 }
 
+func TestHealthHandler_GET_HTML_InjectsShinzoHubRESTBase(t *testing.T) {
+	hs := &HealthServer{shinzoHubRESTBase: "http://testnet.shinzo.network:1317"}
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	req.Header.Set("Accept", "text/html")
+	w := httptest.NewRecorder()
+
+	hs.healthHandler(w, req)
+
+	body := w.Body.String()
+	require.Contains(t, body, "const SHINZOHUB_REST_BASE = 'http://testnet.shinzo.network:1317';")
+	require.NotContains(t, body, "{{SHINZOHUB_REST_BASE}}")
+}
+
+func TestHealthHandler_GET_HTML_EmptyShinzoHubRESTBase(t *testing.T) {
+	hs := newHS(nil, "")
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	req.Header.Set("Accept", "text/html")
+	w := httptest.NewRecorder()
+
+	hs.healthHandler(w, req)
+
+	body := w.Body.String()
+	require.Contains(t, body, "const SHINZOHUB_REST_BASE = '';")
+	require.NotContains(t, body, "{{SHINZOHUB_REST_BASE}}")
+}
+
 func TestHealthHandler_POST_MethodNotAllowed(t *testing.T) {
 	hs := newHS(nil, "")
 
@@ -484,15 +512,16 @@ func TestNewHealthServer(t *testing.T) {
 	mock := &mockHealthChecker{healthy: true}
 	metrics := NewHostMetrics()
 
-	hs := NewHealthServer(9999, mock, "http://localhost:9181", metrics)
+	hs := NewHealthServer(9999, mock, "http://localhost:9181", metrics, "http://testnet.shinzo.network:1317")
 	require.NotNil(t, hs)
 	require.NotNil(t, hs.server)
 	require.Equal(t, ":9999", hs.server.Addr)
 	require.Equal(t, "http://localhost:9181", hs.defraURL)
+	require.Equal(t, "http://testnet.shinzo.network:1317", hs.shinzoHubRESTBase)
 }
 
 func TestNewHealthServer_NilMetrics(t *testing.T) {
-	hs := NewHealthServer(9999, nil, "", nil)
+	hs := NewHealthServer(9999, nil, "", nil, "")
 	require.NotNil(t, hs)
 }
 
@@ -670,7 +699,7 @@ func TestHealthServer_StartStop(t *testing.T) {
 	port := listener.Addr().(*net.TCPAddr).Port
 	_ = listener.Close() // free the port for the server to use
 
-	hs := NewHealthServer(port, nil, "", nil)
+	hs := NewHealthServer(port, nil, "", nil, "")
 
 	// Start() calls ListenAndServe which blocks, so run it in a goroutine
 	errCh := make(chan error, 1)


### PR DESCRIPTION
# Pull Request

## Description
This PR includes a fix to remove a hard coded value which is already set in the config. Additionally this pr adds functionality to set the correct port based on the required api to fetch. 

## Changes
- removes hardcoded hub value
- sets correct port based on context 

## Related Issue
#319 

## Test changes
- go test ./pkg/server/...

## Checklist
- [x] Code compiles / runs
- [x] Tests added / updated
- [x] Documentation updated if needed
- [x] PR is self-contained and focused
- [x] Code does not break any existing features
- [x] Code passes personal internal testing

## Notes
chore: remove hard coded testnet url to use the global config. \n
chore: remove the hard code port and build helper functions to assign correct port for context.
